### PR TITLE
feat: useCycle hook

### DIFF
--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -15,6 +15,7 @@ import {
     MousePointer,
     Move,
     Play,
+    RefreshCw,
     Signal,
     SlidersHorizontal,
     Timer,
@@ -65,6 +66,7 @@ export const docsSections: NavSection[] = [
         icon: Clock,
         items: [
             { title: 'useAnimationFrame', href: '/docs/use-animation-frame', icon: Clock },
+            { title: 'useCycle', href: '/docs/use-cycle', icon: RefreshCw },
             {
                 title: 'useReducedMotion',
                 href: '/docs/use-reduced-motion',

--- a/docs/src/lib/examples/UseCycleExample.svelte
+++ b/docs/src/lib/examples/UseCycleExample.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+    import { motion, useCycle } from '@humanspeak/svelte-motion'
+
+    const variants = {
+        rest: {
+            x: 0,
+            rotate: 0,
+            scale: 1,
+            backgroundColor: '#667eea'
+        },
+        nudge: {
+            x: 90,
+            rotate: 8,
+            scale: 1.05,
+            backgroundColor: '#7c3aed'
+        },
+        flip: {
+            x: 90,
+            rotate: 188,
+            scale: 1.1,
+            backgroundColor: '#db2777'
+        },
+        spin: {
+            x: 0,
+            rotate: 540,
+            scale: 1,
+            backgroundColor: '#f59e0b'
+        }
+    } as const
+
+    const labels = ['rest', 'nudge', 'flip', 'spin'] as const
+    const [variant, cycle] = useCycle<keyof typeof variants>(...labels)
+</script>
+
+<div class="flex min-h-[420px] flex-col items-center justify-center gap-8 p-8">
+    <div class="track">
+        <motion.div
+            class="cycle-card"
+            {variants}
+            animate={$variant}
+            transition={{ type: 'spring', stiffness: 220, damping: 18 }}
+        >
+            {$variant}
+        </motion.div>
+    </div>
+
+    <div class="flex flex-wrap items-center justify-center gap-2">
+        <button type="button" class="primary" onclick={() => cycle()}>cycle()</button>
+        {#each labels as label, i (label)}
+            <button
+                type="button"
+                class="ghost"
+                class:active={$variant === label}
+                onclick={() => cycle(i)}
+            >
+                cycle({i})
+            </button>
+        {/each}
+    </div>
+</div>
+
+<style>
+    .track {
+        width: 280px;
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+    }
+
+    .track :global(.cycle-card) {
+        width: 96px;
+        height: 96px;
+        border-radius: 18px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+        color: white;
+        text-transform: capitalize;
+        box-shadow: 0 12px 32px rgba(15, 15, 35, 0.35);
+        will-change: transform;
+    }
+
+    .primary,
+    .ghost {
+        font-size: 13px;
+        font-weight: 500;
+        padding: 6px 12px;
+        border-radius: 8px;
+        border: 1px solid transparent;
+        cursor: pointer;
+        transition:
+            background-color 120ms ease,
+            border-color 120ms ease,
+            color 120ms ease;
+    }
+
+    .primary {
+        background: #2563eb;
+        color: white;
+    }
+
+    .primary:hover {
+        background: #1d4ed8;
+    }
+
+    .ghost {
+        background: transparent;
+        color: rgba(255, 255, 255, 0.85);
+        border-color: rgba(255, 255, 255, 0.25);
+    }
+
+    .ghost:hover {
+        background: rgba(255, 255, 255, 0.08);
+    }
+
+    .ghost.active {
+        background: rgba(255, 255, 255, 0.12);
+        border-color: rgba(255, 255, 255, 0.5);
+    }
+</style>

--- a/docs/src/routes/docs/use-cycle/+page.svx
+++ b/docs/src/routes/docs/use-cycle/+page.svx
@@ -1,0 +1,124 @@
+---
+title: 'useCycle'
+description: 'Cycle through a series of values to drive variants, properties, or any state machine.'
+---
+
+<script>
+  import { useCycle } from '@humanspeak/svelte-motion';
+  import Example from '$lib/components/general/Example.svelte';
+  import UseCycleExample from '$lib/examples/UseCycleExample.svelte';
+  import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+  const seo = getSeoContext()
+  if (seo) {
+      seo.title = 'useCycle | Docs | Svelte Motion'
+      seo.description = 'Cycle through a series of values - perfect for toggling animation variants in Svelte. useCycle returns a reactive store and a cycle function.'
+      seo.ogTitle = 'useCycle'
+      seo.ogTagline = 'Cycle through animation states'
+      seo.ogFeatures = ['Variants', 'State Toggle', 'Reactive Store', 'SSR Safe']
+      seo.ogSlug = 'docs-use-cycle'
+  }
+</script>
+
+# useCycle
+
+`useCycle` cycles through a series of values. It is the Svelte equivalent of
+Framer Motion's `useCycle` hook and pairs naturally with `motion` variants or
+any prop you want to toggle on user interaction.
+
+```svelte
+<script>
+    import { motion, useCycle } from '@humanspeak/svelte-motion'
+
+    const [x, cycleX] = useCycle(0, 50, 100)
+</script>
+
+<motion.div animate={{ x: $x }} onclick={() => cycleX()} />
+```
+
+`useCycle` returns a `[value, cycle]` tuple:
+
+- `value` is a Svelte `Readable<T>` &mdash; subscribe with `$value`.
+- `cycle()` advances to the next item, wrapping back to the first when it
+  passes the end.
+- `cycle(i)` jumps directly to the value at index `i`.
+
+<Example isSmall exampleUrl="/examples/use-cycle">
+  <UseCycleExample />
+</Example>
+
+## Cycling through variants
+
+The most common use is toggling between named variants on a `motion`
+component. Pass the variant names to `useCycle` and bind the current name to
+the `animate` prop:
+
+```svelte
+<script lang="ts">
+    import { motion, useCycle } from '@humanspeak/svelte-motion'
+
+    const variants = {
+        rest: { x: 0, rotate: 0 },
+        nudge: { x: 80, rotate: 8 },
+        flip: { x: 80, rotate: 188 }
+    }
+
+    const [variant, cycleVariant] = useCycle<keyof typeof variants>(
+        'rest',
+        'nudge',
+        'flip'
+    )
+</script>
+
+<motion.button
+    {variants}
+    animate={$variant}
+    transition={{ type: 'spring', stiffness: 220, damping: 18 }}
+    onclick={() => cycleVariant()}
+>
+    Cycle
+</motion.button>
+```
+
+## Jumping to a specific index
+
+Pass a number to jump directly to that index instead of advancing one step.
+Subsequent `cycle()` calls advance from the new position:
+
+```svelte
+<script>
+    import { useCycle } from '@humanspeak/svelte-motion'
+
+    const [value, cycle] = useCycle('a', 'b', 'c', 'd')
+
+    cycle(2) // value is now 'c'
+    cycle() // value is now 'd'
+    cycle() // value wraps to 'a'
+</script>
+```
+
+## API Reference
+
+### Parameters
+
+- **...items** `T[]` &mdash; one or more values to cycle through. Must include
+  at least one item.
+
+### Returns
+
+A `[Readable<T>, Cycle]` tuple:
+
+- **value** `Readable<T>` &mdash; the current item, starting at `items[0]`.
+- **cycle** `(next?: number) => void` &mdash; advance to the next item, or jump
+  to the value at index `next` when supplied.
+
+## See also
+
+- [Variants](/docs/variants) &mdash; declarative animation states that pair
+  naturally with `useCycle`.
+- [AnimatePresence](/docs/animate-presence) &mdash; coordinate enter/exit
+  animations as cycled state changes.
+
+---
+
+Based on [Motion's useCycle](https://motion.dev/docs/react-use-cycle) API.

--- a/docs/src/routes/docs/use-cycle/+page.ts
+++ b/docs/src/routes/docs/use-cycle/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => ({
+    title: 'useCycle',
+    description:
+        'Cycle through a series of values to drive variants, properties, or any state machine.'
+})

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -115,6 +115,11 @@ export const load: PageLoad = () => {
             description: 'Interactive useanimationframe animation example using Svelte Motion.',
             sourceUrl: 'https://examples.motion.dev/react/use-animation-frame'
         },
+        'use-cycle': {
+            title: 'useCycle',
+            description: 'Interactive usecycle animation example using Svelte Motion.',
+            sourceUrl: 'https://motion.dev/docs/react-use-cycle'
+        },
         'use-reduced-motion': {
             title: 'useReducedMotion',
             description: 'Interactive usereducedmotion animation example using Svelte Motion.',

--- a/docs/src/routes/examples/use-cycle/+page.svelte
+++ b/docs/src/routes/examples/use-cycle/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import Example from '$lib/components/general/Example.svelte'
+    import UseCycleExample from '$lib/examples/UseCycleExample.svelte'
+
+    const { data } = $props()
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [{ title: 'Examples', href: '/examples' }, { title: 'useCycle' }]
+    }
+    if (seo) {
+        seo.title = 'useCycle | Examples | Svelte Motion'
+        seo.description =
+            'Cycle through animation variants in Svelte. useCycle returns a reactive store and a cycle function for toggling motion states.'
+        seo.ogTitle = 'useCycle'
+        seo.ogTagline = 'Cycle through animation states'
+        seo.ogFeatures = ['Variants', 'State Toggle', 'Reactive Store', 'SSR Safe']
+        seo.ogSlug = 'examples-use-cycle'
+    }
+</script>
+
+<Example title="useCycle" sourceUrl={data.sourceUrl}>
+    <UseCycleExample />
+</Example>

--- a/docs/src/routes/examples/use-cycle/+page.ts
+++ b/docs/src/routes/examples/use-cycle/+page.ts
@@ -1,0 +1,9 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async () => {
+    return {
+        title: 'useCycle',
+        description: 'Cycle through animation variants or any series of values.',
+        sourceUrl: 'https://motion.dev/docs/react-use-cycle'
+    }
+}

--- a/e2e/utilities/cycle.spec.ts
+++ b/e2e/utilities/cycle.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('useCycle', () => {
+    test('starts at the first item and advances on cycle()', async ({ page }) => {
+        await page.goto('/tests/cycle')
+
+        const box = page.getByTestId('cycle-variant-box')
+        const next = page.getByTestId('cycle-next')
+
+        await expect(box).toHaveAttribute('data-variant', 'rest')
+
+        await next.click()
+        await expect(box).toHaveAttribute('data-variant', 'nudge')
+
+        await next.click()
+        await expect(box).toHaveAttribute('data-variant', 'flip')
+
+        await next.click()
+        await expect(box).toHaveAttribute('data-variant', 'spin')
+    })
+
+    test('wraps back to the first item after the last', async ({ page }) => {
+        await page.goto('/tests/cycle')
+
+        const box = page.getByTestId('cycle-variant-box')
+        const next = page.getByTestId('cycle-next')
+
+        for (let i = 0; i < 4; i++) await next.click()
+
+        await expect(box).toHaveAttribute('data-variant', 'rest')
+    })
+
+    test('cycle(i) jumps to a specific index', async ({ page }) => {
+        await page.goto('/tests/cycle')
+
+        const box = page.getByTestId('cycle-variant-box')
+
+        await page.getByTestId('jump-flip').click()
+        await expect(box).toHaveAttribute('data-variant', 'flip')
+
+        await page.getByTestId('jump-rest').click()
+        await expect(box).toHaveAttribute('data-variant', 'rest')
+
+        await page.getByTestId('jump-spin').click()
+        await expect(box).toHaveAttribute('data-variant', 'spin')
+    })
+
+    test('numeric cycle reflects current value and advances relative to last jump', async ({
+        page
+    }) => {
+        await page.goto('/tests/cycle')
+
+        const box = page.getByTestId('cycle-x-box')
+        const valueLabel = page.getByTestId('cycle-x-value')
+
+        await expect(box).toHaveAttribute('data-x', '0')
+        await expect(valueLabel).toHaveText('0')
+
+        await page.getByTestId('cycle-x-jump-2').click()
+        await expect(valueLabel).toHaveText('100')
+
+        await page.getByTestId('cycle-x-next').click()
+        await expect(valueLabel).toHaveText('150')
+
+        await page.getByTestId('cycle-x-next').click()
+        await expect(valueLabel).toHaveText('0')
+    })
+})

--- a/src/lib/index.spec.ts
+++ b/src/lib/index.spec.ts
@@ -33,6 +33,7 @@ import {
     stringifyStyleObject,
     transform,
     useAnimationFrame,
+    useCycle,
     useReducedMotion,
     useSpring,
     useTime,
@@ -77,6 +78,7 @@ describe('public API: index.ts', () => {
 
     it('exports utility helpers', () => {
         expect(typeof useAnimationFrame).toBe('function')
+        expect(typeof useCycle).toBe('function')
         expect(typeof useReducedMotion).toBe('function')
         expect(typeof useSpring).toBe('function')
         expect(typeof stringifyStyleObject).toBe('function')

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -47,6 +47,8 @@ export type {
     Variants
 } from '$lib/types'
 export { useAnimationFrame } from '$lib/utils/animationFrame'
+export { useCycle } from '$lib/utils/cycle'
+export type { Cycle, CycleState } from '$lib/utils/cycle'
 export { createDragControls } from '$lib/utils/dragControls'
 export { useMotionTemplate } from '$lib/utils/motionTemplate'
 export { useMotionValue } from '$lib/utils/motionValue'

--- a/src/lib/utils/cycle.spec.ts
+++ b/src/lib/utils/cycle.spec.ts
@@ -1,0 +1,89 @@
+import { get } from 'svelte/store'
+import { describe, expect, it } from 'vitest'
+import { useCycle } from './cycle.js'
+
+describe('utils/cycle - useCycle', () => {
+    it('starts at the first item', () => {
+        const [value] = useCycle('a', 'b', 'c')
+        expect(get(value)).toBe('a')
+    })
+
+    it('advances through items on cycle()', () => {
+        const [value, cycle] = useCycle(1, 2, 3, 4)
+        const seen: number[] = []
+        const unsub = value.subscribe((v) => seen.push(v))
+
+        cycle()
+        cycle()
+        cycle()
+
+        expect(seen).toEqual([1, 2, 3, 4])
+        unsub()
+    })
+
+    it('does not notify subscribers when the resolved index is unchanged', () => {
+        const [value, cycle] = useCycle('a', 'b', 'c')
+        const seen: string[] = []
+        const unsub = value.subscribe((v) => seen.push(v))
+
+        cycle(0)
+        cycle(0)
+
+        expect(seen).toEqual(['a'])
+        unsub()
+    })
+
+    it('wraps back to the first item after the last', () => {
+        const [value, cycle] = useCycle('a', 'b', 'c')
+        cycle()
+        cycle()
+        cycle()
+        expect(get(value)).toBe('a')
+    })
+
+    it('jumps to a specific index when called with a number', () => {
+        const [value, cycle] = useCycle(10, 20, 30, 40)
+        cycle(2)
+        expect(get(value)).toBe(30)
+
+        cycle(0)
+        expect(get(value)).toBe(10)
+    })
+
+    it('continues advancing relative to the last jump', () => {
+        const [value, cycle] = useCycle(1, 2, 3, 4)
+        cycle(2)
+        cycle()
+        expect(get(value)).toBe(4)
+    })
+
+    it('is not bound by the render cycle - sequential calls compose', () => {
+        const [value, cycle] = useCycle(1, 2, 3, 4)
+        cycle()
+        cycle()
+        expect(get(value)).toBe(3)
+    })
+
+    it('supports a single item (cycle() is a no-op visually)', () => {
+        const [value, cycle] = useCycle('only')
+        cycle()
+        cycle()
+        expect(get(value)).toBe('only')
+    })
+
+    it('throws when called with no items', () => {
+        expect(() => useCycle()).toThrow(/at least one item/)
+    })
+
+    it('cycles through object items', () => {
+        const a = { variant: 'open' }
+        const b = { variant: 'closed' }
+        const [value, cycle] = useCycle(a, b)
+
+        expect(get(value)).toBe(a)
+        cycle()
+        expect(get(value)).toBe(b)
+        cycle()
+        expect(get(value)).toBe(a)
+    })
+})

--- a/src/lib/utils/cycle.ts
+++ b/src/lib/utils/cycle.ts
@@ -1,0 +1,54 @@
+import { wrap } from 'motion'
+import { writable, type Readable } from 'svelte/store'
+
+export type Cycle = (next?: number) => void
+export type CycleState<T> = [Readable<T>, Cycle]
+
+/**
+ * Cycles through a series of values. Mirrors Framer Motion's `useCycle`.
+ *
+ * Returns a tuple `[value, cycle]`:
+ *
+ * - `value` is a Svelte readable store of the current item; subscribe with
+ *   `$value` in templates.
+ * - `cycle()` advances to the next item, wrapping back to index `0` when it
+ *   passes the end.
+ * - `cycle(i)` jumps to the item at index `i`. The index is taken as-is to
+ *   match `framer-motion` &mdash; out-of-range values yield `items[i]`, which
+ *   may be `undefined`.
+ *
+ * Calls that resolve to the current index are no-ops and do not notify
+ * subscribers, matching React `useState`'s `Object.is` bail-out semantics.
+ *
+ * @param items - Items to cycle through. Must include at least one item.
+ * @returns A `[Readable<T>, Cycle]` tuple.
+ * @see https://motion.dev/docs/react-use-cycle
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { motion, useCycle } from '@humanspeak/svelte-motion'
+ *
+ *   const [x, cycleX] = useCycle(0, 50, 100)
+ * </script>
+ *
+ * <motion.div animate={{ x: $x }} onclick={() => cycleX()} />
+ * ```
+ */
+export const useCycle = <T>(...items: T[]): CycleState<T> => {
+    if (items.length === 0) {
+        throw new Error('useCycle requires at least one item')
+    }
+
+    let index = 0
+    const store = writable<T>(items[0])
+
+    const cycle: Cycle = (next?: number) => {
+        const target = typeof next === 'number' ? next : wrap(0, items.length, index + 1)
+        if (target === index) return
+        index = target
+        store.set(items[target])
+    }
+
+    return [{ subscribe: store.subscribe }, cycle]
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -241,6 +241,14 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/cycle') + searchParams}
+                    >
+                        useCycle
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/reduced-motion') + searchParams}
                     >
                         useReducedMotion

--- a/src/routes/tests/cycle/+page.svelte
+++ b/src/routes/tests/cycle/+page.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+    import { motion, useCycle } from '$lib'
+
+    const variants = {
+        rest: { x: 0, rotate: 0, backgroundColor: '#667eea' },
+        nudge: { x: 80, rotate: 8, backgroundColor: '#7c3aed' },
+        flip: { x: 80, rotate: 188, backgroundColor: '#db2777' },
+        spin: { x: 0, rotate: 360, backgroundColor: '#f59e0b' }
+    } as const
+
+    const labels = ['rest', 'nudge', 'flip', 'spin'] as const
+    const [variant, cycleVariant] = useCycle<keyof typeof variants>(...labels)
+
+    const items = [0, 50, 100, 150] as const
+    const [x, cycleX] = useCycle(...items)
+</script>
+
+<div class="flex min-h-screen w-full flex-col items-center justify-center gap-12 p-8">
+    <section class="flex w-full max-w-xl flex-col items-center gap-4">
+        <h2 class="text-xl font-semibold">useCycle - variants</h2>
+
+        <motion.div
+            class="h-24 w-24 rounded-2xl shadow-lg"
+            {variants}
+            animate={$variant}
+            transition={{ type: 'spring', stiffness: 220, damping: 18 }}
+            data-testid="cycle-variant-box"
+            data-variant={$variant}
+        />
+
+        <div class="flex flex-wrap items-center gap-2">
+            <button
+                type="button"
+                class="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-blue-500"
+                data-testid="cycle-next"
+                onclick={() => cycleVariant()}
+            >
+                cycleVariant()
+            </button>
+            {#each labels as label, i (label)}
+                <button
+                    type="button"
+                    class="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium hover:bg-gray-100"
+                    data-testid={`jump-${label}`}
+                    onclick={() => cycleVariant(i)}
+                >
+                    cycleVariant({i})
+                </button>
+            {/each}
+        </div>
+    </section>
+
+    <section class="flex w-full max-w-xl flex-col items-center gap-4">
+        <h2 class="text-xl font-semibold">useCycle - numeric</h2>
+
+        <motion.div
+            class="h-16 w-16 rounded-xl bg-emerald-500 shadow-lg"
+            animate={{ x: $x }}
+            transition={{ type: 'spring', stiffness: 200, damping: 20 }}
+            data-testid="cycle-x-box"
+            data-x={$x}
+        />
+
+        <div class="flex flex-wrap items-center gap-2">
+            <button
+                type="button"
+                class="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-emerald-500"
+                data-testid="cycle-x-next"
+                onclick={() => cycleX()}
+            >
+                cycleX()
+            </button>
+            <button
+                type="button"
+                class="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium hover:bg-gray-100"
+                data-testid="cycle-x-jump-2"
+                onclick={() => cycleX(2)}
+            >
+                cycleX(2)
+            </button>
+            <span class="text-sm text-gray-600">
+                current: <strong data-testid="cycle-x-value">{$x}</strong>
+            </span>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary

Adds `useCycle`, the Svelte equivalent of [framer-motion's `useCycle`](https://motion.dev/docs/react-use-cycle). Returns a `[Readable<T>, cycle]` tuple where `cycle()` advances + wraps and `cycle(i)` jumps to a specific index — the canonical pattern for toggling animation variants on tap/click.

Closes #306.

## Changes

✨ **New hook** — `src/lib/utils/cycle.ts`
- `useCycle<T>(...items)` returns `[Readable<T>, Cycle]`.
- `cycle()` advances using the re-exported `wrap` from `motion`, matching framer-motion's internal implementation.
- `cycle(i)` jumps to index `i` (out-of-range mirrors framer-motion: `items[i]` may be `undefined`).
- Same-index calls bail without notifying subscribers, matching React `useState`'s `Object.is` semantics so object payloads don't trigger redundant motion re-evaluation.
- Throws on zero-item construction (clearer failure than emitting `undefined` at first read).

🧪 **Tests**
- `src/lib/utils/cycle.spec.ts` — 9 unit tests covering advance, wrap, jump, post-jump advance, single item, no-op guard, error path, and object items.
- `e2e/utilities/cycle.spec.ts` — 4 Playwright specs against `/tests/cycle`.
- `src/lib/index.spec.ts` — public-API surface assertion.

📚 **Docs**
- `docs/src/routes/docs/use-cycle/` — full doc page with variants + jump examples.
- `docs/src/lib/examples/UseCycleExample.svelte` + `docs/src/routes/examples/use-cycle/` — interactive example.
- Nav entry added in `docs/src/lib/docsNav.ts` (RefreshCw icon).
- Sitemap manifest regenerated.

🔧 **Demo route**
- `src/routes/tests/cycle/+page.svelte` linked from the root demo index.

## Commits

- [`2b94ad6`](https://github.com/humanspeak/svelte-motion/commit/2b94ad61d7d8a916d33ac90892ce73b22b0b4c98) feat: useCycle hook
