### PR TITLE
feat: MotionConfig.reducedMotion + useReducedMotionConfig

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
     sources:
         - id: trunk
-          ref: v1.7.4
+          ref: v1.7.6
           uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -50,19 +50,19 @@ lint:
               - javascript
     enabled:
         - sort-package-json@3.6.1
-        - actionlint@1.7.11
-        - checkov@3.2.504
-        - eslint@10.0.1
+        - actionlint@1.7.12
+        - checkov@3.2.525
+        - eslint@10.2.1
         - git-diff-check
-        - markdownlint@0.47.0
-        - osv-scanner@2.3.3
-        - oxipng@10.1.0
-        - prettier@3.8.1
+        - markdownlint@0.48.0
+        - osv-scanner@2.3.5
+        - oxipng@10.1.1
+        - prettier@3.8.3
         - shellcheck@0.11.0
         - shfmt@3.6.0
-        - svgo@4.0.0
+        - svgo@4.0.1
         - taplo@0.10.0
-        - trufflehog@3.93.4
+        - trufflehog@3.95.2
         - yamllint@1.38.0
 actions:
     disabled:

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -69,6 +69,11 @@ export const docsSections: NavSection[] = [
                 title: 'useReducedMotion',
                 href: '/docs/use-reduced-motion',
                 icon: Accessibility
+            },
+            {
+                title: 'useReducedMotionConfig',
+                href: '/docs/use-reduced-motion-config',
+                icon: Accessibility
             }
         ]
     },

--- a/docs/src/routes/docs/use-reduced-motion-config/+page.svx
+++ b/docs/src/routes/docs/use-reduced-motion-config/+page.svx
@@ -1,0 +1,115 @@
+---
+title: 'useReducedMotionConfig'
+description: 'Resolve the active reduced-motion policy from <MotionConfig> and the OS preference.'
+---
+
+<script>
+  import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+  const seo = getSeoContext()
+  if (seo) {
+      seo.title = 'useReducedMotionConfig | Docs | Svelte Motion'
+      seo.description = "Combine MotionConfig.reducedMotion with the user's OS preference into a single reactive store."
+      seo.ogTitle = 'useReducedMotionConfig'
+      seo.ogTagline = 'Resolved reduced-motion policy from context + OS pref'
+      seo.ogFeatures = ['Accessibility', 'Reactive Store', 'MotionConfig Aware', 'SSR Safe']
+      seo.ogSlug = 'docs-use-reduced-motion-config'
+  }
+</script>
+
+# useReducedMotionConfig
+
+`useReducedMotionConfig` resolves the active reduced-motion policy for the
+current component subtree by combining the nearest
+`<MotionConfig reducedMotion="...">` ancestor with the OS-level
+`prefers-reduced-motion` setting.
+
+```svelte
+<script>
+    import { useReducedMotionConfig } from '@humanspeak/svelte-motion'
+
+    const reduced = useReducedMotionConfig()
+</script>
+
+{#if !$reduced}
+    <motion.div animate={{ x: 100 }} />
+{/if}
+```
+
+## Why two hooks?
+
+- [`useReducedMotion`](/docs/use-reduced-motion) only reads the OS preference.
+- `useReducedMotionConfig` reads the resolved policy &mdash; it lets a parent
+  `<MotionConfig>` override the OS preference (e.g. force-disable motion in a
+  preview pane regardless of system settings).
+
+## `<MotionConfig reducedMotion>`
+
+The `reducedMotion` prop on `<MotionConfig>` controls how transform animations
+are handled for descendant `motion` elements:
+
+| Value      | Behavior                                                                                  |
+| ---------- | ----------------------------------------------------------------------------------------- |
+| `'never'`  | Default. Animations run as authored.                                                      |
+| `'always'` | Strip transform keys (`x`, `y`, `scale`, `rotate`, `skew`, …). Other props still animate. |
+| `'user'`   | Honor the OS-level `prefers-reduced-motion`. Acts like `'always'` when the user opted in. |
+
+```svelte
+<script>
+    import { motion, MotionConfig } from '@humanspeak/svelte-motion'
+</script>
+
+<MotionConfig reducedMotion="user">
+    <motion.div
+        initial={{ x: -200, opacity: 0 }}
+        animate={{ x: 0, opacity: 1 }}
+        transition={{ duration: 0.6 }}
+    >
+        Fades in always; only translates when the user hasn't opted into reduced motion.
+    </motion.div>
+</MotionConfig>
+```
+
+## Custom decisions
+
+Use the hook directly when you want to make per-component decisions that go
+beyond stripping transforms &mdash; for example, swapping a parallax effect for
+a static background:
+
+```svelte
+<script lang="ts">
+    import { useReducedMotionConfig } from '@humanspeak/svelte-motion'
+
+    const reduced = useReducedMotionConfig()
+</script>
+
+{#if $reduced}
+    <StaticHero />
+{:else}
+    <ParallaxHero />
+{/if}
+```
+
+## How it resolves
+
+| Policy      | OS pref `reduce` | OS pref `no-preference` |
+| ----------- | ---------------- | ----------------------- |
+| _no parent_ | `false`          | `false`                 |
+| `'never'`   | `false`          | `false`                 |
+| `'always'`  | `true`           | `true`                  |
+| `'user'`    | `true`           | `false`                 |
+
+## API Reference
+
+### Returns
+
+`Readable<boolean>` &mdash; `true` when descendant motion should be reduced.
+
+## See also
+
+- [`useReducedMotion`](/docs/use-reduced-motion) &mdash; OS preference only
+- [WCAG 2.3.3 Animation from Interactions](https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions.html)
+
+---
+
+Based on [Motion's MotionConfig.reducedMotion](https://motion.dev/docs/react-motion-config#reducedmotion) API.

--- a/docs/src/routes/docs/use-reduced-motion-config/+page.ts
+++ b/docs/src/routes/docs/use-reduced-motion-config/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => ({
+    title: 'useReducedMotionConfig',
+    description:
+        "Resolve the active reduced-motion policy from MotionConfig and the user's OS preference."
+})

--- a/e2e/utilities/motion-config-reduced-motion.spec.ts
+++ b/e2e/utilities/motion-config-reduced-motion.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test, type Locator, type Page } from '@playwright/test'
+
+const ROUTE = '/tests/motion-config-reduced-motion'
+
+const readBoxTransform = (locator: Locator) =>
+    locator.evaluate((el) => getComputedStyle(el as HTMLElement).transform)
+
+const waitForAnimationsToFinish = (page: Page) =>
+    page.waitForFunction(() => {
+        const el = document.querySelector('[data-testid="motion-box"]') as HTMLElement | null
+        if (!el) return false
+        const anims = el.getAnimations()
+        if (anims.length > 0 && anims.some((a) => a.playState === 'running')) return false
+        return parseFloat(getComputedStyle(el).opacity) > 0.99
+    })
+
+test.describe('MotionConfig.reducedMotion', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.emulateMedia({ reducedMotion: 'no-preference' })
+    })
+
+    test("policy='always' strips transforms but still fades in opacity", async ({ page }) => {
+        await page.goto(ROUTE)
+        await page.getByTestId('policy-always').check()
+
+        const box = page.getByTestId('motion-box')
+        await expect(box).toBeAttached()
+
+        await waitForAnimationsToFinish(page)
+        const transform = await readBoxTransform(box)
+        expect(transform === 'none' || /matrix\(1, 0, 0, 1, 0, 0\)/.test(transform)).toBe(true)
+
+        const opacity = await box.evaluate((el) => getComputedStyle(el as HTMLElement).opacity)
+        expect(parseFloat(opacity)).toBeGreaterThan(0.95)
+    })
+
+    test("policy='never' lets transforms animate", async ({ page }) => {
+        await page.goto(ROUTE)
+        await page.getByTestId('policy-never').check()
+
+        const box = page.getByTestId('motion-box')
+        await expect(box).toBeAttached()
+
+        await waitForAnimationsToFinish(page)
+        const transform = await readBoxTransform(box)
+        expect(transform).toMatch(/matrix\(1,\s*0,\s*0,\s*1,\s*200/)
+    })
+
+    test("policy='user' honors OS prefers-reduced-motion", async ({ page }) => {
+        await page.emulateMedia({ reducedMotion: 'reduce' })
+        await page.goto(ROUTE)
+        await page.getByTestId('policy-user').check()
+
+        const box = page.getByTestId('motion-box')
+        await waitForAnimationsToFinish(page)
+
+        const transform = await readBoxTransform(box)
+        expect(transform === 'none' || /matrix\(1, 0, 0, 1, 0, 0\)/.test(transform)).toBe(true)
+
+        const opacity = await box.evaluate((el) => getComputedStyle(el as HTMLElement).opacity)
+        expect(parseFloat(opacity)).toBeGreaterThan(0.95)
+    })
+})

--- a/src/lib/components/MotionConfig.svelte
+++ b/src/lib/components/MotionConfig.svelte
@@ -6,15 +6,29 @@
     /**
      * Provide default Motion configuration to descendants.
      *
-     * Wraps content and supplies defaults such as `transition` that are merged
-     * with per-element props. Descendants can retrieve config via context.
+     * Wraps content and supplies defaults such as `transition` and
+     * `reducedMotion` that are merged with per-element props. Descendants can
+     * retrieve config via context.
      *
      * @prop transition Default `AnimationOptions` merged with element props.
+     * @prop reducedMotion Reduced-motion policy: `'user' | 'always' | 'never'`.
+     *   Defaults to `'never'`.
      * @prop children Slotted content receiving this configuration.
      */
-    let { transition, children }: MotionConfigProps & { children?: Snippet } = $props()
+    let { transition, reducedMotion, children }: MotionConfigProps & { children?: Snippet } =
+        $props()
 
-    let motionConfig = $state<MotionConfigProps>({ transition })
+    // Use property getters so descendants always read the parent's current
+    // prop values — including remounted children inside `{#key}` blocks, which
+    // would otherwise see a stale snapshot if we cached the value in $state.
+    const motionConfig: MotionConfigProps = {
+        get transition() {
+            return transition
+        },
+        get reducedMotion() {
+            return reducedMotion
+        }
+    }
     createMotionConfig(motionConfig)
 </script>
 

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -5,6 +5,10 @@
 
 <script lang="ts">
     import { getMotionConfig } from '$lib/components/motionConfig.context'
+    import {
+        filterReducedMotionKeyframes,
+        useReducedMotionConfig
+    } from '$lib/utils/reducedMotionConfig'
     import type {
         MotionProps,
         MotionTransition,
@@ -50,7 +54,7 @@
         setInitialFalseContext,
         getInitialFalseContext
     } from '$lib/components/variantContext.context'
-    import { writable } from 'svelte/store'
+    import { get, writable } from 'svelte/store'
     import {
         transformSVGPathProperties,
         computeNormalizedSVGInitialAttrs,
@@ -115,6 +119,11 @@
     let isLoaded = $state<'mounting' | 'initial' | 'ready' | 'animated'>('mounting')
     let dataPath = $state<number>(-1)
     const motionConfig = $derived(getMotionConfig())
+    const reducedMotionStore = useReducedMotionConfig()
+    // Seed synchronously so the first render filters keyframes correctly —
+    // otherwise transforms could flash before the subscribe effect runs.
+    let reducedMotion = $state(get(reducedMotionStore))
+    $effect(() => reducedMotionStore.subscribe((value) => (reducedMotion = value)))
 
     // Get presence context to check if we're inside AnimatePresence
     const context = getAnimatePresenceContext()
@@ -219,10 +228,14 @@
     // Reactively update registration when element/exit/transition props change
     $effect(() => {
         if (element && context && resolvedExit) {
+            const filteredExit = filterReducedMotionKeyframes(
+                resolvedExit as Record<string, unknown>,
+                reducedMotion
+            )
             context.registerChild(
                 presenceKey,
                 element,
-                resolvedExit,
+                filteredExit,
                 mergedTransition as unknown as MotionTransition
             )
         }
@@ -350,7 +363,12 @@
     const resolvedExit = $derived(resolveExit(exitProp, variantsProp))
 
     // Extract keyframes from resolved initial, handling initial={false}
-    const initialKeyframes = $derived(getInitialKeyframes(resolvedInitial))
+    const initialKeyframes = $derived(
+        filterReducedMotionKeyframes(
+            getInitialKeyframes(resolvedInitial) as Record<string, unknown>,
+            reducedMotion
+        )
+    )
 
     // Derived attributes to keep both branches in sync (focusability, data flags, style, class)
     const derivedAttrs = $derived<Record<string, unknown>>({
@@ -490,6 +508,13 @@
         payload = transformSVGPathProperties(
             element,
             payload as Record<string, unknown>
+        ) as typeof payload
+
+        // Strip transform keys when reduced-motion is active so the element
+        // stays in place while opacity / color etc. still animate.
+        payload = filterReducedMotionKeyframes(
+            payload as Record<string, unknown>,
+            reducedMotion
         ) as typeof payload
 
         // Ensure dash properties aren't pinned as inline styles
@@ -801,7 +826,10 @@
             try {
                 // 1. Run exit animation if defined
                 if (resolvedExit && element && !keyTransitionStopped) {
-                    const exitKeyframes = { ...(resolvedExit as Record<string, unknown>) }
+                    const exitKeyframes = filterReducedMotionKeyframes(
+                        { ...(resolvedExit as Record<string, unknown>) },
+                        reducedMotion
+                    )
                     // Remove transition from keyframes (it's passed separately)
                     delete exitKeyframes.transition
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -43,6 +43,7 @@ export type {
     MotionWhileHover,
     MotionWhileInView,
     MotionWhileTap,
+    ReducedMotionConfig,
     Variants
 } from '$lib/types'
 export { useAnimationFrame } from '$lib/utils/animationFrame'
@@ -52,6 +53,7 @@ export { useMotionValue } from '$lib/utils/motionValue'
 export type { MotionValue } from '$lib/utils/motionValue'
 export { useMotionValueEvent } from '$lib/utils/motionValueEvent'
 export { useReducedMotion } from '$lib/utils/reducedMotion'
+export { useReducedMotionConfig } from '$lib/utils/reducedMotionConfig'
 export { useScroll } from '$lib/utils/scroll'
 export { useSpring } from '$lib/utils/spring'
 export { useVelocity } from '$lib/utils/velocity'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -352,9 +352,28 @@ export type MotionProps = {
  *   - delay: Time to wait before starting the animation
  *   - repeat: Number of times to repeat the animation
  */
+/**
+ * Reduced-motion policy for {@link MotionConfigProps.reducedMotion}.
+ *
+ * - `'never'` (default): Animations run as authored, regardless of OS preference.
+ * - `'always'`: Transform animations (x, y, scale, rotate, skew, translate) are
+ *   skipped. Other properties such as `opacity` and `color` still animate.
+ * - `'user'`: Honors the OS-level `prefers-reduced-motion: reduce` setting —
+ *   behaves like `'always'` when the user has opted in, otherwise `'never'`.
+ *
+ * @see https://motion.dev/docs/react-reduced-motion
+ */
+export type ReducedMotionConfig = 'user' | 'always' | 'never'
+
 export type MotionConfigProps = {
     /** Animation configuration */
     transition?: MotionTransition
+    /**
+     * Reduced-motion policy applied to descendant motion elements.
+     *
+     * Defaults to `'never'`. See {@link ReducedMotionConfig}.
+     */
+    reducedMotion?: ReducedMotionConfig
 }
 
 /**

--- a/src/lib/utils/reducedMotionConfig.spec.ts
+++ b/src/lib/utils/reducedMotionConfig.spec.ts
@@ -1,0 +1,136 @@
+import { get } from 'svelte/store'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('$lib/components/motionConfig.context', () => ({
+    getMotionConfig: vi.fn()
+}))
+
+import { getMotionConfig } from '$lib/components/motionConfig.context'
+import { filterReducedMotionKeyframes, useReducedMotionConfig } from './reducedMotionConfig.js'
+
+const mockedGetMotionConfig = vi.mocked(getMotionConfig)
+
+type ChangeHandler = (event: MediaQueryListEvent) => void
+
+const createMediaQueryList = (initialMatches: boolean) => {
+    const listeners = new Set<ChangeHandler>()
+    const mql = {
+        matches: initialMatches,
+        addEventListener: vi.fn((event: string, cb: ChangeHandler) => {
+            if (event === 'change') listeners.add(cb)
+        }),
+        removeEventListener: vi.fn((event: string, cb: ChangeHandler) => {
+            if (event === 'change') listeners.delete(cb)
+        }),
+        addListener: vi.fn((cb: ChangeHandler) => listeners.add(cb)),
+        removeListener: vi.fn((cb: ChangeHandler) => listeners.delete(cb))
+    }
+    return {
+        mql,
+        emit: (matches: boolean) => {
+            mql.matches = matches
+            const event = { matches } as MediaQueryListEvent
+            for (const listener of listeners) listener(event)
+        }
+    }
+}
+
+describe('utils/reducedMotionConfig - filterReducedMotionKeyframes', () => {
+    it('returns input unchanged when reduced is false', () => {
+        const input = { x: 100, y: 50, opacity: 1 }
+        const out = filterReducedMotionKeyframes(input, false)
+        expect(out).toBe(input)
+    })
+
+    it('strips transform keys when reduced is true', () => {
+        const input = {
+            x: 100,
+            y: 50,
+            translateX: 10,
+            scale: 1.5,
+            scaleX: 1,
+            rotate: 45,
+            skewY: 5,
+            opacity: 1,
+            backgroundColor: '#fff'
+        }
+        const out = filterReducedMotionKeyframes(input, true)
+        expect(out).toEqual({ opacity: 1, backgroundColor: '#fff' })
+    })
+
+    it('preserves non-transform keys including transition', () => {
+        const input = { x: 1, opacity: 0.5, transition: { duration: 0.3 } }
+        const out = filterReducedMotionKeyframes(input, true)
+        expect(out).toEqual({ opacity: 0.5, transition: { duration: 0.3 } })
+    })
+
+    it('handles undefined input', () => {
+        expect(filterReducedMotionKeyframes(undefined, true)).toBeUndefined()
+        expect(filterReducedMotionKeyframes(undefined, false)).toBeUndefined()
+    })
+})
+
+describe('utils/reducedMotionConfig - useReducedMotionConfig', () => {
+    beforeEach(() => {
+        mockedGetMotionConfig.mockReset()
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+        vi.restoreAllMocks()
+    })
+
+    it("returns true when policy is 'always'", () => {
+        mockedGetMotionConfig.mockReturnValue({ reducedMotion: 'always' })
+        const store = useReducedMotionConfig()
+        expect(get(store)).toBe(true)
+    })
+
+    it("returns false when policy is 'never'", () => {
+        mockedGetMotionConfig.mockReturnValue({ reducedMotion: 'never' })
+        const store = useReducedMotionConfig()
+        expect(get(store)).toBe(false)
+    })
+
+    it("returns false when no MotionConfig ancestor (defaults to 'never')", () => {
+        mockedGetMotionConfig.mockReturnValue(undefined)
+        const store = useReducedMotionConfig()
+        expect(get(store)).toBe(false)
+    })
+
+    it("mirrors OS preference when policy is 'user'", () => {
+        const { mql } = createMediaQueryList(true)
+        vi.stubGlobal(
+            'matchMedia',
+            vi.fn(() => mql)
+        )
+        mockedGetMotionConfig.mockReturnValue({ reducedMotion: 'user' })
+        const store = useReducedMotionConfig()
+        expect(get(store)).toBe(true)
+    })
+
+    it("updates reactively when OS preference changes under 'user' policy", () => {
+        const { mql, emit } = createMediaQueryList(false)
+        vi.stubGlobal(
+            'matchMedia',
+            vi.fn(() => mql)
+        )
+        mockedGetMotionConfig.mockReturnValue({ reducedMotion: 'user' })
+        const store = useReducedMotionConfig()
+        const seen: boolean[] = []
+        const unsub = store.subscribe((value) => seen.push(value))
+
+        emit(true)
+        emit(false)
+
+        expect(seen).toEqual([false, true, false])
+        unsub()
+    })
+
+    it('is SSR-safe when policy is user and no matchMedia', () => {
+        vi.stubGlobal('window', undefined)
+        mockedGetMotionConfig.mockReturnValue({ reducedMotion: 'user' })
+        const store = useReducedMotionConfig()
+        expect(get(store)).toBe(false)
+    })
+})

--- a/src/lib/utils/reducedMotionConfig.ts
+++ b/src/lib/utils/reducedMotionConfig.ts
@@ -1,0 +1,94 @@
+import { getMotionConfig } from '$lib/components/motionConfig.context.js'
+import { useReducedMotion } from '$lib/utils/reducedMotion.js'
+import { derived, type Readable } from 'svelte/store'
+
+/**
+ * CSS / motion property keys that move or rotate an element via `transform`.
+ * When reduced motion is active these keys are stripped from animate keyframes
+ * so the element stays in place while non-transform properties (opacity, color,
+ * etc.) continue to animate.
+ */
+const TRANSFORM_KEYS = new Set([
+    'x',
+    'y',
+    'z',
+    'translate',
+    'translateX',
+    'translateY',
+    'translateZ',
+    'scale',
+    'scaleX',
+    'scaleY',
+    'scaleZ',
+    'rotate',
+    'rotateX',
+    'rotateY',
+    'rotateZ',
+    'skew',
+    'skewX',
+    'skewY',
+    'transform',
+    'transformPerspective',
+    'perspective'
+])
+
+/**
+ * Returns a copy of `keyframes` with transform-related keys removed when
+ * `reduced` is `true`. Returns `keyframes` unchanged otherwise.
+ *
+ * The `transition` key is preserved so per-key transitions still flow through
+ * to the animation engine.
+ */
+export function filterReducedMotionKeyframes<T extends Record<string, unknown> | undefined>(
+    keyframes: T,
+    reduced: boolean
+): T {
+    if (!reduced || !keyframes) return keyframes
+    const out: Record<string, unknown> = {}
+    for (const key of Object.keys(keyframes)) {
+        if (!TRANSFORM_KEYS.has(key)) out[key] = keyframes[key]
+    }
+    return out as T
+}
+
+/**
+ * Returns a readable store that reflects the resolved reduced-motion policy
+ * for the current component subtree.
+ *
+ * Resolution combines the nearest `<MotionConfig reducedMotion>` ancestor with
+ * the OS-level `prefers-reduced-motion` setting:
+ *
+ * - `'always'` → always `true`
+ * - `'never'` (or no `<MotionConfig>` ancestor) → always `false`
+ * - `'user'` → mirrors the OS preference, defaulting to `false` in SSR
+ *
+ * Use this from inside motion-aware components to decide whether to skip
+ * transform animations.
+ *
+ * @returns {Readable<boolean>} `true` when descendant motion should be reduced.
+ * @see https://motion.dev/docs/react-reduced-motion
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { useReducedMotionConfig } from '@humanspeak/svelte-motion'
+ *   const reduced = useReducedMotionConfig()
+ * </script>
+ *
+ * {#if !$reduced}
+ *   <motion.div animate={{ x: 100 }} />
+ * {/if}
+ * ```
+ */
+export const useReducedMotionConfig = (): Readable<boolean> => {
+    const motionConfig = getMotionConfig()
+    // Read motionConfig?.reducedMotion *inside* the derived so dynamic
+    // `<MotionConfig reducedMotion={...}>` updates surface to subscribers —
+    // motionConfig uses property getters, so the value is always fresh.
+    return derived(useReducedMotion(), ($osReduced) => {
+        const policy = motionConfig?.reducedMotion ?? 'never'
+        if (policy === 'always') return true
+        if (policy === 'never') return false
+        return $osReduced
+    })
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -249,6 +249,14 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/motion-config-reduced-motion') + searchParams}
+                    >
+                        MotionConfig.reducedMotion
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/reactive-style') + searchParams}
                     >
                         styleString (Reactive Styles)

--- a/src/routes/tests/motion-config-reduced-motion/+page.svelte
+++ b/src/routes/tests/motion-config-reduced-motion/+page.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+    import { motion, MotionConfig, type ReducedMotionConfig } from '$lib'
+
+    let policy = $state<ReducedMotionConfig>('always')
+</script>
+
+<div class="flex min-h-screen w-full flex-col items-center justify-center gap-8 p-8">
+    <div class="space-y-2 text-center">
+        <h1 class="text-3xl font-bold">MotionConfig.reducedMotion</h1>
+        <p class="max-w-xl text-gray-600">
+            <code class="rounded bg-gray-100 px-2 py-1"
+                >&lt;MotionConfig reducedMotion="..."&gt;</code
+            >
+            strips transform animations from descendants while leaving
+            <code class="rounded bg-gray-100 px-2 py-1">opacity</code> and other non-transform properties
+            animating normally.
+        </p>
+    </div>
+
+    <div class="flex flex-wrap items-center justify-center gap-3">
+        {#each ['always', 'user', 'never'] as const as option (option)}
+            <label class="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                    type="radio"
+                    name="policy"
+                    value={option}
+                    data-testid={`policy-${option}`}
+                    checked={policy === option}
+                    onchange={() => (policy = option)}
+                />
+                {option}
+            </label>
+        {/each}
+    </div>
+
+    <p class="text-sm text-gray-600" data-testid="active-policy">
+        Active policy: <strong>{policy}</strong>
+    </p>
+
+    <MotionConfig reducedMotion={policy}>
+        {#key policy}
+            <motion.div
+                data-testid="motion-box"
+                initial={{ x: -200, opacity: 0 }}
+                animate={{ x: 200, opacity: 1 }}
+                transition={{ duration: 1.2, ease: 'easeOut' }}
+                class="box"
+            />
+        {/key}
+    </MotionConfig>
+
+    <div class="max-w-xl space-y-2 text-sm text-gray-600">
+        <p>
+            With <code class="rounded bg-gray-100 px-1">reducedMotion="always"</code> the box stays at
+            its natural position (transform animations stripped) but still fades in.
+        </p>
+        <p>
+            With <code class="rounded bg-gray-100 px-1">reducedMotion="user"</code> the OS preference
+            decides; in DevTools toggle "Emulate prefers-reduced-motion: reduce" to see the effect.
+        </p>
+        <p>
+            With <code class="rounded bg-gray-100 px-1">reducedMotion="never"</code> the box translates
+            and fades as authored.
+        </p>
+    </div>
+</div>
+
+<style>
+    :global(.box) {
+        width: 120px;
+        height: 120px;
+        border-radius: 16px;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    }
+</style>


### PR DESCRIPTION
## Summary

Implements [#299](https://github.com/humanspeak/svelte-motion/issues/299) — adds the `reducedMotion: 'user' | 'always' | 'never'` prop to `<MotionConfig>` and a `useReducedMotionConfig` hook that resolves the active policy by combining the nearest MotionConfig ancestor with the OS-level `prefers-reduced-motion` setting. When reduced, descendant motion elements strip transform keys (`x`/`y`/`scale`/`rotate`/`skew`/translate variants/perspective) from `initial`, `animate`, and `exit` keyframes so the element stays in place while `opacity`, `color`, and other non-transform properties continue to animate — matching React Framer Motion's behavior.

A noteworthy implementation detail: the MotionConfig context switched from a `$state` + `$effect` cache to a plain object with **property getters**. This was needed because descendants inside `{#key}` blocks would otherwise read a stale snapshot — the parent's update `$effect` runs *after* the child remounts. Getters always read the parent's live prop value.

## Changes

### ✨ New features

- `MotionConfig` accepts `reducedMotion: 'user' | 'always' | 'never'` (default `'never'`)
- `useReducedMotionConfig()` hook returns a `Readable<boolean>` resolving the policy + OS preference
- `ReducedMotionConfig` type exported from the public API
- Transform-key filtering integrated into `_MotionContainer` so the policy actually gates animations end-to-end

### 🔧 Refactoring

- `motionConfig.context` now exposes values via property getters so dynamic prop changes propagate correctly through `{#key}` remounts
- `useReducedMotionConfig` resolves policy *inside* the derived store callback (no stale snapshot)

### 🧪 Testing

- 10 new unit tests covering all three policies + SSR fallback + runtime OS-pref changes (`src/lib/utils/reducedMotionConfig.spec.ts`)
- 3 new Playwright specs verifying transforms strip / animate per policy with deterministic WAAPI-based waits (`e2e/utilities/motion-config-reduced-motion.spec.ts`)
- Interactive demo route with policy radios at `/tests/motion-config-reduced-motion`

### 📚 Documentation

- New docs page at `/docs/use-reduced-motion-config` with policy table, usage examples, and link from the docs nav
- JSDoc on the new types/hooks

### 🔄 Tooling

- `chore(trunk)`: plugin ref `v1.7.4 → v1.7.6` and routine linter version bumps

## Test plan

- [x] `pnpm test` — 294/294 unit pass
- [x] `pnpm exec playwright test e2e/utilities` — 14/14 utilities pass
- [x] `pnpm exec playwright test e2e/motion e2e/animate-presence` — 41/42 pass (1 pre-existing skip)
- [x] `pnpm check` — 0 errors
- [x] `trunk fmt` + `trunk check` — clean

## Commits

- [`020d305`](https://github.com/humanspeak/svelte-motion/commit/020d305) feat: MotionConfig.reducedMotion + useReducedMotionConfig
- [`c711302`](https://github.com/humanspeak/svelte-motion/commit/c711302) chore(trunk): bump plugin ref and linters

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
