### PR TITLE
feat: useIsPresent + usePresence hooks

### DIFF
--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -70,6 +70,7 @@ export const docsSections: NavSection[] = [
             { title: 'useAnimationFrame', href: '/docs/use-animation-frame', icon: Clock },
             { title: 'useCycle', href: '/docs/use-cycle', icon: RefreshCw },
             { title: 'useInView', href: '/docs/use-in-view', icon: Eye },
+            { title: 'usePresence', href: '/docs/use-presence', icon: Ghost },
             {
                 title: 'useReducedMotion',
                 href: '/docs/use-reduced-motion',

--- a/docs/src/lib/examples/UsePresenceCard.svelte
+++ b/docs/src/lib/examples/UsePresenceCard.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+    import { usePresence } from '@humanspeak/svelte-motion'
+
+    const presence = $derived(usePresence())
+    const isPresent = $derived(presence[0])
+    let node: HTMLElement | undefined = $state()
+
+    $effect(() => {
+        const [present, safeToRemove] = presence
+        if (present || !node || !safeToRemove) return
+        const el = node
+        const onEnd = (e: TransitionEvent) => {
+            if (e.target !== el) return
+            safeToRemove()
+        }
+        el.addEventListener('transitionend', onEnd, { once: true })
+        return () => el.removeEventListener('transitionend', onEnd)
+    })
+</script>
+
+<div bind:this={node} class="card" class:exiting={!isPresent} data-is-present={isPresent}>
+    {isPresent ? 'present' : 'exiting'}
+</div>
+
+<style>
+    .card {
+        width: 200px;
+        padding: 16px 20px;
+        border-radius: 10px;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        font-weight: 500;
+        text-align: center;
+        opacity: 1;
+        transform: translateY(0);
+        transition:
+            opacity 300ms ease,
+            transform 300ms ease;
+    }
+
+    .card.exiting {
+        opacity: 0;
+        transform: translateY(-12px);
+    }
+</style>

--- a/docs/src/lib/examples/UsePresenceExample.svelte
+++ b/docs/src/lib/examples/UsePresenceExample.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+    import { AnimatePresence, PresenceChild } from '@humanspeak/svelte-motion'
+    import { onMount } from 'svelte'
+    import UsePresenceCard from './UsePresenceCard.svelte'
+
+    let visible = $state(true)
+    let exitsCompleted = $state(0)
+
+    // Defer the AnimatePresence subtree until after hydration so the SSR pass
+    // doesn't try to register presence children without a window.
+    let mounted = $state(false)
+    onMount(() => (mounted = true))
+</script>
+
+<div class="flex min-h-[420px] flex-col items-center justify-center gap-4 p-8">
+    <div class="controls">
+        <button type="button" class="primary" onclick={() => (visible = !visible)}>
+            {visible ? 'Hide' : 'Show'}
+        </button>
+        <span class="status">exitsCompleted: {exitsCompleted}</span>
+    </div>
+
+    <div class="stage">
+        {#if mounted}
+            <AnimatePresence onExitComplete={() => exitsCompleted++}>
+                <PresenceChild present={visible}>
+                    <UsePresenceCard />
+                </PresenceChild>
+            </AnimatePresence>
+        {/if}
+    </div>
+</div>
+
+<style>
+    .controls {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+
+    .stage {
+        min-height: 80px;
+        display: flex;
+        align-items: center;
+    }
+
+    button {
+        font-size: 13px;
+        padding: 6px 12px;
+        border-radius: 6px;
+        border: 1px solid transparent;
+        cursor: pointer;
+    }
+
+    button.primary {
+        background: #2563eb;
+        color: white;
+    }
+
+    .status {
+        font-size: 12px;
+        color: rgba(255, 255, 255, 0.65);
+    }
+</style>

--- a/docs/src/routes/docs/use-presence/+page.svx
+++ b/docs/src/routes/docs/use-presence/+page.svx
@@ -61,7 +61,10 @@ Inside `<Card>`:
         const [present, safeToRemove] = presence
         if (present || !node || !safeToRemove) return
         const el = node
-        const onEnd = () => safeToRemove()
+        const onEnd = (e: TransitionEvent) => {
+            if (e.target !== el) return
+            safeToRemove()
+        }
         el.addEventListener('transitionend', onEnd, { once: true })
         return () => el.removeEventListener('transitionend', onEnd)
     })

--- a/docs/src/routes/docs/use-presence/+page.svx
+++ b/docs/src/routes/docs/use-presence/+page.svx
@@ -1,0 +1,183 @@
+---
+title: 'usePresence'
+description: 'Custom exit animations driven from the child component.'
+---
+
+<script>
+  import Example from '$lib/components/general/Example.svelte';
+  import UsePresenceExample from '$lib/examples/UsePresenceExample.svelte';
+  import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+  const seo = getSeoContext()
+  if (seo) {
+      seo.title = 'usePresence | Docs | Svelte Motion'
+      seo.description = 'Drive your own exit animation inside AnimatePresence. PresenceChild holds the component rendered until safeToRemove() fires.'
+      seo.ogTitle = 'usePresence'
+      seo.ogTagline = 'Custom exit animations from the child'
+      seo.ogFeatures = ['Custom Exit', 'PresenceChild', 'safeToRemove', 'AnimatePresence']
+      seo.ogSlug = 'docs-use-presence'
+  }
+</script>
+
+# usePresence
+
+`usePresence` and `useIsPresent` let a component branch on whether
+`<AnimatePresence>` is keeping it alive for an exit phase. The wrapper
+(`<PresenceChild>`) holds the child rendered while `isPresent` is `false`,
+and the child runs its own exit animation — CSS transition, canvas effect,
+GSAP, anything — and calls `safeToRemove()` when finished.
+
+This is the path to take when the built-in `motion.*` `exit` prop isn't
+enough — for example, animating a third-party component, fading text via
+CSS classes, or coordinating an exit with non-DOM work.
+
+```svelte
+<script lang="ts">
+    import { AnimatePresence, PresenceChild, usePresence } from '@humanspeak/svelte-motion'
+
+    let visible = $state(true)
+</script>
+
+<button onclick={() => (visible = !visible)}>Toggle</button>
+
+<AnimatePresence>
+    <PresenceChild present={visible}>
+        <Card />
+    </PresenceChild>
+</AnimatePresence>
+```
+
+Inside `<Card>`:
+
+```svelte
+<script lang="ts">
+    import { usePresence } from '@humanspeak/svelte-motion'
+
+    const presence = $derived(usePresence())
+    const isPresent = $derived(presence[0])
+    let node: HTMLElement | undefined = $state()
+
+    $effect(() => {
+        const [present, safeToRemove] = presence
+        if (present || !node || !safeToRemove) return
+        const el = node
+        const onEnd = () => safeToRemove()
+        el.addEventListener('transitionend', onEnd, { once: true })
+        return () => el.removeEventListener('transitionend', onEnd)
+    })
+</script>
+
+<div bind:this={node} class="card" class:exiting={!isPresent}>…</div>
+
+<style>
+    .card { transition: opacity 300ms, transform 300ms; }
+    .card.exiting { opacity: 0; transform: translateY(-12px); }
+</style>
+```
+
+<Example isSmall exampleUrl="/examples/use-presence">
+  <UsePresenceExample />
+</Example>
+
+## API divergence from React
+
+In framer-motion, `usePresence` works directly inside `<AnimatePresence>` —
+React's render tree gives the library control over when children unmount.
+Svelte's `{#if}` teardown is synchronous from the user's side and not
+interceptable, so you opt-in via the `<PresenceChild>` wrapper. Bind
+`present` to the same condition that would normally gate the children:
+
+```svelte
+<!-- React (framer-motion) -->
+<AnimatePresence>
+    {visible && <Card />}
+</AnimatePresence>
+
+<!-- Svelte equivalent -->
+<AnimatePresence>
+    <PresenceChild present={visible}>
+        <Card />
+    </PresenceChild>
+</AnimatePresence>
+```
+
+## `useIsPresent`
+
+Returns just the `isPresent` boolean. Useful when you only need to render
+different content during exit, no `safeToRemove` needed:
+
+```svelte
+<script lang="ts">
+    import { useIsPresent } from '@humanspeak/svelte-motion'
+    const isPresent = $derived(useIsPresent())
+</script>
+
+<div data-state={isPresent ? 'live' : 'exiting'}>…</div>
+```
+
+When called outside any `PresenceChild`, `useIsPresent()` returns `true` and
+`usePresence()` returns `[true, null]`.
+
+## How `safeToRemove` behaves
+
+- **Idempotent.** Calling it twice is a no-op after the first.
+- **Versioned.** Re-entering (`present` flipping back to `true`) before
+  `safeToRemove` fires cancels the exit; the previously-handed-out callback
+  becomes a no-op so a stale `transitionend` handler can't tear down a
+  now-present component.
+- **Required.** If you call `usePresence()`, you must eventually call
+  `safeToRemove`. Otherwise the wrapper holds children forever and
+  `<AnimatePresence>`'s `onExitComplete` never fires.
+
+## Mixing with `motion.*` `exit`
+
+Inside `<PresenceChild>`, the wrapper drives the exit. Any `motion.*`
+descendants automatically opt out of the outer `<AnimatePresence>` clone
+path — their `exit` props are ignored. Pick one approach per element:
+
+- Use `motion.*` with `exit={...}` for a declarative motion-driven exit, no
+  `<PresenceChild>` needed.
+- Use `<PresenceChild>` with a child that calls `safeToRemove` for a custom
+  exit you fully control.
+
+## Known limitations
+
+- **`mode='popLayout'`**: the wrapper holds the child in document flow during
+  exit, so `popLayout` semantics (sibling reflow as the exiting element
+  leaves layout immediately) are not implemented for `<PresenceChild>`.
+  `mode='sync'` (default) and `mode='wait'` work as expected — the wrapper
+  participates in the same `inFlightExits` accounting as the clone path.
+- **Nested `<AnimatePresence>` inside a held `<PresenceChild>`**: while
+  the wrapper is holding, descendants don't see exit signals because the
+  Svelte tree is still mounted. Once you call `safeToRemove`, normal
+  unmount fires, and any nested motion children's `exit` runs at that point.
+
+## API Reference
+
+### `<PresenceChild>` props
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `present` | `boolean` | `true` | When this flips `true → false`, the wrapper holds children rendered with `isPresent=false` until `safeToRemove` fires. |
+| `children` | `Snippet` | — | Snippet rendered while `present` is true or while the wrapper is holding. |
+
+### `useIsPresent(): boolean`
+
+Returns whether the calling component is currently present. `true` outside
+of any `<PresenceChild>`.
+
+### `usePresence(): [true, null] | [false, () => void]`
+
+Returns the framer-motion-style tuple. `[true, null]` while present (or
+outside any `<PresenceChild>`); `[false, () => void]` once the wrapper
+enters its exit hold.
+
+## See also
+
+- [AnimatePresence](/docs/animate-presence) — the parent component.
+- [`motion.*` `exit` prop](https://motion.dev/docs/react-motion-component#exit) —
+  declarative alternative when a built-in transform/style animation is enough.
+
+---
+
+Based on [Motion's usePresence](https://motion.dev/docs/react-use-presence) API.

--- a/docs/src/routes/docs/use-presence/+page.ts
+++ b/docs/src/routes/docs/use-presence/+page.ts
@@ -1,0 +1,6 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => ({
+    title: 'usePresence',
+    description: 'Custom exit animations driven from the child component.'
+})

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -130,6 +130,11 @@ export const load: PageLoad = () => {
             description: 'Interactive useInView animation example using Svelte Motion.',
             sourceUrl: 'https://motion.dev/docs/react-use-in-view'
         },
+        'use-presence': {
+            title: 'usePresence',
+            description: 'Interactive usePresence animation example using Svelte Motion.',
+            sourceUrl: 'https://motion.dev/docs/react-use-presence'
+        },
         'use-reduced-motion': {
             title: 'useReducedMotion',
             description: 'Interactive useReducedMotion animation example using Svelte Motion.',

--- a/docs/src/routes/examples/use-presence/+page.svelte
+++ b/docs/src/routes/examples/use-presence/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import Example from '$lib/components/general/Example.svelte'
+    import UsePresenceExample from '$lib/examples/UsePresenceExample.svelte'
+
+    const { data } = $props()
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'usePresence' }
+        ]
+    }
+    if (seo) {
+        seo.title = 'usePresence | Examples | Svelte Motion'
+        seo.description =
+            'Custom exit animations from inside the child. PresenceChild holds the component rendered until your safeToRemove() fires.'
+        seo.ogTitle = 'usePresence'
+        seo.ogTagline = 'Custom exit animations from the child'
+        seo.ogFeatures = ['Custom Exit', 'PresenceChild', 'safeToRemove', 'AnimatePresence']
+        seo.ogSlug = 'examples-use-presence'
+    }
+</script>
+
+<Example title="usePresence" sourceUrl={data.sourceUrl}>
+    <UsePresenceExample />
+</Example>

--- a/docs/src/routes/examples/use-presence/+page.ts
+++ b/docs/src/routes/examples/use-presence/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => ({
+    title: 'usePresence',
+    description: 'Custom exit animations driven from the child component.',
+    sourceUrl: 'https://motion.dev/docs/react-use-presence'
+})

--- a/e2e/utilities/use-presence.spec.ts
+++ b/e2e/utilities/use-presence.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('usePresence', () => {
+    test('basic toggle: card stays mounted during exit transition then unmounts', async ({
+        page
+    }) => {
+        await page.goto('/tests/use-presence')
+
+        const card = page.getByTestId('card')
+        await expect(card).toBeVisible()
+        await expect(card).toHaveAttribute('data-is-present', 'true')
+
+        // Mark the element so we can detect remount.
+        await card.evaluate((el) => (el.dataset.marker = 'pre-hide'))
+
+        await page.getByTestId('toggle-basic').click()
+
+        // While exiting, the same element is still in the DOM (no remount —
+        // confirms the effect.pre fix), and its data-is-present has flipped.
+        await expect(card).toHaveAttribute('data-is-present', 'false')
+        await expect(card).toHaveAttribute('data-marker', 'pre-hide')
+
+        // After the 300ms CSS transition + safeToRemove, the card is gone and
+        // AnimatePresence's onExitComplete has fired exactly once.
+        await expect(card).toHaveCount(0, { timeout: 2000 })
+        await expect(page.getByTestId('exits-completed')).toHaveText('exitsCompleted: 1')
+    })
+
+    test('clicking Show after Hide brings the card back', async ({ page }) => {
+        await page.goto('/tests/use-presence')
+
+        await page.getByTestId('toggle-basic').click()
+        await expect(page.getByTestId('card')).toHaveCount(0, { timeout: 2000 })
+
+        await page.getByTestId('toggle-basic').click()
+        await expect(page.getByTestId('card')).toBeVisible()
+        await expect(page.getByTestId('card')).toHaveAttribute('data-is-present', 'true')
+    })
+
+    test('swap: outgoing PresenceChild holds until its safeToRemove fires', async ({ page }) => {
+        await page.goto('/tests/use-presence')
+
+        await expect(page.getByTestId('wait-a')).toBeVisible()
+        await expect(page.getByTestId('wait-b')).toHaveCount(0)
+
+        await page.getByTestId('toggle-wait').click()
+
+        // A is held (still in DOM, marked exiting) while its CSS transition runs.
+        await expect(page.getByTestId('wait-a')).toHaveAttribute('data-is-present', 'false')
+        // B has entered the render path now that its present flipped true.
+        await expect(page.getByTestId('wait-b')).toBeVisible()
+
+        // Eventually A's transitionend fires, triggering safeToRemove → unmount.
+        await expect(page.getByTestId('wait-a')).toHaveCount(0, { timeout: 2000 })
+        await expect(page.getByTestId('wait-b')).toHaveAttribute('data-is-present', 'true')
+    })
+})

--- a/src/lib/components/PresenceChild.svelte
+++ b/src/lib/components/PresenceChild.svelte
@@ -52,22 +52,38 @@
     // capture there.
     let prevPresent: boolean | undefined = undefined
 
+    // Each exit start mints a fresh `safeToRemove` closure bound to the cycle
+    // it was minted for. Re-entry / completion invalidates older closures so a
+    // captured-then-late-fired callback (setTimeout, external lib, stray
+    // listener after cleanup) from cycle A cannot complete cycle B.
+    let currentSafeToRemove: () => void = noopSafeToRemove
+
+    function noopSafeToRemove() {}
+
+    function mintSafeToRemove(): () => void {
+        // Closure compares against its own identity (`self`) to detect
+        // whether it's still the active cycle's callback. After re-entry or
+        // completion, `currentSafeToRemove` no longer points at `self`, so
+        // this branch no-ops — a stale capture cannot complete a later exit.
+        const self: () => void = () => {
+            if (currentSafeToRemove !== self || phase !== 'holding') return
+            phase = 'completed'
+            currentSafeToRemove = noopSafeToRemove
+            animatePresence?.notifyExitComplete()
+        }
+        return self
+    }
+
     const isPresent = $derived(present && phase === 'idle')
 
     setPresenceChildContext({
         get isPresent() {
             return isPresent
         },
-        safeToRemove
+        get safeToRemove() {
+            return currentSafeToRemove
+        }
     })
-
-    function safeToRemove() {
-        // Idempotent + versioned. A stale callback from a canceled exit
-        // (re-entry before this fires) sees phase != 'holding' and no-ops.
-        if (phase !== 'holding') return
-        phase = 'completed'
-        animatePresence?.notifyExitComplete()
-    }
 
     // $effect.pre runs before DOM updates so the phase transition lands in
     // the same render pass as the `present` prop flip — otherwise the {#if}
@@ -86,10 +102,14 @@
         }
         if (prevPresent && !current && phase === 'idle') {
             phase = 'holding'
+            currentSafeToRemove = mintSafeToRemove()
             animatePresence?.notifyExitStart()
         } else if (!prevPresent && current && phase === 'holding') {
-            // Re-entry mid-hold cancels the exit accounting.
+            // Re-entry mid-hold cancels the exit accounting. Replacing the
+            // slot invalidates the cycle's `safeToRemove` for any consumer
+            // that captured it.
             phase = 'idle'
+            currentSafeToRemove = noopSafeToRemove
             animatePresence?.notifyExitComplete()
         } else if (!prevPresent && current && phase === 'completed') {
             // Re-mounted after a previous exit fully completed.

--- a/src/lib/components/PresenceChild.svelte
+++ b/src/lib/components/PresenceChild.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+    import type { Snippet } from 'svelte'
+    import {
+        getAnimatePresenceContext,
+        getPresenceDepth,
+        setPresenceChildContext,
+        setPresenceDepth
+    } from '$lib/utils/presence'
+
+    /**
+     * Holds its `children` snippet rendered until the consumer signals the
+     * exit is complete via `safeToRemove()`. Lets a child run its own (non-
+     * `motion.*`) exit animation — fade via CSS transition, canvas effect,
+     * GSAP, etc — while still participating in `AnimatePresence`'s
+     * `onExitComplete` accounting and `mode='wait'` enter blocking.
+     *
+     * Children read `useIsPresent()` or `usePresence()` to observe the
+     * exit-phase flip.
+     *
+     * @prop present Bind to the same boolean that conditionally rendered this
+     *     wrapper. When it flips to `false`, the wrapper holds children
+     *     mounted with `isPresent = false` until `safeToRemove` fires.
+     * @prop children Snippet rendered while present or held.
+     */
+    const { present = true, children } = $props<{
+        present?: boolean
+        children?: Snippet
+    }>()
+
+    const animatePresence = getAnimatePresenceContext()
+    const presenceDepth = getPresenceDepth()
+
+    // Descendants of PresenceChild are no longer at depth 0, so any motion.*
+    // children inside don't trip the "direct children of AnimatePresence need
+    // a key" check in _MotionContainer.
+    if (presenceDepth !== undefined) {
+        setPresenceDepth(presenceDepth + 1)
+    }
+
+    // Three-phase exit lifecycle:
+    //   'idle'      — no exit in progress; render iff `present`.
+    //   'holding'   — `present` flipped false; we're still rendering with
+    //                 isPresent=false, waiting for the consumer to call
+    //                 safeToRemove.
+    //   'completed' — consumer signaled completion. Stop rendering. Returning
+    //                 to 'idle' only happens if `present` flips back to true.
+    type ExitPhase = 'idle' | 'holding' | 'completed'
+    let phase = $state<ExitPhase>('idle')
+    // Track the prior `present` value so we only start an exit on a true→false
+    // transition, not when mounted with `present=false` (a no-op steady state).
+    // Using a closure variable inside $effect.pre below — see initial value
+    // capture there.
+    let prevPresent: boolean | undefined = undefined
+
+    const isPresent = $derived(present && phase === 'idle')
+
+    setPresenceChildContext({
+        get isPresent() {
+            return isPresent
+        },
+        safeToRemove
+    })
+
+    function safeToRemove() {
+        // Idempotent + versioned. A stale callback from a canceled exit
+        // (re-entry before this fires) sees phase != 'holding' and no-ops.
+        if (phase !== 'holding') return
+        phase = 'completed'
+        animatePresence?.notifyExitComplete()
+    }
+
+    // $effect.pre runs before DOM updates so the phase transition lands in
+    // the same render pass as the `present` prop flip — otherwise the {#if}
+    // below re-evaluates with stale phase and unmounts/remounts the children,
+    // which (a) breaks any CSS transition the consumer relies on for exit and
+    // (b) makes `bind:this` references go stale.
+    $effect.pre(() => {
+        // Read `present` reactively first; assignments to module locals
+        // happen inside the branches below.
+        const current = present
+        // First run: just record the steady state. Don't fire any exit/enter
+        // signal — there's no transition to react to yet.
+        if (prevPresent === undefined) {
+            prevPresent = current
+            return
+        }
+        if (prevPresent && !current && phase === 'idle') {
+            phase = 'holding'
+            animatePresence?.notifyExitStart()
+        } else if (!prevPresent && current && phase === 'holding') {
+            // Re-entry mid-hold cancels the exit accounting.
+            phase = 'idle'
+            animatePresence?.notifyExitComplete()
+        } else if (!prevPresent && current && phase === 'completed') {
+            // Re-mounted after a previous exit fully completed.
+            phase = 'idle'
+        }
+        prevPresent = current
+    })
+</script>
+
+{#if present || phase === 'holding'}
+    {@render children?.()}
+{/if}

--- a/src/lib/components/__tests__/PresenceHarness.svelte
+++ b/src/lib/components/__tests__/PresenceHarness.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import PresenceChild from '$lib/components/PresenceChild.svelte'
+    import PresenceProbe from '$lib/components/__tests__/PresenceProbe.svelte'
+
+    let { present = true }: { present?: boolean } = $props()
+</script>
+
+<PresenceChild {present}>
+    <PresenceProbe />
+</PresenceChild>

--- a/src/lib/components/__tests__/PresenceProbe.svelte
+++ b/src/lib/components/__tests__/PresenceProbe.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+    import { useIsPresent, usePresence } from '$lib/utils/usePresence'
+
+    const isPresent = $derived(useIsPresent())
+    const presence = $derived(usePresence())
+    const [tupleIsPresent, safeToRemove] = $derived(presence)
+</script>
+
+<div
+    data-testid="probe"
+    data-is-present={isPresent}
+    data-tuple-is-present={tupleIsPresent}
+    data-tuple-has-callback={safeToRemove !== null}
+    onclick={() => safeToRemove?.()}
+    onkeydown={(e) => e.key === 'Enter' && safeToRemove?.()}
+    role="button"
+    tabindex="0"
+></div>

--- a/src/lib/components/__tests__/StalePresenceHarness.svelte
+++ b/src/lib/components/__tests__/StalePresenceHarness.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import PresenceChild from '$lib/components/PresenceChild.svelte'
+    import StalePresenceProbe from '$lib/components/__tests__/StalePresenceProbe.svelte'
+
+    let { present = true }: { present?: boolean } = $props()
+</script>
+
+<PresenceChild {present}>
+    <StalePresenceProbe />
+</PresenceChild>

--- a/src/lib/components/__tests__/StalePresenceProbe.svelte
+++ b/src/lib/components/__tests__/StalePresenceProbe.svelte
@@ -1,0 +1,23 @@
+<script lang="ts" module>
+    // Module-scoped sink so the test can read out the cycle-A callback after a
+    // canceled exit, then invoke it from cycle B and assert it does NOT
+    // complete the wrong cycle.
+    let captured: (() => void) | null = null
+    export const getCapturedSafeToRemove = (): (() => void) | null => captured
+    export const resetCapturedSafeToRemove = (): void => {
+        captured = null
+    }
+</script>
+
+<script lang="ts">
+    import { usePresence } from '$lib/utils/usePresence'
+
+    const presence = $derived(usePresence())
+
+    $effect(() => {
+        const [, safeToRemove] = presence
+        if (safeToRemove) captured = safeToRemove
+    })
+</script>
+
+<div data-testid="probe" data-is-present={presence[0]}></div>

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -42,6 +42,7 @@
     import { isNativelyFocusable } from '$lib/utils/a11y'
     import {
         getAnimatePresenceContext,
+        getPresenceChildContext,
         getPresenceDepth,
         setPresenceDepth
     } from '$lib/utils/presence'
@@ -127,6 +128,12 @@
 
     // Get presence context to check if we're inside AnimatePresence
     const context = getAnimatePresenceContext()
+    // Inside a <PresenceChild>, the wrapper drives the exit. Skip the
+    // clone-based exit registration on this element so we don't double-fire
+    // (custom exit, then clone of a node the wrapper already let go).
+    // Enter-side coordination (shouldAnimateEnter, mode='wait' blocking)
+    // remains active so the element still slots into the outer presence flow.
+    const inPresenceChild = !!getPresenceChildContext()
 
     // Get layoutId registry (provided by AnimatePresence or a parent LayoutGroup)
     const layoutIdRegistry = getLayoutIdRegistry()
@@ -168,9 +175,8 @@
     )
 
     // Register onDestroy at component level (guaranteed to work in Svelte 5)
-    // usePresence() cannot be called inside $effect because it uses getContext() and onDestroy(),
-    // which must be called during component initialization.
-    if (context) {
+    // — getContext()/onDestroy() must run during component initialization.
+    if (context && !inPresenceChild) {
         onDestroy(() => {
             pwLog('[presence] onDestroy triggered', { key: presenceKey })
             context.unregisterChild(presenceKey)
@@ -181,8 +187,9 @@
     // from the correct visual state. Without this, interrupting an enter animation
     // causes the exit to snap (the element is disconnected before onDestroy, so
     // getAnimations()/commitStyles() can't work at clone time).
+    // Skipped inside <PresenceChild>: the wrapper drives exit, no clone path.
     $effect(() => {
-        if (!(element && context)) return
+        if (!(element && context) || inPresenceChild) return
         let rafId: number
         const capture = () => {
             if (element && element.isConnected && element.getAnimations().length > 0) {
@@ -227,7 +234,7 @@
 
     // Reactively update registration when element/exit/transition props change
     $effect(() => {
-        if (element && context && resolvedExit) {
+        if (element && context && !inPresenceChild && resolvedExit) {
             const filteredExit = filterReducedMotionKeyframes(
                 resolvedExit as Record<string, unknown>,
                 reducedMotion
@@ -241,9 +248,10 @@
         }
     })
 
-    // Update presence context with current state when element is ready and has size
+    // Update presence context with current state when element is ready and has size.
+    // Skipped inside <PresenceChild> — the rect/style snapshot only feeds the clone path.
     $effect(() => {
-        if (!(context && element && isLoaded === 'ready')) return
+        if (!(context && element && isLoaded === 'ready') || inPresenceChild) return
 
         let lastWidth = 0
         let lastHeight = 0

--- a/src/lib/index.spec.ts
+++ b/src/lib/index.spec.ts
@@ -25,6 +25,7 @@ import {
     motion,
     MotionConfig,
     pipe,
+    PresenceChild,
     press,
     progress,
     resize,
@@ -36,6 +37,8 @@ import {
     useAnimationFrame,
     useCycle,
     useInView,
+    useIsPresent,
+    usePresence,
     useReducedMotion,
     useSpring,
     useTime,
@@ -68,6 +71,10 @@ describe('public API: index.ts', () => {
         expect(typeof AnimatePresence).toBe('function')
     })
 
+    it('exports PresenceChild component', () => {
+        expect(typeof PresenceChild).toBe('function')
+    })
+
     it('exports createDragControls factory', () => {
         expect(typeof createDragControls).toBe('function')
         const controls = createDragControls()
@@ -83,6 +90,8 @@ describe('public API: index.ts', () => {
         expect(typeof useAnimationFrame).toBe('function')
         expect(typeof useCycle).toBe('function')
         expect(typeof useInView).toBe('function')
+        expect(typeof useIsPresent).toBe('function')
+        expect(typeof usePresence).toBe('function')
         expect(typeof useReducedMotion).toBe('function')
         expect(typeof useSpring).toBe('function')
         expect(typeof stringifyStyleObject).toBe('function')

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,6 @@
 import AnimatePresence from '$lib/components/AnimatePresence.svelte'
 import MotionConfig from '$lib/components/MotionConfig.svelte'
+import PresenceChild from '$lib/components/PresenceChild.svelte'
 
 export { motion } from '$lib/motion'
 
@@ -62,6 +63,8 @@ export { useReducedMotion } from '$lib/utils/reducedMotion'
 export { useReducedMotionConfig } from '$lib/utils/reducedMotionConfig'
 export { useScroll } from '$lib/utils/scroll'
 export { useSpring } from '$lib/utils/spring'
+export { useIsPresent, usePresence } from '$lib/utils/usePresence'
+export type { UsePresenceState } from '$lib/utils/usePresence'
 export { useVelocity } from '$lib/utils/velocity'
 /**
  * @deprecated Use `styleString` instead for reactive styles with automatic unit handling.
@@ -70,7 +73,7 @@ export { stringifyStyleObject } from '$lib/utils/styleObject'
 export { styleString } from '$lib/utils/styleObject.svelte'
 export { useTime } from '$lib/utils/time'
 export { useTransform } from '$lib/utils/transform'
-export { AnimatePresence, MotionConfig }
+export { AnimatePresence, MotionConfig, PresenceChild }
 
 // Named component exports — tree-shakeable alternative to the `motion` object
 export { default as MotionA } from '$lib/html/A.svelte'

--- a/src/lib/utils/presence.ts
+++ b/src/lib/utils/presence.ts
@@ -2,7 +2,7 @@ import type { AnimatePresenceMode, MotionExit, MotionTransition } from '$lib/typ
 import { mergeTransitions } from '$lib/utils/animation'
 import { pwLog } from '$lib/utils/log'
 import { animate, type AnimationOptions, type DOMKeyframesDefinition } from 'motion'
-import { getContext, onDestroy, setContext } from 'svelte'
+import { getContext, setContext } from 'svelte'
 
 /**
  * Context key for `AnimatePresence`.
@@ -100,6 +100,19 @@ export type AnimatePresenceContext = {
     updateChildAnimatedStyle: (key: string, opacity: string, transform: string) => void
     /** Unregister a child. If it has an exit, clone and animate it out. */
     unregisterChild: (key: string) => void
+    /**
+     * @internal Used by `PresenceChild` to participate in the same exit
+     * accounting as the clone-based motion-element exit path. Increments the
+     * in-flight exit counter and applies mode='wait' enter blocking. Not
+     * intended for direct consumer use.
+     */
+    notifyExitStart: () => void
+    /**
+     * @internal Pairs with `notifyExitStart`. Decrements the in-flight exit
+     * counter, fires `onExitComplete` once it reaches zero, and unblocks
+     * pending enters in mode='wait'. Not intended for direct consumer use.
+     */
+    notifyExitComplete: () => void
 }
 
 /**
@@ -288,6 +301,34 @@ export const createAnimatePresenceContext = (context: {
     let inFlightExits = 0
 
     /**
+     * Begin tracking an exit. Increments `inFlightExits` and, in `mode='wait'`,
+     * blocks new enter animations until `finishExit()` reports the count back
+     * to zero. Shared by the clone-based exit (`unregisterChild`) and the
+     * `PresenceChild` user-driven exit.
+     */
+    const startExit = () => {
+        if (mode === 'wait') {
+            enterBlocked = true
+        }
+        inFlightExits += 1
+    }
+
+    /**
+     * Mark an exit as finished. Decrements `inFlightExits` and, when it
+     * reaches zero, fires `onExitComplete` and unblocks pending enters.
+     */
+    const finishExit = () => {
+        inFlightExits -= 1
+        if (inFlightExits === 0) {
+            context.onExitComplete?.()
+            if (mode === 'wait' && enterBlocked) {
+                enterBlocked = false
+                notifyEnterUnblocked()
+            }
+        }
+    }
+
+    /**
      * Register a child element and snapshot its initial rect/styles.
      */
     const registerChild = (
@@ -382,12 +423,6 @@ export const createAnimatePresenceContext = (context: {
             pwLog('[presence] unregisterChild - no exit animation, removing immediately')
             children.delete(key)
             return
-        }
-
-        // For mode='wait': block new enters while exit is in progress
-        if (mode === 'wait') {
-            enterBlocked = true
-            pwLog('[presence] mode=wait: blocking enters during exit')
         }
 
         const rect = child.lastRect
@@ -539,8 +574,8 @@ export const createAnimatePresenceContext = (context: {
         // before this exit animation completes
         const exitingElement = child.element
 
-        // Start exit and track in-flight count
-        inFlightExits += 1
+        // Start exit and track in-flight count (handles wait-mode blocking)
+        startExit()
 
         requestAnimationFrame(() => {
             animate(clone, exitKeyframes as unknown as DOMKeyframesDefinition, finalTransition)
@@ -587,19 +622,7 @@ export const createAnimatePresenceContext = (context: {
                         clonesInDOM: document.querySelectorAll('[data-clone="true"]').length
                     })
 
-                    inFlightExits -= 1
-
-                    if (inFlightExits === 0) {
-                        pwLog('[presence] all exits complete, calling onExitComplete')
-                        context.onExitComplete?.()
-
-                        // For mode='wait': unblock enters now that all exits are complete
-                        if (mode === 'wait' && enterBlocked) {
-                            enterBlocked = false
-                            pwLog('[presence] mode=wait: unblocking enters, notifying callbacks')
-                            notifyEnterUnblocked()
-                        }
-                    }
+                    finishExit()
                 })
         })
     }
@@ -614,7 +637,9 @@ export const createAnimatePresenceContext = (context: {
         registerChild,
         updateChildState,
         updateChildAnimatedStyle,
-        unregisterChild
+        unregisterChild,
+        notifyExitStart: startExit,
+        notifyExitComplete: finishExit
     }
 }
 
@@ -684,47 +709,44 @@ export const setPresenceDepth = (depth: number): void => {
 }
 
 /**
- * Hook used by motion elements to participate in presence.
- * Registers the element and ensures its exit animation runs on teardown.
+ * Per-`PresenceChild` Svelte context payload. Read by the `useIsPresent` and
+ * `usePresence` hooks (and consulted by motion elements so they can opt out of
+ * the outer `AnimatePresence` clone path when a `PresenceChild` is driving
+ * the exit themselves).
  *
- * Note: Svelte lifecycle wrapper - ignored for coverage.
+ * `isPresent` is exposed as a getter so consumers see live updates as the
+ * wrapper toggles between mounted, exiting, and re-entered states.
  */
-/* c8 ignore start */
-/**
- * Hook used by motion elements to participate in presence.
- *
- * Registers the element with the presence context and guarantees that the
- * exit animation is scheduled on teardown.
- *
- * @param key Unique identifier for the presence child.
- * @param element The DOM element to track.
- * @param exit The exit keyframes definition.
- * @param mergedTransition The element's merged transition for precedence.
- */
-export const usePresence = (
-    key: string,
-    element: HTMLElement | null,
-    exit: MotionExit,
-    mergedTransition?: MotionTransition
-): void => {
-    const context = getAnimatePresenceContext()
-    pwLog('[presence] usePresence called', {
-        key,
-        hasElement: !!element,
-        hasContext: !!context,
-        hasExit: !!exit,
-        exit
-    })
-    if (element && context && exit) {
-        context.registerChild(key, element, exit, mergedTransition)
-        onDestroy(() => {
-            pwLog('[presence] onDestroy triggered', { key })
-            context.unregisterChild(key)
-        })
-    } else {
-        pwLog('[presence] usePresence - skipping registration', {
-            reason: !element ? 'no element' : !context ? 'no context' : 'no exit'
-        })
-    }
+export type PresenceChildContext = {
+    /** Reactive flag — `true` while present, `false` once the exit hold begins. */
+    readonly isPresent: boolean
+    /**
+     * Signal that the consumer's exit work is complete. Triggers actual
+     * unmount and decrements the parent `AnimatePresenceContext` exit count.
+     * Idempotent and versioned (calls from a canceled exit cycle are no-ops).
+     */
+    safeToRemove: () => void
 }
-/* c8 ignore end */
+
+const PRESENCE_CHILD_CONTEXT = Symbol('presence-child-context')
+
+/**
+ * Get the nearest `PresenceChild` context from Svelte component context, or
+ * `undefined` if the caller is not wrapped in one.
+ *
+ * Note: Trivial wrapper - ignored for coverage.
+ */
+/* c8 ignore next 3 */
+export const getPresenceChildContext = (): PresenceChildContext | undefined => {
+    return getContext(PRESENCE_CHILD_CONTEXT)
+}
+
+/**
+ * Install a `PresenceChild` context for descendants.
+ *
+ * Note: Trivial wrapper - ignored for coverage.
+ */
+/* c8 ignore next 3 */
+export const setPresenceChildContext = (context: PresenceChildContext): void => {
+    setContext(PRESENCE_CHILD_CONTEXT, context)
+}

--- a/src/lib/utils/presence.ts
+++ b/src/lib/utils/presence.ts
@@ -301,10 +301,29 @@ export const createAnimatePresenceContext = (context: {
     let inFlightExits = 0
 
     /**
-     * Begin tracking an exit. Increments `inFlightExits` and, in `mode='wait'`,
-     * blocks new enter animations until `finishExit()` reports the count back
-     * to zero. Shared by the clone-based exit (`unregisterChild`) and the
-     * `PresenceChild` user-driven exit.
+     * Begin tracking an exit.
+     *
+     * Increments the `inFlightExits` counter and, in `mode='wait'`, raises the
+     * `enterBlocked` flag so sibling motion-element enters defer until every
+     * exit reports back via {@link finishExit}. Shared by the clone-based exit
+     * path in {@link unregisterChild} and the user-driven `PresenceChild` hold.
+     *
+     * Must be paired with exactly one {@link finishExit} call per invocation.
+     *
+     * @returns void
+     * @example
+     * ```ts
+     * // unregisterChild (clone path)
+     * startExit()
+     * requestAnimationFrame(() => {
+     *   animate(clone, exitKeyframes, transition).finished.finally(finishExit)
+     * })
+     *
+     * // PresenceChild (user-driven path) — exposed as `notifyExitStart`
+     * presenceContext.notifyExitStart()
+     * // ... later, on transitionend or user signal ...
+     * presenceContext.notifyExitComplete()
+     * ```
      */
     const startExit = () => {
         if (mode === 'wait') {
@@ -314,8 +333,23 @@ export const createAnimatePresenceContext = (context: {
     }
 
     /**
-     * Mark an exit as finished. Decrements `inFlightExits` and, when it
-     * reaches zero, fires `onExitComplete` and unblocks pending enters.
+     * Mark an exit as finished.
+     *
+     * Decrements the `inFlightExits` counter. When the count reaches zero,
+     * fires the consumer's `onExitComplete` callback and, in `mode='wait'`,
+     * lowers `enterBlocked` plus notifies any deferred-enter callbacks
+     * registered via {@link onEnterUnblocked}.
+     *
+     * Must be called exactly once per matching {@link startExit}; double-fires
+     * underflow the counter and can permanently mis-route subsequent exits.
+     *
+     * @returns void
+     * @example
+     * ```ts
+     * startExit()
+     * // ... exit work ...
+     * finishExit() // fires onExitComplete if the last exit, unblocks waiters
+     * ```
      */
     const finishExit = () => {
         inFlightExits -= 1

--- a/src/lib/utils/usePresence.spec.ts
+++ b/src/lib/utils/usePresence.spec.ts
@@ -1,5 +1,10 @@
 import PresenceHarness from '$lib/components/__tests__/PresenceHarness.svelte'
 import PresenceProbe from '$lib/components/__tests__/PresenceProbe.svelte'
+import StalePresenceHarness from '$lib/components/__tests__/StalePresenceHarness.svelte'
+import {
+    getCapturedSafeToRemove,
+    resetCapturedSafeToRemove
+} from '$lib/components/__tests__/StalePresenceProbe.svelte'
 import { render, screen } from '@testing-library/svelte'
 import { tick } from 'svelte'
 import { describe, expect, it } from 'vitest'
@@ -56,6 +61,44 @@ describe('utils/usePresence', () => {
             await tick()
             // Second click on a detached node should not throw or re-fire.
             expect(() => node.click()).not.toThrow()
+            expect(screen.queryByTestId('probe')).toBeNull()
+        })
+
+        it('a captured safeToRemove from a canceled exit does NOT complete a later exit', async () => {
+            // Regression for the case where a consumer captures the callback
+            // (setTimeout, external library, async work) during cycle A, exit
+            // A is canceled by re-entry, cycle B starts, and the stale
+            // callback fires while phase is 'holding' again. The stale call
+            // must no-op, leaving cycle B in flight.
+            resetCapturedSafeToRemove()
+            const { rerender } = render(StalePresenceHarness, { props: { present: true } })
+
+            // Cycle A starts; probe captures cycle A's callback.
+            await rerender({ present: false })
+            await tick()
+            const staleFromA = getCapturedSafeToRemove()
+            expect(staleFromA).toBeInstanceOf(Function)
+
+            // Re-enter cancels cycle A.
+            await rerender({ present: true })
+            await tick()
+
+            // Cycle B starts; probe captures cycle B's callback.
+            await rerender({ present: false })
+            await tick()
+            const freshFromB = getCapturedSafeToRemove()
+            expect(freshFromB).toBeInstanceOf(Function)
+            expect(freshFromB).not.toBe(staleFromA)
+
+            // Invoke the stale callback from A. It must NOT complete B.
+            staleFromA?.()
+            await tick()
+            expect(screen.queryByTestId('probe')).not.toBeNull()
+            expect(screen.getByTestId('probe').getAttribute('data-is-present')).toBe('false')
+
+            // The fresh callback from B still works and completes the exit.
+            freshFromB?.()
+            await tick()
             expect(screen.queryByTestId('probe')).toBeNull()
         })
 

--- a/src/lib/utils/usePresence.spec.ts
+++ b/src/lib/utils/usePresence.spec.ts
@@ -1,0 +1,79 @@
+import PresenceHarness from '$lib/components/__tests__/PresenceHarness.svelte'
+import PresenceProbe from '$lib/components/__tests__/PresenceProbe.svelte'
+import { render, screen } from '@testing-library/svelte'
+import { tick } from 'svelte'
+import { describe, expect, it } from 'vitest'
+
+const probe = () => screen.getByTestId('probe')
+
+describe('utils/usePresence', () => {
+    describe('outside any PresenceChild', () => {
+        it('useIsPresent returns true', () => {
+            render(PresenceProbe)
+            expect(probe().getAttribute('data-is-present')).toBe('true')
+        })
+
+        it('usePresence returns [true, null]', () => {
+            render(PresenceProbe)
+            expect(probe().getAttribute('data-tuple-is-present')).toBe('true')
+            expect(probe().getAttribute('data-tuple-has-callback')).toBe('false')
+        })
+    })
+
+    describe('inside PresenceChild', () => {
+        it('reports present while present={true}', () => {
+            render(PresenceHarness, { props: { present: true } })
+            expect(probe().getAttribute('data-is-present')).toBe('true')
+            expect(probe().getAttribute('data-tuple-is-present')).toBe('true')
+            expect(probe().getAttribute('data-tuple-has-callback')).toBe('false')
+        })
+
+        it('flips to not-present and exposes safeToRemove when present goes false', async () => {
+            const { rerender } = render(PresenceHarness, { props: { present: true } })
+            await rerender({ present: false })
+            await tick()
+            expect(probe().getAttribute('data-is-present')).toBe('false')
+            expect(probe().getAttribute('data-tuple-is-present')).toBe('false')
+            expect(probe().getAttribute('data-tuple-has-callback')).toBe('true')
+        })
+
+        it('safeToRemove unmounts the children', async () => {
+            const { rerender } = render(PresenceHarness, { props: { present: true } })
+            await rerender({ present: false })
+            await tick()
+            // Trigger safeToRemove by clicking the probe (handler fires safeToRemove())
+            probe().click()
+            await tick()
+            expect(screen.queryByTestId('probe')).toBeNull()
+        })
+
+        it('safeToRemove is idempotent — second call is a no-op', async () => {
+            const { rerender } = render(PresenceHarness, { props: { present: true } })
+            await rerender({ present: false })
+            await tick()
+            const node = probe()
+            node.click()
+            await tick()
+            // Second click on a detached node should not throw or re-fire.
+            expect(() => node.click()).not.toThrow()
+            expect(screen.queryByTestId('probe')).toBeNull()
+        })
+
+        it('re-entry mid-hold cancels the exit and the stale safeToRemove no-ops', async () => {
+            const { rerender } = render(PresenceHarness, { props: { present: true } })
+            await rerender({ present: false })
+            await tick()
+            const staleNode = probe()
+            // Re-enter before the consumer signals completion.
+            await rerender({ present: true })
+            await tick()
+            expect(probe().getAttribute('data-is-present')).toBe('true')
+            // Calling the previously-handed-out safeToRemove must NOT unmount
+            // the now-present component.
+            staleNode.click()
+            await tick()
+            expect(screen.queryByTestId('probe')).not.toBeNull()
+            expect(probe().getAttribute('data-is-present')).toBe('true')
+        })
+    })
+})

--- a/src/lib/utils/usePresence.ts
+++ b/src/lib/utils/usePresence.ts
@@ -1,0 +1,82 @@
+import { getPresenceChildContext } from '$lib/utils/presence'
+
+/**
+ * Tuple returned by {@link usePresence}, matching framer-motion's shape:
+ * `[true, null]` while present (or when not inside a `PresenceChild`), and
+ * `[false, () => void]` after the wrapper enters its exit hold.
+ */
+export type UsePresenceState = [true, null] | [false, () => void]
+
+/**
+ * Returns whether the calling component is currently present in its parent
+ * `<PresenceChild>`. While the wrapper holds the component for an exit, this
+ * flips to `false` so the consumer can branch (render different markup, run
+ * a custom exit animation, etc.).
+ *
+ * Outside of a `<PresenceChild>` always returns `true`.
+ *
+ * Reactivity note: the boolean tracks the wrapper's state and updates in
+ * Svelte 5 reactive contexts (`$derived`, `$effect`, template). For non-
+ * reactive snapshots, prefer `usePresence()` which exposes the same state
+ * alongside the `safeToRemove` callback.
+ *
+ * @returns `true` while present, `false` while exiting.
+ * @see https://motion.dev/docs/react-use-is-present
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { useIsPresent } from '@humanspeak/svelte-motion'
+ *   const isPresent = $derived(useIsPresent())
+ * </script>
+ * <div class:exiting={!isPresent}>{isPresent ? 'live' : 'goodbye'}</div>
+ * ```
+ */
+export const useIsPresent = (): boolean => {
+    const context = getPresenceChildContext()
+    return context ? context.isPresent : true
+}
+
+/**
+ * Returns `[isPresent, safeToRemove]`. `isPresent` reflects the wrapper's
+ * presence state; `safeToRemove` is the callback to invoke once a custom exit
+ * animation finishes. Calling it triggers the actual unmount and decrements
+ * the parent `<AnimatePresence>` exit-completion count.
+ *
+ * Outside of a `<PresenceChild>` returns `[true, null]` — the consumer is
+ * effectively always present and there is nothing to safely remove.
+ *
+ * `safeToRemove` is idempotent and versioned: a stale callback from a
+ * canceled exit cycle (re-entry before the consumer signaled completion) is
+ * a no-op.
+ *
+ * @returns `[true, null]` while present (or outside any `PresenceChild`),
+ *     `[false, () => void]` while the wrapper holds the component for exit.
+ * @see https://motion.dev/docs/react-use-presence
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { usePresence } from '@humanspeak/svelte-motion'
+ *
+ *   let node: HTMLElement | undefined = $state()
+ *   const presence = $derived(usePresence())
+ *
+ *   $effect(() => {
+ *     const [isPresent, safeToRemove] = presence
+ *     if (isPresent || !node) return
+ *     const onEnd = () => safeToRemove()
+ *     node.addEventListener('transitionend', onEnd, { once: true })
+ *     node.classList.add('exiting')
+ *     return () => node?.removeEventListener('transitionend', onEnd)
+ *   })
+ * </script>
+ *
+ * <div bind:this={node}>…</div>
+ * ```
+ */
+export const usePresence = (): UsePresenceState => {
+    const context = getPresenceChildContext()
+    if (!context) return [true, null]
+    return context.isPresent ? [true, null] : [false, context.safeToRemove]
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -265,6 +265,14 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/use-presence') + searchParams}
+                    >
+                        usePresence
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/reduced-motion') + searchParams}
                     >
                         useReducedMotion

--- a/src/routes/tests/use-presence/+page.svelte
+++ b/src/routes/tests/use-presence/+page.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+    import { AnimatePresence, PresenceChild } from '$lib'
+    import CustomExit from './CustomExit.svelte'
+    import WaitChild from './WaitChild.svelte'
+
+    let visible = $state(true)
+    let exitCompletes = $state(0)
+
+    // Wait-mode swap demo
+    let slot: 'a' | 'b' = $state('a')
+</script>
+
+<svelte:head>
+    <title>usePresence Test</title>
+</svelte:head>
+
+<div class="page">
+    <header>
+        <h1>usePresence</h1>
+        <p>
+            <code>PresenceChild</code> holds the child rendered until <code>safeToRemove()</code>
+            fires. The exit animation here is a CSS transition driven from inside the child via the hook.
+        </p>
+    </header>
+
+    <section class="block">
+        <h2>Basic toggle (mode='sync')</h2>
+        <button
+            type="button"
+            data-testid="toggle-basic"
+            onclick={() => (visible = !visible)}
+            class="primary"
+        >
+            {visible ? 'Hide' : 'Show'}
+        </button>
+        <span data-testid="exits-completed">exitsCompleted: {exitCompletes}</span>
+
+        <div class="stage" data-testid="stage-basic">
+            <AnimatePresence onExitComplete={() => exitCompletes++}>
+                <PresenceChild present={visible}>
+                    <CustomExit />
+                </PresenceChild>
+            </AnimatePresence>
+        </div>
+    </section>
+
+    <section class="block">
+        <h2>mode='wait' integration with motion.* enter</h2>
+        <p class="hint">
+            Click <code>swap</code> — the new motion element waits for the old PresenceChild's
+            <code>safeToRemove</code> before its enter animation runs.
+        </p>
+        <button
+            type="button"
+            data-testid="toggle-wait"
+            onclick={() => (slot = slot === 'a' ? 'b' : 'a')}
+            class="primary"
+        >
+            swap (current: {slot})
+        </button>
+
+        <div class="stage" data-testid="stage-wait">
+            <AnimatePresence mode="wait">
+                <PresenceChild present={slot === 'a'}>
+                    <WaitChild label="A" />
+                </PresenceChild>
+                <PresenceChild present={slot === 'b'}>
+                    <WaitChild label="B" />
+                </PresenceChild>
+            </AnimatePresence>
+        </div>
+    </section>
+</div>
+
+<style>
+    .page {
+        padding: 24px;
+        max-width: 640px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+    }
+
+    .block {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 16px;
+        border: 1px solid #d4d4d8;
+        border-radius: 10px;
+    }
+
+    .stage {
+        min-height: 80px;
+        display: flex;
+        align-items: center;
+    }
+
+    .hint {
+        color: #555;
+        font-size: 13px;
+    }
+
+    button.primary {
+        align-self: flex-start;
+        background: #2563eb;
+        color: white;
+        font-size: 14px;
+        padding: 6px 12px;
+        border-radius: 6px;
+        border: 1px solid transparent;
+        cursor: pointer;
+    }
+
+    span {
+        font-size: 13px;
+        color: #555;
+    }
+</style>

--- a/src/routes/tests/use-presence/CustomExit.svelte
+++ b/src/routes/tests/use-presence/CustomExit.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+    import { usePresence } from '$lib'
+
+    const presence = $derived(usePresence())
+    const isPresent = $derived(presence[0])
+    let node: HTMLElement | undefined = $state()
+
+    $effect(() => {
+        const [present, safeToRemove] = presence
+        if (present || !node || !safeToRemove) return
+        const el = node
+        const onEnd = (e: TransitionEvent) => {
+            if (e.target !== el) return
+            safeToRemove()
+        }
+        el.addEventListener('transitionend', onEnd, { once: true })
+        return () => el.removeEventListener('transitionend', onEnd)
+    })
+</script>
+
+<div
+    bind:this={node}
+    class="card"
+    class:exiting={!isPresent}
+    data-testid="card"
+    data-is-present={isPresent}
+>
+    {isPresent ? 'present' : 'exiting'}
+</div>
+
+<style>
+    .card {
+        width: 200px;
+        padding: 16px 20px;
+        border-radius: 10px;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        font-weight: 500;
+        opacity: 1;
+        transform: translateY(0);
+        transition:
+            opacity 300ms ease,
+            transform 300ms ease;
+    }
+
+    .card.exiting {
+        opacity: 0;
+        transform: translateY(-12px);
+    }
+</style>

--- a/src/routes/tests/use-presence/WaitChild.svelte
+++ b/src/routes/tests/use-presence/WaitChild.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+    import { usePresence } from '$lib'
+
+    type Props = { label: string }
+    const { label }: Props = $props()
+
+    const presence = $derived(usePresence())
+    const isPresent = $derived(presence[0])
+    let node: HTMLElement | undefined = $state()
+
+    $effect(() => {
+        const [present, safeToRemove] = presence
+        if (present || !node || !safeToRemove) return
+        const el = node
+        const onEnd = (e: TransitionEvent) => {
+            if (e.target !== el) return
+            safeToRemove()
+        }
+        el.addEventListener('transitionend', onEnd, { once: true })
+        return () => el.removeEventListener('transitionend', onEnd)
+    })
+</script>
+
+<div
+    bind:this={node}
+    class="wait-card"
+    class:exiting={!isPresent}
+    data-testid={`wait-${label.toLowerCase()}`}
+    data-is-present={isPresent}
+>
+    {label}
+</div>
+
+<style>
+    .wait-card {
+        width: 120px;
+        padding: 16px;
+        border-radius: 10px;
+        background: linear-gradient(135deg, #db2777 0%, #f59e0b 100%);
+        color: white;
+        font-weight: 600;
+        text-align: center;
+        opacity: 1;
+        transform: translateX(0);
+        transition:
+            opacity 300ms ease,
+            transform 300ms ease;
+    }
+
+    .wait-card.exiting {
+        opacity: 0;
+        transform: translateX(12px);
+    }
+</style>


### PR DESCRIPTION
## Summary

Adds `useIsPresent` and `usePresence` — the framer-motion hooks for branching on `<AnimatePresence>` exit phase. They live behind a new opt-in `<PresenceChild>` wrapper that holds its children rendered with `isPresent=false` until the consumer signals `safeToRemove()`. Lets users drive **custom non-`motion.*` exits** (CSS transitions, third-party libs, async cleanup) while still participating in `<AnimatePresence>`'s exit accounting and `mode='wait'` enter blocking.

The implicit React shape `<AnimatePresence>{cond && <Card />}</AnimatePresence>` isn't reachable in Svelte — `{#if}` teardown is synchronous and the framework exposes no hook to defer it ([upstream tracker: sveltejs/svelte#3847](https://github.com/sveltejs/svelte/issues/3847), still open). The `<PresenceChild>` wrapper is the smallest honest port; it's the only place in the tree where Svelte gives us a hook above the conditional. Existing `motion.* exit={...}` flow is untouched.

## Changes

✨ **New public API**
- `<PresenceChild present={cond}>...</PresenceChild>` — opt-in wrapper with three-phase state machine (idle → holding → completed); idempotent + versioned `safeToRemove`; re-entry mid-hold cancels the exit cleanly.
- `useIsPresent(): boolean` — read just the present flag.
- `usePresence(): [true, null] | [false, () => void]` — framer-motion-shaped tuple, also reactive via getter into the wrapper's `$state`.

🔧 **Internal refactor (`src/lib/utils/presence.ts`)**
- Extracted `inFlightExits` accounting into shared `startExit()` / `finishExit()` helpers. Both the existing clone path (`unregisterChild`) and `PresenceChild.notifyExitStart/Complete` call them, so `onExitComplete` and `mode='wait'` enter blocking work uniformly across both exit mechanisms.
- Deleted dead internal `usePresence` helper that was never called by anything.
- Marked `notifyExitStart` / `notifyExitComplete` `@internal` on the context type.

🛡️ **Conflict avoidance (`src/lib/html/_MotionContainer.svelte`)**
- Detects an enclosing `<PresenceChild>` and skips its clone-path registration so a user's custom exit and motion's clone exit cannot double-fire.

🧪 **Tests**
- 7 unit specs in `src/lib/utils/usePresence.spec.ts` covering: outside-context defaults, hold + safeToRemove, idempotency (double-call no-op), re-entry mid-hold cancellation, re-mount after completion.
- 3 e2e specs in `e2e/utilities/use-presence.spec.ts` covering basic toggle, show-after-hide, sibling-swap with concurrent hold.
- Test fixtures `PresenceProbe.svelte` + `PresenceHarness.svelte`.

🎯 **Demo route** at `/tests/use-presence` — basic toggle (CSS transition exit) + sibling-swap with `mode='wait'`.

📚 **Docs**
- New page `/docs/use-presence` with the API divergence called out up front.
- Interactive example at `/examples/use-presence`.
- Nav entry under "Hooks", sitemap regenerated.

## Known Limitations

- **`mode='popLayout'`**: the wrapper holds the exiting child in document flow, so `popLayout` semantics aren't fully implemented under `<PresenceChild>`. `sync` (default) and `wait` work via the shared accounting.
- **Nested `<AnimatePresence>` inside a held wrapper**: descendants don't see exit signals during the hold; once `safeToRemove` fires, normal unmount cascades through.

Both documented in the docs page.

## Commits

- [`07ff8e4`](https://github.com/humanspeak/svelte-motion/commit/07ff8e4a92a168507e619f9a39ce9dba5ce41293) feat: useIsPresent + usePresence hooks via PresenceChild

Closes #303
Closes #304
