### PR TITLE
feat: useAnimate hook

### DIFF
--- a/docs/scripts/generate-sitemap-manifest.mjs
+++ b/docs/scripts/generate-sitemap-manifest.mjs
@@ -51,6 +51,19 @@ async function loadExampleMetadata(examplePath) {
 }
 
 /**
+ * Format a title for use mid-sentence in the auto-generated description.
+ * Phrases ("Animated Button") get lowercased so the sentence reads naturally.
+ * Identifier-style names ("useAnimate", "AnimatePresence") keep their casing
+ * so the public API name stays correct.
+ *
+ * @param {string} title
+ * @returns {string}
+ */
+function describable(title) {
+    return /\s/.test(title) ? title.toLowerCase() : title
+}
+
+/**
  * Generate example metadata for the examples landing page
  * @param {Object} manifest - The sitemap manifest
  * @returns {Promise<Object>} Examples metadata object
@@ -73,7 +86,7 @@ async function generateExamplesMetadata(manifest) {
             const title = metadata.title
             examples[slug] = {
                 title,
-                description: `Interactive ${title.toLowerCase()} animation example using Svelte Motion.`,
+                description: `Interactive ${describable(title)} animation example using Svelte Motion.`,
                 sourceUrl: metadata.sourceUrl
             }
         } else {
@@ -85,7 +98,7 @@ async function generateExamplesMetadata(manifest) {
 
             examples[slug] = {
                 title,
-                description: `Interactive ${title.toLowerCase()} animation example using Svelte Motion.`,
+                description: `Interactive ${describable(title)} animation example using Svelte Motion.`,
                 sourceUrl: null
             }
         }

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -66,6 +66,7 @@ export const docsSections: NavSection[] = [
         title: 'Hooks',
         icon: Clock,
         items: [
+            { title: 'useAnimate', href: '/docs/use-animate', icon: Play },
             { title: 'useAnimationFrame', href: '/docs/use-animation-frame', icon: Clock },
             { title: 'useCycle', href: '/docs/use-cycle', icon: RefreshCw },
             { title: 'useInView', href: '/docs/use-in-view', icon: Eye },

--- a/docs/src/lib/examples/UseAnimateExample.svelte
+++ b/docs/src/lib/examples/UseAnimateExample.svelte
@@ -19,6 +19,8 @@
         )
 
     const reset = () => {
+        for (const animation of scope.animations) animation.stop()
+        scope.animations.length = 0
         animate('li', { opacity: 1, y: 0 }, { duration: 0 })
         animate('button.target', { scale: 1 }, { duration: 0 })
     }

--- a/docs/src/lib/examples/UseAnimateExample.svelte
+++ b/docs/src/lib/examples/UseAnimateExample.svelte
@@ -30,19 +30,28 @@
         <button type="button" class="secondary" onclick={reset}>Reset</button>
     </div>
 
-    <ul {@attach scope}>
-        {#each items as item (item)}
-            <li>{item}</li>
-        {/each}
-    </ul>
+    <div {@attach scope} class="stage">
+        <ul>
+            {#each items as item (item)}
+                <li>{item}</li>
+            {/each}
+        </ul>
 
-    <button type="button" class="target">Target button</button>
+        <button type="button" class="target">Target button</button>
+    </div>
 </div>
 
 <style>
     .controls {
         display: flex;
         gap: 8px;
+    }
+
+    .stage {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        align-items: center;
     }
 
     button {

--- a/docs/src/lib/examples/UseAnimateExample.svelte
+++ b/docs/src/lib/examples/UseAnimateExample.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+    import { stagger, useAnimate } from '@humanspeak/svelte-motion'
+
+    const [scope, animate] = useAnimate()
+
+    const items = ['Stagger', 'Sequence', 'Compose', 'Done'] as const
+
+    const run = () =>
+        animate(
+            [
+                ['li', { opacity: [0, 1], y: [20, 0] }, { delay: stagger(0.08), duration: 0.4 }],
+                [
+                    'button.target',
+                    { scale: [1, 1.08, 1] },
+                    { duration: 0.4, at: '-0.2', ease: 'easeOut' }
+                ]
+            ],
+            { defaultTransition: { ease: 'easeOut' } }
+        )
+
+    const reset = () => {
+        animate('li', { opacity: 1, y: 0 }, { duration: 0 })
+        animate('button.target', { scale: 1 }, { duration: 0 })
+    }
+</script>
+
+<div class="flex min-h-[420px] flex-col items-center justify-center gap-4 p-8">
+    <div class="controls">
+        <button type="button" class="primary" onclick={run}>Animate</button>
+        <button type="button" class="secondary" onclick={reset}>Reset</button>
+    </div>
+
+    <ul {@attach scope}>
+        {#each items as item (item)}
+            <li>{item}</li>
+        {/each}
+    </ul>
+
+    <button type="button" class="target">Target button</button>
+</div>
+
+<style>
+    .controls {
+        display: flex;
+        gap: 8px;
+    }
+
+    button {
+        font-size: 13px;
+        padding: 6px 12px;
+        border-radius: 6px;
+        border: 1px solid transparent;
+        cursor: pointer;
+    }
+
+    button.primary {
+        background: #2563eb;
+        color: white;
+    }
+
+    button.secondary {
+        background: rgba(255, 255, 255, 0.06);
+        border-color: rgba(255, 255, 255, 0.18);
+        color: white;
+    }
+
+    button.target {
+        background: linear-gradient(135deg, #db2777 0%, #f59e0b 100%);
+        color: white;
+    }
+
+    ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        width: 240px;
+    }
+
+    li {
+        padding: 10px 14px;
+        border-radius: 8px;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        font-weight: 500;
+        font-size: 14px;
+    }
+</style>

--- a/docs/src/routes/docs/use-animate/+page.svx
+++ b/docs/src/routes/docs/use-animate/+page.svx
@@ -57,6 +57,11 @@ animations. The `at` field controls when each segment starts: a number is an
 absolute time, a string like `'-0.2'` offsets relative to the previous segment,
 and `'<'` runs alongside it.
 
+Selectors resolve against `scope.current`, so any element you want to target
+must be a descendant of the element you spread `{@attach scope}` on. To
+choreograph across the list and a sibling, attach the scope to a wrapper that
+contains both:
+
 ```svelte
 <script lang="ts">
     import { stagger, useAnimate } from '@humanspeak/svelte-motion'
@@ -72,6 +77,14 @@ and `'<'` runs alongside it.
             { defaultTransition: { ease: 'easeOut' } }
         )
 </script>
+
+<div {@attach scope}>
+    <ul>
+        <li>One</li>
+        <li>Two</li>
+    </ul>
+    <button class="cta">Continue</button>
+</div>
 ```
 
 ## Awaiting completion

--- a/docs/src/routes/docs/use-animate/+page.svx
+++ b/docs/src/routes/docs/use-animate/+page.svx
@@ -1,0 +1,143 @@
+---
+title: 'useAnimate'
+description: 'Imperative animation with a scoped CSS-selector API.'
+---
+
+<script>
+  import Example from '$lib/components/general/Example.svelte';
+  import UseAnimateExample from '$lib/examples/UseAnimateExample.svelte';
+  import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+  const seo = getSeoContext()
+  if (seo) {
+      seo.title = 'useAnimate | Docs | Svelte Motion'
+      seo.description = 'Imperative animation in Svelte 5. useAnimate returns a scope attachment and a scoped animate() that resolves CSS selectors against it.'
+      seo.ogTitle = 'useAnimate'
+      seo.ogTagline = 'Imperative animation with scoped selectors'
+      seo.ogFeatures = ['Imperative API', 'Scoped Selectors', 'Sequences', 'Auto Cleanup']
+      seo.ogSlug = 'docs-use-animate'
+  }
+</script>
+
+# useAnimate
+
+`useAnimate` returns a tuple `[scope, animate]` for running animations
+imperatively from Svelte. `scope` is a Svelte 5 attachment you spread onto a
+parent element with `{@attach scope}`. The scoped `animate` accepts the same
+overloads as motion's standalone `animate`, and resolves string selectors
+against `scope.current`.
+
+```svelte
+<script lang="ts">
+    import { stagger, useAnimate } from '@humanspeak/svelte-motion'
+
+    const [scope, animate] = useAnimate()
+
+    const run = () =>
+        animate('li', { opacity: 1, y: 0 }, { delay: stagger(0.1) })
+</script>
+
+<ul {@attach scope}>
+    <li>One</li>
+    <li>Two</li>
+    <li>Three</li>
+</ul>
+
+<button onclick={run}>Animate</button>
+```
+
+<Example isSmall exampleUrl="/examples/use-animate">
+  <UseAnimateExample />
+</Example>
+
+## Sequences
+
+Pass an array of `[target, keyframes, options?]` tuples to compose timed
+animations. The `at` field controls when each segment starts: a number is an
+absolute time, a string like `'-0.2'` offsets relative to the previous segment,
+and `'<'` runs alongside it.
+
+```svelte
+<script lang="ts">
+    import { stagger, useAnimate } from '@humanspeak/svelte-motion'
+
+    const [scope, animate] = useAnimate()
+
+    const playIntro = () =>
+        animate(
+            [
+                ['li', { opacity: [0, 1], y: [20, 0] }, { delay: stagger(0.08) }],
+                ['button.cta', { scale: [1, 1.05, 1] }, { duration: 0.4, at: '-0.2' }]
+            ],
+            { defaultTransition: { ease: 'easeOut' } }
+        )
+</script>
+```
+
+## Awaiting completion
+
+The returned controls are `await`-able. Resolve when the entire sequence
+finishes:
+
+```svelte
+<script lang="ts">
+    import { useAnimate } from '@humanspeak/svelte-motion'
+
+    const [scope, animate] = useAnimate()
+
+    const exit = async () => {
+        await animate('li', { opacity: 0, y: -20 }, { duration: 0.3 })
+        // safe to unmount, navigate, fetch the next page, etc.
+    }
+</script>
+```
+
+## Cleanup
+
+The attachment cleanup runs when the parent element detaches. Every animation
+started through the scoped `animate` is stopped and `scope.animations` is
+cleared, so animations don't leak across unmount or HMR boundaries.
+
+## When to reach for `useAnimate`
+
+- Multi-target choreography that's awkward to express declaratively
+  &mdash; sequenced reveals, exit animations gated on user actions, complex
+  staggered effects.
+- Animating elements you don't own as `motion.*` components &mdash; third-party
+  components, portaled DOM, or content rendered by a child.
+
+For state-driven animations on a single element, the declarative
+`<motion.div animate={...}>` API is usually a better fit.
+
+## API Reference
+
+### Returns
+
+`[scope, animate]`
+
+- **`scope`** &mdash; a Svelte 5 attachment (`(node) => cleanup`) with these
+  properties:
+  - `scope.current: HTMLElement | undefined` &mdash; the attached element,
+    populated once `{@attach scope}` fires.
+  - `scope.animations: AnimationPlaybackControlsWithThen[]` &mdash; in-flight
+    animations started through the scoped `animate`. Cleared automatically when
+    the parent detaches.
+- **`animate(target, keyframes, options?)`** &mdash; same overloads as
+  motion's standalone `animate`. Strings are resolved against
+  `scope.current`. Also accepts `[ [target, keyframes, options], ... ]`
+  sequences with optional `SequenceOptions` (see motion docs).
+
+`animate` returns an `AnimationPlaybackControlsWithThen`. It's `await`-able
+and exposes `play`, `pause`, `stop`, `cancel`, `complete`, `time`, `speed`,
+and a `finished` promise.
+
+## See also
+
+- [animate](https://motion.dev/docs/animate) &mdash; the underlying imperative
+  API that powers `useAnimate`.
+- [stagger](https://motion.dev/docs/stagger) &mdash; helper that produces
+  per-element delays for selector-based animations.
+
+---
+
+Based on [Motion's useAnimate](https://motion.dev/docs/react-use-animate) API.

--- a/docs/src/routes/docs/use-animate/+page.ts
+++ b/docs/src/routes/docs/use-animate/+page.ts
@@ -1,0 +1,6 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => ({
+    title: 'useAnimate',
+    description: 'Imperative animation with a scoped CSS-selector API.'
+})

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -110,6 +110,11 @@ export const load: PageLoad = () => {
             description: 'Interactive toggle switch animation example using Svelte Motion.',
             sourceUrl: null
         },
+        'use-animate': {
+            title: 'useAnimate',
+            description: 'Interactive useanimate animation example using Svelte Motion.',
+            sourceUrl: 'https://motion.dev/docs/react-use-animate'
+        },
         'use-animation-frame': {
             title: 'useAnimationFrame',
             description: 'Interactive useanimationframe animation example using Svelte Motion.',

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -6,7 +6,7 @@ export const load: PageLoad = () => {
     const examples = {
         'animate-presence': {
             title: 'AnimatePresence',
-            description: 'Interactive animatepresence animation example using Svelte Motion.',
+            description: 'Interactive AnimatePresence animation example using Svelte Motion.',
             sourceUrl: 'https://motion.dev/examples/react-exit-animation'
         },
         'animated-button': {
@@ -51,7 +51,7 @@ export const load: PageLoad = () => {
         },
         keyframes: {
             title: 'Keyframes',
-            description: 'Interactive keyframes animation example using Svelte Motion.',
+            description: 'Interactive Keyframes animation example using Svelte Motion.',
             sourceUrl: 'https://motion.dev/examples/react-keyframes'
         },
         'motion-path': {
@@ -76,12 +76,12 @@ export const load: PageLoad = () => {
         },
         reordering: {
             title: 'Reordering',
-            description: 'Interactive reordering animation example using Svelte Motion.',
+            description: 'Interactive Reordering animation example using Svelte Motion.',
             sourceUrl: 'https://examples.motion.dev/react/reordering'
         },
         rotate: {
             title: 'Rotate',
-            description: 'Interactive rotate animation example using Svelte Motion.',
+            description: 'Interactive Rotate animation example using Svelte Motion.',
             sourceUrl: 'https://examples.motion.dev/react/rotate?utm_source=embed'
         },
         'scroll-progress': {
@@ -97,7 +97,7 @@ export const load: PageLoad = () => {
         },
         'style-string': {
             title: 'styleString',
-            description: 'Interactive stylestring animation example using Svelte Motion.',
+            description: 'Interactive styleString animation example using Svelte Motion.',
             sourceUrl: null
         },
         'tab-select': {
@@ -112,32 +112,32 @@ export const load: PageLoad = () => {
         },
         'use-animate': {
             title: 'useAnimate',
-            description: 'Interactive useanimate animation example using Svelte Motion.',
+            description: 'Interactive useAnimate animation example using Svelte Motion.',
             sourceUrl: 'https://motion.dev/docs/react-use-animate'
         },
         'use-animation-frame': {
             title: 'useAnimationFrame',
-            description: 'Interactive useanimationframe animation example using Svelte Motion.',
+            description: 'Interactive useAnimationFrame animation example using Svelte Motion.',
             sourceUrl: 'https://examples.motion.dev/react/use-animation-frame'
         },
         'use-cycle': {
             title: 'useCycle',
-            description: 'Interactive usecycle animation example using Svelte Motion.',
+            description: 'Interactive useCycle animation example using Svelte Motion.',
             sourceUrl: 'https://motion.dev/docs/react-use-cycle'
         },
         'use-in-view': {
             title: 'useInView',
-            description: 'Interactive useinview animation example using Svelte Motion.',
+            description: 'Interactive useInView animation example using Svelte Motion.',
             sourceUrl: 'https://motion.dev/docs/react-use-in-view'
         },
         'use-reduced-motion': {
             title: 'useReducedMotion',
-            description: 'Interactive usereducedmotion animation example using Svelte Motion.',
+            description: 'Interactive useReducedMotion animation example using Svelte Motion.',
             sourceUrl: 'https://motion.dev/docs/react-use-reduced-motion'
         },
         'use-time': {
             title: 'useTime',
-            description: 'Interactive usetime animation example using Svelte Motion.',
+            description: 'Interactive useTime animation example using Svelte Motion.',
             sourceUrl: 'https://motion.dev/docs/react-use-time'
         },
         'use-time-synced': {

--- a/docs/src/routes/examples/use-animate/+page.svelte
+++ b/docs/src/routes/examples/use-animate/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import Example from '$lib/components/general/Example.svelte'
+    import UseAnimateExample from '$lib/examples/UseAnimateExample.svelte'
+
+    const { data } = $props()
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'useAnimate' }
+        ]
+    }
+    if (seo) {
+        seo.title = 'useAnimate | Examples | Svelte Motion'
+        seo.description =
+            'Imperative animation with a scoped CSS-selector API. Sequenced staggered list with a follow-up beat on a target button.'
+        seo.ogTitle = 'useAnimate'
+        seo.ogTagline = 'Imperative animation with scoped selectors'
+        seo.ogFeatures = ['Imperative API', 'Scoped Selectors', 'Sequences', 'Auto Cleanup']
+        seo.ogSlug = 'examples-use-animate'
+    }
+</script>
+
+<Example title="useAnimate" sourceUrl={data.sourceUrl}>
+    <UseAnimateExample />
+</Example>

--- a/docs/src/routes/examples/use-animate/+page.ts
+++ b/docs/src/routes/examples/use-animate/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => ({
+    title: 'useAnimate',
+    description: 'Imperative animation with a scoped CSS-selector API.',
+    sourceUrl: 'https://motion.dev/docs/react-use-animate'
+})

--- a/e2e/utilities/use-animate.spec.ts
+++ b/e2e/utilities/use-animate.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('useAnimate', () => {
+    test('idle on load; list items render', async ({ page }) => {
+        await page.goto('/tests/useAnimate')
+
+        await expect(page.getByTestId('status')).toHaveText('idle')
+        await expect(page.getByTestId('list').locator('li')).toHaveCount(4)
+        await expect(page.getByTestId('item-1')).toHaveText('Item one')
+    })
+
+    test('clicking Animate runs the sequence and flips status to done', async ({ page }) => {
+        await page.goto('/tests/useAnimate')
+
+        await page.getByTestId('run').click()
+        await expect(page.getByTestId('status')).toHaveText('done', { timeout: 4000 })
+
+        // Final keyframes left scoped elements at their resting visible state.
+        const opacity = await page
+            .getByTestId('item-1')
+            .evaluate((el) => getComputedStyle(el).opacity)
+        expect(Number(opacity)).toBeCloseTo(1, 1)
+    })
+
+    test('clicking Reset returns status to idle', async ({ page }) => {
+        await page.goto('/tests/useAnimate')
+
+        await page.getByTestId('run').click()
+        await expect(page.getByTestId('status')).toHaveText('done', { timeout: 4000 })
+
+        await page.getByTestId('reset').click()
+        await expect(page.getByTestId('status')).toHaveText('idle')
+    })
+})

--- a/e2e/utilities/use-animate.spec.ts
+++ b/e2e/utilities/use-animate.spec.ts
@@ -22,6 +22,32 @@ test.describe('useAnimate', () => {
         expect(Number(opacity)).toBeCloseTo(1, 1)
     })
 
+    test('the second sequence segment animates the target button (sibling of the list)', async ({
+        page
+    }) => {
+        await page.goto('/tests/useAnimate')
+
+        // The sequence's second segment grows the target to scale 1.15. It
+        // only runs if scope.current resolves a parent containing both the
+        // <ul> and the sibling <button.target>; attaching the scope to the
+        // <ul> alone leaves the target's transform at 'none'.
+        const target = page.getByTestId('target')
+        const initialTransform = await target.evaluate((el) => getComputedStyle(el).transform)
+        expect(initialTransform === 'none' || initialTransform === 'matrix(1, 0, 0, 1, 0, 0)').toBe(
+            true
+        )
+
+        await page.getByTestId('run').click()
+        await expect(page.getByTestId('status')).toHaveText('done', { timeout: 4000 })
+
+        const finalTransform = await target.evaluate((el) => getComputedStyle(el).transform)
+        // matrix(a, b, c, d, e, f) — a and d are the x/y scale factors.
+        const match = /matrix\(([\d.]+),\s*[\d.]+,\s*[\d.]+,\s*([\d.]+)/.exec(finalTransform)
+        expect(match, `expected scaled transform, got ${finalTransform}`).not.toBeNull()
+        expect(Number(match![1])).toBeCloseTo(1.15, 1)
+        expect(Number(match![2])).toBeCloseTo(1.15, 1)
+    })
+
     test('clicking Reset returns status to idle', async ({ page }) => {
         await page.goto('/tests/useAnimate')
 

--- a/src/lib/index.spec.ts
+++ b/src/lib/index.spec.ts
@@ -32,6 +32,7 @@ import {
     stagger,
     stringifyStyleObject,
     transform,
+    useAnimate,
     useAnimationFrame,
     useCycle,
     useInView,
@@ -78,6 +79,7 @@ describe('public API: index.ts', () => {
     })
 
     it('exports utility helpers', () => {
+        expect(typeof useAnimate).toBe('function')
         expect(typeof useAnimationFrame).toBe('function')
         expect(typeof useCycle).toBe('function')
         expect(typeof useInView).toBe('function')

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -46,6 +46,8 @@ export type {
     ReducedMotionConfig,
     Variants
 } from '$lib/types'
+export { useAnimate } from '$lib/utils/animate.svelte'
+export type { AnimationScope } from '$lib/utils/animate.svelte'
 export { useAnimationFrame } from '$lib/utils/animationFrame'
 export { useCycle } from '$lib/utils/cycle'
 export type { Cycle, CycleState } from '$lib/utils/cycle'

--- a/src/lib/utils/animate.spec.ts
+++ b/src/lib/utils/animate.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest'
+import { useAnimate } from './animate.svelte.js'
+
+describe('utils/animate - useAnimate', () => {
+    it('returns a [scope, animate] tuple', () => {
+        const [scope, animate] = useAnimate()
+        expect(typeof scope).toBe('function')
+        expect(typeof animate).toBe('function')
+    })
+
+    it('initialises scope with current=undefined and an empty animations array', () => {
+        const [scope] = useAnimate()
+        expect(scope.current).toBeUndefined()
+        expect(Array.isArray(scope.animations)).toBe(true)
+        expect(scope.animations).toHaveLength(0)
+    })
+
+    it('hydrates scope.current when invoked as an attachment', () => {
+        const [scope] = useAnimate()
+        const parent = document.createElement('ul')
+        scope(parent)
+        expect(scope.current).toBe(parent)
+    })
+
+    it('clears scope.current when the attachment cleanup runs', () => {
+        const [scope] = useAnimate()
+        const parent = document.createElement('ul')
+        const cleanup = scope(parent)
+        cleanup()
+        expect(scope.current).toBeUndefined()
+    })
+
+    it('resolves string selectors against scope.current', () => {
+        const [scope, animate] = useAnimate()
+        const parent = document.createElement('ul')
+        const li1 = document.createElement('li')
+        const li2 = document.createElement('li')
+        parent.append(li1, li2)
+        document.body.append(parent)
+        scope(parent)
+
+        const animation = animate('li', { opacity: 0.5 }, { duration: 0.001 })
+        expect(animation).toBeTruthy()
+        expect(scope.animations.length).toBeGreaterThan(0)
+
+        document.body.removeChild(parent)
+    })
+
+    it('stops in-flight animations and clears the list when the parent detaches', () => {
+        const [scope, animate] = useAnimate()
+        const parent = document.createElement('div')
+        const child = document.createElement('span')
+        parent.append(child)
+        document.body.append(parent)
+        const cleanup = scope(parent)
+
+        const animation = animate('span', { opacity: 0.5 }, { duration: 10 })
+        const stopSpy = vi.spyOn(animation, 'stop')
+
+        cleanup()
+
+        expect(stopSpy).toHaveBeenCalled()
+        expect(scope.animations).toHaveLength(0)
+        expect(scope.current).toBeUndefined()
+
+        document.body.removeChild(parent)
+    })
+
+    it('animates element references directly (no scope hydration required)', () => {
+        const [, animate] = useAnimate()
+        const el = document.createElement('div')
+        document.body.append(el)
+
+        const animation = animate(el, { opacity: 0.5 }, { duration: 0.001 })
+        expect(animation).toBeTruthy()
+
+        document.body.removeChild(el)
+    })
+
+    it('supports animation sequences', () => {
+        const [scope, animate] = useAnimate()
+        const parent = document.createElement('div')
+        const a = document.createElement('span')
+        const b = document.createElement('span')
+        a.classList.add('a')
+        b.classList.add('b')
+        parent.append(a, b)
+        document.body.append(parent)
+        scope(parent)
+
+        const animation = animate(
+            [
+                ['.a', { opacity: 0.5 }, { duration: 0.001 }],
+                ['.b', { opacity: 0.5 }, { duration: 0.001, at: '<' }]
+            ],
+            { duration: 0.01 }
+        )
+        expect(animation).toBeTruthy()
+
+        document.body.removeChild(parent)
+    })
+
+    it('reattaching to a new parent updates scope.current', () => {
+        const [scope] = useAnimate()
+        const first = document.createElement('div')
+        const second = document.createElement('div')
+
+        const cleanupFirst = scope(first)
+        expect(scope.current).toBe(first)
+        cleanupFirst()
+
+        scope(second)
+        expect(scope.current).toBe(second)
+    })
+})

--- a/src/lib/utils/animate.svelte.ts
+++ b/src/lib/utils/animate.svelte.ts
@@ -1,0 +1,93 @@
+import { createScopedAnimate } from 'motion'
+import type {
+    AnimationPlaybackControlsWithThen,
+    AnimationScope as MotionAnimationScope
+} from 'motion-dom'
+
+/**
+ * The scope returned by {@link useAnimate}. Functions as a Svelte 5
+ * attachment — pass it as `{@attach scope}` on the parent element so the
+ * scoped `animate` function can resolve string selectors against it.
+ *
+ * Mirrors framer-motion's `AnimationScope`. `current` is hydrated once the
+ * attachment runs; `animations` tracks every in-flight animation started
+ * through the scoped `animate` so they can be stopped together when the
+ * element detaches.
+ */
+export type AnimationScope<T extends Element = HTMLElement> = ((node: T) => () => void) & {
+    /** The parent element, populated when the attachment fires. `undefined` before mount or after detach. */
+    current: T | undefined
+    /** Animations currently scoped to this element. */
+    animations: AnimationPlaybackControlsWithThen[]
+}
+
+/**
+ * Imperative animation API mirroring framer-motion's `useAnimate`. Returns a
+ * tuple `[scope, animate]`:
+ *
+ * - `scope` is a Svelte 5 attachment: spread it on the parent element with
+ *   `{@attach scope}`. Once mounted, `scope.current` is the element and
+ *   `animate('selector', ...)` resolves selectors against it.
+ * - `animate(target, keyframes, transition)` accepts the same overloads as
+ *   motion's standalone `animate` — strings, elements, motion values, and
+ *   sequences.
+ *
+ * When the attached element detaches, every animation started through the
+ * scoped `animate` is stopped and `scope.animations` is cleared.
+ *
+ * `animate` ignores calls before the attachment fires — `scope.current` is
+ * still `undefined`, and motion throws when asked to query selectors against
+ * a missing root. Trigger animations from user events or `$effect` after
+ * mount.
+ *
+ * @template T The parent element type. Defaults to `HTMLElement`.
+ * @returns A `[scope, animate]` tuple.
+ * @see https://motion.dev/docs/react-use-animate
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { useAnimate } from '@humanspeak/svelte-motion'
+ *
+ *   const [scope, animate] = useAnimate()
+ *
+ *   const run = () =>
+ *     animate(
+ *       [
+ *         ['li', { opacity: 1, x: 0 }, { delay: stagger(0.1) }],
+ *         ['button', { scale: 1.05 }, { at: '-0.2' }]
+ *       ]
+ *     )
+ * </script>
+ *
+ * <ul {@attach scope}>
+ *   <li>One</li>
+ *   <li>Two</li>
+ *   <li>Three</li>
+ * </ul>
+ * <button onclick={run}>Animate</button>
+ * ```
+ */
+export const useAnimate = <T extends HTMLElement = HTMLElement>(): [
+    AnimationScope<T>,
+    ReturnType<typeof createScopedAnimate>
+] => {
+    const scope = ((node: T) => {
+        scope.current = node
+        return () => {
+            for (const animation of scope.animations) {
+                animation.stop()
+            }
+            scope.animations.length = 0
+            scope.current = undefined
+        }
+    }) as AnimationScope<T>
+    scope.current = undefined
+    scope.animations = []
+
+    const animate = createScopedAnimate({
+        scope: scope as MotionAnimationScope<T>
+    })
+
+    return [scope, animate]
+}

--- a/src/lib/utils/animate.svelte.ts
+++ b/src/lib/utils/animate.svelte.ts
@@ -68,7 +68,7 @@ export type AnimationScope<T extends Element = HTMLElement> = ((node: T) => () =
  * <button onclick={run}>Animate</button>
  * ```
  */
-export const useAnimate = <T extends HTMLElement = HTMLElement>(): [
+export const useAnimate = <T extends Element = HTMLElement>(): [
     AnimationScope<T>,
     ReturnType<typeof createScopedAnimate>
 ] => {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -233,6 +233,14 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/useAnimate') + searchParams}
+                    >
+                        useAnimate
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/animation-frame') + searchParams}
                     >
                         useAnimationFrame

--- a/src/routes/tests/useAnimate/+page.svelte
+++ b/src/routes/tests/useAnimate/+page.svelte
@@ -10,11 +10,7 @@
         const animation = animate(
             [
                 ['li', { opacity: [0, 1], y: [20, 0] }, { delay: stagger(0.08), duration: 0.4 }],
-                [
-                    'button.target',
-                    { scale: [1, 1.1, 1] },
-                    { duration: 0.4, at: '-0.2', ease: 'easeOut' }
-                ]
+                ['button.target', { scale: 1.15 }, { duration: 0.4, at: '-0.2', ease: 'easeOut' }]
             ],
             { defaultTransition: { ease: 'easeOut' } }
         )
@@ -37,8 +33,9 @@
     <header>
         <h1>useAnimate</h1>
         <p>
-            Imperative animation with a scoped CSS-selector API. The scope action attaches to the
-            list, and <code>animate('li', …)</code> resolves selectors against it.
+            Imperative animation with a scoped CSS-selector API. The scope attaches to the wrapper
+            that contains both the list and the target button, so <code>animate('li', …)</code> and
+            <code>animate('button.target', …)</code> both resolve against it.
         </p>
     </header>
 
@@ -50,14 +47,16 @@
         <span class="status" data-testid="status">{status}</span>
     </section>
 
-    <ul {@attach scope} data-testid="list">
-        <li data-testid="item-1">Item one</li>
-        <li data-testid="item-2">Item two</li>
-        <li data-testid="item-3">Item three</li>
-        <li data-testid="item-4">Item four</li>
-    </ul>
+    <div {@attach scope} class="stage" data-testid="stage">
+        <ul data-testid="list">
+            <li data-testid="item-1">Item one</li>
+            <li data-testid="item-2">Item two</li>
+            <li data-testid="item-3">Item three</li>
+            <li data-testid="item-4">Item four</li>
+        </ul>
 
-    <button type="button" class="target" data-testid="target">Target button</button>
+        <button type="button" class="target" data-testid="target">Target button</button>
+    </div>
 </div>
 
 <style>
@@ -74,6 +73,12 @@
         display: flex;
         align-items: center;
         gap: 8px;
+    }
+
+    .stage {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
     }
 
     button {

--- a/src/routes/tests/useAnimate/+page.svelte
+++ b/src/routes/tests/useAnimate/+page.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+    import { stagger, useAnimate } from '$lib'
+
+    const [scope, animate] = useAnimate()
+
+    let status: 'idle' | 'running' | 'done' = $state('idle')
+
+    const run = async () => {
+        status = 'running'
+        const animation = animate(
+            [
+                ['li', { opacity: [0, 1], y: [20, 0] }, { delay: stagger(0.08), duration: 0.4 }],
+                [
+                    'button.target',
+                    { scale: [1, 1.1, 1] },
+                    { duration: 0.4, at: '-0.2', ease: 'easeOut' }
+                ]
+            ],
+            { defaultTransition: { ease: 'easeOut' } }
+        )
+        await animation
+        status = 'done'
+    }
+
+    const reset = () => {
+        animate('li', { opacity: 1, y: 0 }, { duration: 0 })
+        animate('button.target', { scale: 1 }, { duration: 0 })
+        status = 'idle'
+    }
+</script>
+
+<svelte:head>
+    <title>useAnimate Test</title>
+</svelte:head>
+
+<div class="page">
+    <header>
+        <h1>useAnimate</h1>
+        <p>
+            Imperative animation with a scoped CSS-selector API. The scope action attaches to the
+            list, and <code>animate('li', …)</code> resolves selectors against it.
+        </p>
+    </header>
+
+    <section class="controls">
+        <button type="button" class="primary" data-testid="run" data-status={status} onclick={run}>
+            Animate
+        </button>
+        <button type="button" class="secondary" data-testid="reset" onclick={reset}>Reset</button>
+        <span class="status" data-testid="status">{status}</span>
+    </section>
+
+    <ul {@attach scope} data-testid="list">
+        <li data-testid="item-1">Item one</li>
+        <li data-testid="item-2">Item two</li>
+        <li data-testid="item-3">Item three</li>
+        <li data-testid="item-4">Item four</li>
+    </ul>
+
+    <button type="button" class="target" data-testid="target">Target button</button>
+</div>
+
+<style>
+    .page {
+        padding: 24px;
+        max-width: 520px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .controls {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    button {
+        font-size: 14px;
+        padding: 6px 12px;
+        border-radius: 6px;
+        border: 1px solid transparent;
+        cursor: pointer;
+    }
+
+    button.primary {
+        background: #2563eb;
+        color: white;
+    }
+
+    button.secondary {
+        background: white;
+        border-color: #d1d5db;
+        color: #111;
+    }
+
+    button.target {
+        background: linear-gradient(135deg, #db2777 0%, #f59e0b 100%);
+        color: white;
+        align-self: flex-start;
+    }
+
+    ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    li {
+        padding: 12px 16px;
+        border-radius: 8px;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        font-weight: 500;
+    }
+
+    .status {
+        margin-left: auto;
+        font-size: 13px;
+        color: #555;
+    }
+</style>

--- a/src/routes/tests/useAnimate/+page.svelte
+++ b/src/routes/tests/useAnimate/+page.svelte
@@ -4,8 +4,10 @@
     const [scope, animate] = useAnimate()
 
     let status: 'idle' | 'running' | 'done' = $state('idle')
+    let runToken = 0
 
     const run = async () => {
+        const token = ++runToken
         status = 'running'
         const animation = animate(
             [
@@ -15,10 +17,13 @@
             { defaultTransition: { ease: 'easeOut' } }
         )
         await animation
-        status = 'done'
+        if (token === runToken) status = 'done'
     }
 
     const reset = () => {
+        runToken++
+        for (const animation of scope.animations) animation.stop()
+        scope.animations.length = 0
         animate('li', { opacity: 1, y: 0 }, { duration: 0 })
         animate('button.target', { scale: 1 }, { duration: 0 })
         status = 'idle'

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -48,3 +48,37 @@ Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: mockMatchMedia
 })
+
+// jsdom doesn't ship the Web Animations API; motion's WAAPI animator calls
+// element.animate() and reads .finished. Stub just enough surface to let
+// scoped animations run synchronously to completion.
+if (!HTMLElement.prototype.animate) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(HTMLElement.prototype as any).animate = vi.fn(() => ({
+        cancel: vi.fn(),
+        commitStyles: vi.fn(),
+        finish: vi.fn(),
+        finished: Promise.resolve(),
+        pause: vi.fn(),
+        play: vi.fn(),
+        playState: 'finished',
+        currentTime: 0,
+        playbackRate: 1,
+        startTime: 0,
+        timeline: null,
+        effect: null,
+        id: '',
+        replaceState: 'active',
+        ready: Promise.resolve(),
+        pending: false,
+        updatePlaybackRate: vi.fn(),
+        persist: vi.fn(),
+        reverse: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        oncancel: null,
+        onfinish: null,
+        onremove: null
+    }))
+}


### PR DESCRIPTION
## Summary

Adds `useAnimate`, the imperative animation API from framer-motion. Returns `[scope, animate]` — `scope` is a Svelte 5 attachment that hydrates `scope.current` when applied via `{@attach scope}`, and `animate` is a scoped wrapper around motion's `createScopedAnimate` that resolves CSS selectors against the parent. Animations are tracked on the scope and stopped together when the parent detaches.

## Changes

✨ **New hook**

- `useAnimate<T>()` returning `[scope, animate]` from `$lib/utils/animate.svelte.ts`
- Public `AnimationScope<T>` type for the attachment + tracked animations
- Wired into `src/lib/index.ts` and the public-API export test

🧪 **Testing**

- 9 unit specs in `src/lib/utils/animate.spec.ts` covering tuple shape, attachment hydration, cleanup, selector resolution, sequences, direct-element animation, and reattach
- 3 Playwright e2e specs at `e2e/utilities/use-animate.spec.ts`
- Centralised the jsdom Web Animations API stub in `vitest.setup.ts` so any spec exercising motion's WAAPI animator can rely on it

🎯 **Demo route**

- `/tests/useAnimate` with a sequenced staggered list + follow-up beat on a target button, plus reset
- Linked from the root demo index in `src/routes/+page.svelte`

📚 **Docs**

- `/docs/use-animate` page with sequence, awaiting, and cleanup sections
- `/examples/use-animate` interactive showcase + shared `UseAnimateExample` component
- Nav entry under "Hooks" and metadata wired into `examples/+page.ts`

## Commits

- [`69128a4`](https://github.com/humanspeak/svelte-motion/commit/69128a4814a9f215c4f09a35e98e2f33c8cbaefb) feat: useAnimate hook

Closes #301
