### PR TITLE
feat(whileInView): add viewport prop (once / root / margin / amount)

### DIFF
--- a/docs/src/lib/examples/WhileInViewExample.svelte
+++ b/docs/src/lib/examples/WhileInViewExample.svelte
@@ -34,10 +34,10 @@
                 duration: 0.8
             }
         }}
-        viewport={{ once: true, amount: 0.5 }}
+        viewport={{ once: true, amount: 0.5, margin: '-50px' }}
         style="display: flex; align-items: center; justify-content: center; padding: 2rem; background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%); border-radius: 12px; color: white; font-weight: 600; text-align: center; font-size: 1.25rem;"
     >
-        I animate once — viewport=&lbrace; once: true, amount: 0.5 &rbrace;
+        I animate once — viewport=&lbrace; once: true, amount: 0.5, margin: '-50px' &rbrace;
     </motion.div>
     <div class="spacer-bottom"></div>
     <p class="scroll-hint">Scroll back up — only the first card re-animates</p>

--- a/docs/src/lib/examples/WhileInViewExample.svelte
+++ b/docs/src/lib/examples/WhileInViewExample.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <div class="scroll-container">
-    <p class="scroll-hint">Scroll down to see the animation</p>
+    <p class="scroll-hint">Scroll down to see the animations</p>
     <div class="spacer"></div>
     <motion.div
         initial={{ opacity: 0, y: 100, scale: 0.8 }}
@@ -19,10 +19,28 @@
         }}
         style="display: flex; align-items: center; justify-content: center; padding: 2rem; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); border-radius: 12px; color: white; font-weight: 600; text-align: center; font-size: 1.25rem;"
     >
-        I animate when in view!
+        I animate every time I enter view
     </motion.div>
     <div class="spacer-bottom"></div>
-    <p class="scroll-hint">Scroll back up to see it animate again</p>
+    <motion.div
+        initial={{ opacity: 0, y: 100, scale: 0.8 }}
+        whileInView={{
+            opacity: 1,
+            y: 0,
+            scale: 1,
+            transition: {
+                type: 'spring',
+                bounce: 0.4,
+                duration: 0.8
+            }
+        }}
+        viewport={{ once: true, amount: 0.5 }}
+        style="display: flex; align-items: center; justify-content: center; padding: 2rem; background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%); border-radius: 12px; color: white; font-weight: 600; text-align: center; font-size: 1.25rem;"
+    >
+        I animate once — viewport=&lbrace; once: true, amount: 0.5 &rbrace;
+    </motion.div>
+    <div class="spacer-bottom"></div>
+    <p class="scroll-hint">Scroll back up — only the first card re-animates</p>
     <div class="spacer-end"></div>
 </div>
 

--- a/docs/src/routes/docs/+page.svx
+++ b/docs/src/routes/docs/+page.svx
@@ -195,6 +195,21 @@ You can also use lifecycle callbacks:
 />
 ```
 
+Configure the underlying IntersectionObserver with the `viewport` prop:
+
+```svelte
+<motion.div
+  initial={{ opacity: 0, y: 50 }}
+  whileInView={{ opacity: 1, y: 0 }}
+  viewport={{ once: true, amount: 0.5, margin: '-50px' }}
+/>
+```
+
+- `once: true` — fire entry once, latch, never animate back
+- `amount` — `number` (0-1), `'some'` (any pixel), or `'all'` (fully visible)
+- `margin` — CSS margin string applied to the IntersectionObserver root box
+- `root` — custom IntersectionObserver root (defaults to the viewport)
+
 For scroll-linked animations (where values track scroll position), use utilities like `useTime`/`useTransform`:
 
 ```svelte

--- a/docs/static/llms-full.txt
+++ b/docs/static/llms-full.txt
@@ -161,13 +161,17 @@ Keyboard accessible (Enter/Space).
 <motion.div
     initial={{ opacity: 0, y: 40 }}
     whileInView={{ opacity: 1, y: 0 }}
+    viewport={{ once: true, amount: 0.5, margin: '-50px' }}
     transition={{ duration: 0.6 }}
     onInViewStart={() => console.log('entered viewport')}
     onInViewEnd={() => console.log('left viewport')}
 />
 ```
 
-Uses IntersectionObserver internally.
+Uses IntersectionObserver internally. Configure it with the `viewport`
+prop: `once` (fire once and latch), `amount` (`number` 0-1 / `'some'` /
+`'all'`), `margin` (CSS margin string applied to the IO root box), and
+`root` (custom IO root — defaults to the viewport).
 
 ---
 

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -87,6 +87,7 @@
         whileHover: whileHoverProp,
         whileFocus: whileFocusProp,
         whileInView: whileInViewProp,
+        viewport: viewportProp,
         whileDrag: whileDragProp,
         onHoverStart: onHoverStartProp,
         onHoverEnd: onHoverEndProp,
@@ -781,7 +782,8 @@
             {
                 initial: (resolvedInitial ?? {}) as Record<string, unknown>,
                 animate: (resolvedAnimate ?? {}) as Record<string, unknown>
-            }
+            },
+            viewportProp
         )
     })
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -151,6 +151,30 @@ export type MotionWhileInView =
     | undefined
 
 /**
+ * IntersectionObserver configuration for `whileInView`. Mirrors framer-motion's
+ * `viewport` prop. Same shape as `UseInViewOptions` minus `initial` (which is
+ * only meaningful for the hook's pre-mount return value).
+ *
+ * @example
+ * ```svelte
+ * <motion.div
+ *   whileInView={{ opacity: 1, y: 0 }}
+ *   viewport={{ once: true, amount: 0.5 }}
+ * />
+ * ```
+ */
+export type MotionViewport = {
+    /** When `true`, fire only once on first entry. Subsequent re-entries no-op. */
+    once?: boolean
+    /** Element to use as the IntersectionObserver root. Defaults to the viewport. */
+    root?: Element | Document
+    /** CSS margin string applied to the root bounding box (e.g. `"100px 0px"`). */
+    margin?: string
+    /** Fraction (0-1) or `"some"` / `"all"` of the target that must be visible. */
+    amount?: 'some' | 'all' | number
+}
+
+/**
  * Animation transition configuration for hover interactions.
  * Overrides the global transition when provided.
  */
@@ -268,6 +292,8 @@ export type MotionProps = {
     whileDrag?: MotionWhileDrag
     /** In-view interaction animation - animates when element enters viewport */
     whileInView?: MotionWhileInView
+    /** IntersectionObserver options for `whileInView` (once / root / margin / amount) */
+    viewport?: MotionViewport
     /** Called right before a main animate transition starts */
     onAnimationStart?: MotionAnimationStart
     /** Called after a main animate transition completes */

--- a/src/lib/utils/inView.spec.ts
+++ b/src/lib/utils/inView.spec.ts
@@ -195,6 +195,12 @@ describe('utils/inView - attachWhileInView viewport options', () => {
         expect(io.instances()[0].init?.threshold).toBe(1)
     })
 
+    it('forwards amount: "some" as threshold 0', () => {
+        const el = document.createElement('div')
+        attachWhileInView(el, { opacity: 1 }, {}, undefined, undefined, { amount: 'some' })
+        expect(io.instances()[0].init?.threshold).toBe(0)
+    })
+
     it('latches on first entry when once: true — no exit animation, no re-entry', async () => {
         const el = document.createElement('div')
         const onStart = vi.fn()

--- a/src/lib/utils/inView.spec.ts
+++ b/src/lib/utils/inView.spec.ts
@@ -1,7 +1,15 @@
 import { get } from 'svelte/store'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockIntersectionObserver } from './__tests__/intersectionObserver.js'
-import { useInView } from './inView.js'
+import { attachWhileInView, useInView } from './inView.js'
+
+vi.mock(import('motion'), async (importOriginal) => {
+    const actual = await importOriginal()
+    return {
+        ...actual,
+        animate: vi.fn(() => ({ finished: Promise.resolve() })) as never
+    }
+})
 
 let io: ReturnType<typeof createMockIntersectionObserver>
 
@@ -150,5 +158,81 @@ describe('utils/inView - useInView', () => {
 
         expect(io.instances()[0].init?.threshold).toBe(1)
         unsub()
+    })
+})
+
+describe('utils/inView - attachWhileInView viewport options', () => {
+    it('defaults to threshold 0 (any pixel visible) when no viewport is passed', () => {
+        const el = document.createElement('div')
+        attachWhileInView(el, { opacity: 1 }, {})
+        expect(io.instances()[0].init?.threshold).toBe(0)
+    })
+
+    it('forwards root to IntersectionObserver', () => {
+        const el = document.createElement('div')
+        const root = document.createElement('section')
+        attachWhileInView(el, { opacity: 1 }, {}, undefined, undefined, { root })
+        expect(io.instances()[0].init?.root).toBe(root)
+    })
+
+    it('forwards margin as rootMargin', () => {
+        const el = document.createElement('div')
+        attachWhileInView(el, { opacity: 1 }, {}, undefined, undefined, {
+            margin: '100px 0px'
+        })
+        expect(io.instances()[0].init?.rootMargin).toBe('100px 0px')
+    })
+
+    it('forwards amount: number as threshold', () => {
+        const el = document.createElement('div')
+        attachWhileInView(el, { opacity: 1 }, {}, undefined, undefined, { amount: 0.5 })
+        expect(io.instances()[0].init?.threshold).toBe(0.5)
+    })
+
+    it('forwards amount: "all" as threshold 1', () => {
+        const el = document.createElement('div')
+        attachWhileInView(el, { opacity: 1 }, {}, undefined, undefined, { amount: 'all' })
+        expect(io.instances()[0].init?.threshold).toBe(1)
+    })
+
+    it('latches on first entry when once: true — no exit animation, no re-entry', async () => {
+        const el = document.createElement('div')
+        const onStart = vi.fn()
+        const onEnd = vi.fn()
+        attachWhileInView(el, { opacity: 1 }, {}, { onStart, onEnd }, undefined, { once: true })
+
+        io.fireOn(el, true)
+        expect(onStart).toHaveBeenCalledTimes(1)
+
+        // Latched: a subsequent enter event must not re-fire onStart.
+        io.fireOn(el, true)
+        expect(onStart).toHaveBeenCalledTimes(1)
+
+        // Latched: an exit event must not fire onEnd (no exit animation when once).
+        io.fireOn(el, false)
+        expect(onEnd).not.toHaveBeenCalled()
+    })
+
+    it('without once, calls onStart on enter and onEnd on exit each cycle', () => {
+        const el = document.createElement('div')
+        const onStart = vi.fn()
+        const onEnd = vi.fn()
+        attachWhileInView(el, { opacity: 1 }, {}, { onStart, onEnd })
+
+        io.fireOn(el, true)
+        io.fireOn(el, false)
+        io.fireOn(el, true)
+        io.fireOn(el, false)
+
+        expect(onStart).toHaveBeenCalledTimes(2)
+        expect(onEnd).toHaveBeenCalledTimes(2)
+    })
+
+    it('returns a noop cleanup when whileInView is undefined (no observer created)', () => {
+        const el = document.createElement('div')
+        const before = io.instances().length
+        const cleanup = attachWhileInView(el, undefined, {})
+        expect(io.instances().length).toBe(before)
+        expect(() => cleanup()).not.toThrow()
     })
 })

--- a/src/lib/utils/inView.ts
+++ b/src/lib/utils/inView.ts
@@ -5,6 +5,7 @@ import {
     type DOMKeyframesDefinition
 } from 'motion'
 import { readable, writable, type Readable } from 'svelte/store'
+import type { MotionViewport } from '../types.js'
 import { createAttachable } from './attachable.js'
 import { type ElementOrGetter } from './dom.js'
 
@@ -128,21 +129,6 @@ export const computeInViewBaseline = (
 }
 
 /**
- * Viewport options for `attachWhileInView`. Mirrors framer-motion's
- * `viewport` prop on motion components.
- */
-export type AttachWhileInViewOptions = {
-    /** Fire only once; subsequent re-entries are no-ops (no exit animation either). */
-    once?: boolean
-    /** IntersectionObserver root. Defaults to the document viewport. */
-    root?: Element | Document
-    /** CSS margin string applied to the root box (e.g. `"100px 0px"`). */
-    margin?: string
-    /** Fraction (0-1) or `"some"` / `"all"` of the target that must be visible. */
-    amount?: 'some' | 'all' | number
-}
-
-/**
  * Attach whileInView interactions to an element via motion's `inView` primitive.
  *
  * On entry, animates to `whileInView` state (using the nested `transition` if
@@ -183,7 +169,7 @@ export const attachWhileInView = (
         onAnimationComplete?: (definition: DOMKeyframesDefinition | undefined) => void
     },
     baselineSources?: { initial?: Record<string, unknown>; animate?: Record<string, unknown> },
-    viewport?: AttachWhileInViewOptions
+    viewport?: MotionViewport
 ): (() => void) => {
     if (!whileInView) return () => {}
 

--- a/src/lib/utils/inView.ts
+++ b/src/lib/utils/inView.ts
@@ -128,6 +128,21 @@ export const computeInViewBaseline = (
 }
 
 /**
+ * Viewport options for `attachWhileInView`. Mirrors framer-motion's
+ * `viewport` prop on motion components.
+ */
+export type AttachWhileInViewOptions = {
+    /** Fire only once; subsequent re-entries are no-ops (no exit animation either). */
+    once?: boolean
+    /** IntersectionObserver root. Defaults to the document viewport. */
+    root?: Element | Document
+    /** CSS margin string applied to the root box (e.g. `"100px 0px"`). */
+    margin?: string
+    /** Fraction (0-1) or `"some"` / `"all"` of the target that must be visible. */
+    amount?: 'some' | 'all' | number
+}
+
+/**
  * Attach whileInView interactions to an element via motion's `inView` primitive.
  *
  * On entry, animates to `whileInView` state (using the nested `transition` if
@@ -142,6 +157,7 @@ export const computeInViewBaseline = (
  * @param mergedTransition Root/component merged transition.
  * @param callbacks Optional lifecycle callbacks for in-view start/end and animation completion.
  * @param baselineSources Optional sources used to compute baseline.
+ * @param viewport Optional IntersectionObserver options. `amount` defaults to `0` (any pixel visible).
  * @returns Cleanup function to stop observing.
  * @example
  * const cleanup = attachWhileInView(
@@ -152,7 +168,8 @@ export const computeInViewBaseline = (
  *     onStart: () => console.log('Entered viewport'),
  *     onEnd: () => console.log('Left viewport')
  *   },
- *   { initial: { opacity: 0, y: 50 } }
+ *   { initial: { opacity: 0, y: 50 } },
+ *   { once: true, amount: 0.5 }
  * )
  * // Later: cleanup() to stop observing
  */
@@ -165,13 +182,17 @@ export const attachWhileInView = (
         onEnd?: () => void
         onAnimationComplete?: (definition: DOMKeyframesDefinition | undefined) => void
     },
-    baselineSources?: { initial?: Record<string, unknown>; animate?: Record<string, unknown> }
+    baselineSources?: { initial?: Record<string, unknown>; animate?: Record<string, unknown> },
+    viewport?: AttachWhileInViewOptions
 ): (() => void) => {
     if (!whileInView) return () => {}
 
-    return motionInView(
+    let latched = false
+
+    const stop = motionInView(
         el,
         () => {
+            if (latched) return
             const inViewBaseline = computeInViewBaseline(el, {
                 initial: baselineSources?.initial,
                 animate: baselineSources?.animate,
@@ -192,6 +213,15 @@ export const attachWhileInView = (
                     /* animation cancelled — skip completion callback */
                 })
 
+            if (viewport?.once) {
+                // Latch on first entry. Don't return an exit handler so the
+                // element holds its in-view state and we never animate back.
+                // Stop observing entirely after the entry handler returns.
+                latched = true
+                queueMicrotask(stop)
+                return
+            }
+
             return () => {
                 if (Object.keys(inViewBaseline).length > 0) {
                     animate(
@@ -203,8 +233,16 @@ export const attachWhileInView = (
                 callbacks?.onEnd?.()
             }
         },
-        { amount: 0 }
+        {
+            root: viewport?.root,
+            // framer-motion types `margin` as a CSS-shorthand template literal;
+            // we expose plain `string` so consumers can pass any computed value.
+            margin: viewport?.margin as never,
+            amount: viewport?.amount ?? 0
+        }
     )
+
+    return stop
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds framer-motion's `viewport` prop to motion components, configuring the
underlying IntersectionObserver used by `whileInView`. Closes #300.

```svelte
<motion.div
  whileInView={{ opacity: 1, y: 0 }}
  viewport={{ once: true, amount: 0.5 }}
/>
```

| Option | Behavior |
|--------|----------|
| `once?: boolean` | Fire entry once, latch, never re-trigger or animate back |
| `root?: Element \| Document` | Custom IntersectionObserver root (defaults to viewport) |
| `margin?: string` | CSS margin string applied to the root box |
| `amount?: 'some' \| 'all' \| number` | Visibility threshold (defaults to `0` — any pixel visible) |

`once` is implemented by returning no exit handler from motion's `inView`
(which auto-unobserves) and gating with a `latched` closure flag so any
late re-entry events no-op even if the observer is still active.

### Why this matters

Almost every motion.dev `whileInView` recipe passes `{ once: true }`.
Before this PR, every copy-paste from framer-motion docs re-fired on
every scroll-in. Top "user opens our lib for the first time and bounces"
risk in the parity backlog.

## Changes

✨ **Feature**
- `src/lib/types.ts` — new `MotionViewport` type; `viewport?` added to `MotionProps`
- `src/lib/utils/inView.ts` — `attachWhileInView` accepts new `viewport` arg, threads `root`/`margin`/`amount` to the IntersectionObserver, implements `once` latching
- `src/lib/html/_MotionContainer.svelte` — receives `viewport` prop and forwards it

🧪 **Tests** (8 new, 350/350 total passing)
- `src/lib/utils/inView.spec.ts` — new describe block for `attachWhileInView` covering: default threshold, root forwarding, margin → rootMargin, amount: number/'all', once-latch behavior (entry fires once, no exit, no re-entry), noop for undefined whileInView

📚 **Docs**
- `docs/src/lib/examples/WhileInViewExample.svelte` — extended to show both default re-trigger vs `once: true` latch side-by-side

## Commits

- [`255214d`](https://github.com/humanspeak/svelte-motion/commit/255214d) feat(whileInView): add viewport prop (once / root / margin / amount)

## Test plan

- [x] `pnpm test:only` — 350/350 green
- [x] `pnpm exec svelte-check` — 0 errors
- [x] Browser-verified via playwright on `/examples/while-in-view`:
  - default card re-animates each scroll-in/out
  - `viewport={{ once: true, amount: 0.5 }}` card animates once and stays latched
  - no console errors

Closes #300
