### PR TITLE
feat(variants): custom prop + function-form variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,29 @@ Supported drag props:
 
 - String variant keys are resolved from `variants`.
 - Variant state inherits through context.
+- A variant entry can be a `(custom) => keyframes` factory. The `custom` prop is forwarded — useful for staggered lists where each child needs its own offset or delay. Children without `custom` inherit the nearest motion ancestor's value.
+
+```svelte
+<script lang="ts">
+    import { motion, type Variants } from '@humanspeak/svelte-motion'
+
+    const variants: Variants = {
+        hidden: { opacity: 0, x: -100 },
+        visible: (i) => ({
+            opacity: 1,
+            x: 0,
+            transition: { delay: (i as number) * 0.1 }
+        })
+    }
+    const items = ['Alpha', 'Beta', 'Gamma', 'Delta']
+</script>
+
+{#each items as item, i}
+    <motion.li custom={i} {variants} initial="hidden" animate="visible">
+        {item}
+    </motion.li>
+{/each}
+```
 
 ## Layout animation
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.5.24",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.5.25",
         "@humanspeak/svelte-motion": "workspace:*",
         "@inlang/paraglide-js": "^2.18.0",
         "@lucide/svelte": "^1.16.0",

--- a/docs/src/lib/components/general/Example.svelte
+++ b/docs/src/lib/components/general/Example.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { motion } from '@humanspeak/svelte-motion'
+    import { exampleSourceUrl } from '$lib/docs-config'
     import { cn } from '$lib/shadcn/utils'
     import * as m from '$msgs'
     import type { Snippet } from 'svelte'
@@ -8,18 +9,19 @@
     type ExampleProps = {
         children: Snippet
         isSmall?: boolean
-        sourceUrl?: string
+        /**
+         * Filename inside `docs/src/lib/examples/` (e.g. `HoverAndTap.svelte`).
+         * The Source button links to this file on GitHub `main`, so users
+         * can read the actual Svelte source for the demo they're viewing.
+         */
+        file?: string
         exampleUrl?: string
         title?: string
     }
 
-    const { children, isSmall = false, sourceUrl, exampleUrl, title }: ExampleProps = $props()
+    const { children, isSmall = false, file, exampleUrl, title }: ExampleProps = $props()
 
-    const sourceHost = $derived.by(() => {
-        if (!sourceUrl) return ''
-        const host = new URL(sourceUrl).hostname.replace(/^www\./i, '').replace(/^examples\./i, '')
-        return host.charAt(0).toUpperCase() + host.slice(1)
-    })
+    const sourceUrl = $derived(file ? exampleSourceUrl(file) : undefined)
 
     let refreshId = $state(0)
     const refreshMotion = () => {
@@ -68,7 +70,7 @@
                     whileHover={{ scale: 1.1 }}
                     class="inline-flex items-center justify-center rounded-md border border-border-muted px-2 py-1 text-sm text-text-muted transition-colors hover:border-border-mid hover:text-text-secondary"
                 >
-                    {sourceHost}
+                    Source
                 </motion.button>
             {/if}
             <motion.button

--- a/docs/src/lib/components/general/Footer.svelte
+++ b/docs/src/lib/components/general/Footer.svelte
@@ -1,5 +1,0 @@
-<script lang="ts">
-    import { Footer } from '@humanspeak/docs-kit'
-</script>
-
-<Footer />

--- a/docs/src/lib/components/general/Header.svelte
+++ b/docs/src/lib/components/general/Header.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-    import { Header } from '@humanspeak/docs-kit'
-    import favicon from '$lib/assets/logo.svg'
-    import { docsConfig } from '$lib/docs-config'
-</script>
-
-<Header config={docsConfig} {favicon} />

--- a/docs/src/lib/docs-config.ts
+++ b/docs/src/lib/docs-config.ts
@@ -23,3 +23,14 @@ export const docsConfig: DocsKitConfig = {
     defaultFeatures: ['AnimatePresence', 'Spring Physics', 'Gestures & Drag', 'Layout Animation'],
     fallbackStars: 200
 }
+
+const REPO_BLOB = `https://github.com/${docsConfig.repo}/blob/main`
+const EXAMPLES_DIR = 'docs/src/lib/examples'
+
+/**
+ * Build the GitHub URL for an example component shipped with the docs site.
+ *
+ * @param file Filename inside `docs/src/lib/examples/` (e.g. `HoverAndTap.svelte`).
+ * @returns Absolute URL to the file on the `main` branch.
+ */
+export const exampleSourceUrl = (file: string): string => `${REPO_BLOB}/${EXAMPLES_DIR}/${file}`

--- a/docs/src/lib/examples/VariantsDynamicExample.svelte
+++ b/docs/src/lib/examples/VariantsDynamicExample.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+    import { motion, styleString, type Variants } from '@humanspeak/svelte-motion'
+
+    let cycle = $state(0)
+
+    // Dynamic variant: each child receives its index as `custom` and the
+    // factory derives a per-child delay + x offset from it.
+    const item: Variants = {
+        hidden: (i) => ({
+            opacity: 0,
+            x: -60 - (i as number) * 10,
+            transition: { duration: 0.3 }
+        }),
+        visible: (i) => ({
+            opacity: 1,
+            x: 0,
+            transition: {
+                delay: (i as number) * 0.08,
+                duration: 0.45
+            }
+        })
+    }
+
+    const items = ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon']
+</script>
+
+<div
+    style={styleString(() => ({
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.5rem',
+        padding: '2rem',
+        background: 'var(--color-background-secondary)',
+        borderRadius: 8,
+        margin: '2rem 0'
+    }))}
+>
+    <motion.button
+        style={styleString(() => ({
+            alignSelf: 'flex-start',
+            padding: '0.5rem 1rem',
+            background: 'var(--color-primary)',
+            color: 'white',
+            border: 'none',
+            borderRadius: 8,
+            fontSize: '0.9rem',
+            fontWeight: 600,
+            cursor: 'pointer',
+            marginBottom: '0.5rem'
+        }))}
+        whileTap={{ scale: 0.96 }}
+        onclick={() => (cycle += 1)}
+    >
+        Replay
+    </motion.button>
+
+    {#each items as item_label, i (cycle + '-' + i)}
+        <motion.div
+            custom={i}
+            variants={item}
+            initial="hidden"
+            animate="visible"
+            style={styleString(() => ({
+                padding: '0.65rem 1rem',
+                background: 'var(--color-background-tertiary, #ffffff10)',
+                borderRadius: 6,
+                color: 'var(--color-text-primary)',
+                fontFamily: 'JetBrains Mono Variable, ui-monospace, monospace',
+                fontSize: '0.95rem'
+            }))}
+        >
+            №{i + 1} · {item_label} — custom={i}, delay={i * 0.08}s
+        </motion.div>
+    {/each}
+</div>

--- a/docs/src/lib/examples/VariantsDynamicExample.svelte
+++ b/docs/src/lib/examples/VariantsDynamicExample.svelte
@@ -1,75 +1,158 @@
 <script lang="ts">
     import { motion, styleString, type Variants } from '@humanspeak/svelte-motion'
 
-    let cycle = $state(0)
+    const STATES = ['fanned', 'exploded', 'stacked'] as const
+    type State = (typeof STATES)[number]
 
-    // Dynamic variant: each child receives its index as `custom` and the
-    // factory derives a per-child delay + x offset from it.
-    const item: Variants = {
-        hidden: (i) => ({
-            opacity: 0,
-            x: -60 - (i as number) * 10,
-            transition: { duration: 0.3 }
-        }),
-        visible: (i) => ({
+    const NEXT_LABEL: Record<State, string> = {
+        fanned: 'Explode →',
+        exploded: 'Stack →',
+        stacked: 'Fan out →'
+    }
+
+    let state = $state<State>('fanned')
+
+    const CARDS = 7
+    const cards = Array.from({ length: CARDS }, (_, i) => i)
+    const center = (CARDS - 1) / 2
+
+    const cardVariants: Variants = {
+        fanned: (i) => {
+            const offset = (i as number) - center
+            return {
+                x: offset * 22,
+                y: Math.abs(offset) * 12,
+                rotate: offset * 9,
+                scale: 1,
+                opacity: 1,
+                transition: { type: 'spring', stiffness: 220, damping: 22 }
+            }
+        },
+        exploded: (i) => {
+            const offset = (i as number) - center
+            return {
+                x: offset * 95,
+                y: -Math.abs(offset) * 8 - 20,
+                rotate: offset * 14,
+                scale: 1.05,
+                opacity: 1,
+                transition: { type: 'spring', stiffness: 200, damping: 18 }
+            }
+        },
+        stacked: (i) => ({
+            x: (i as number) * 1,
+            y: -(i as number) * 1,
+            rotate: 0,
+            scale: 1,
             opacity: 1,
-            x: 0,
             transition: {
-                delay: (i as number) * 0.08,
-                duration: 0.45
+                type: 'spring',
+                stiffness: 320,
+                damping: 30,
+                delay: (i as number) * 0.03
             }
         })
     }
 
-    const items = ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon']
+    const hues = ['#f97316', '#ec4899', '#8b5cf6', '#06b6d4', '#22c55e', '#eab308', '#ef4444']
+
+    function cycle() {
+        state = STATES[(STATES.indexOf(state) + 1) % STATES.length]
+    }
 </script>
 
 <div
     style={styleString(() => ({
+        position: 'relative',
         display: 'flex',
         flexDirection: 'column',
-        gap: '0.5rem',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '440px',
         padding: '2rem',
-        background: 'var(--color-background-secondary)',
-        borderRadius: 8,
         margin: '2rem 0'
     }))}
 >
-    <motion.button
+    <div
         style={styleString(() => ({
-            alignSelf: 'flex-start',
-            padding: '0.5rem 1rem',
-            background: 'var(--color-primary)',
-            color: 'white',
+            position: 'relative',
+            width: '100%',
+            height: '280px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+        }))}
+    >
+        {#each cards as i (i)}
+            <motion.div
+                custom={i}
+                variants={cardVariants}
+                initial="stacked"
+                animate={state}
+                whileHover={{
+                    scale: 1.15,
+                    zIndex: 10,
+                    transition: { type: 'spring', stiffness: 320, damping: 20 }
+                }}
+                style={styleString(() => ({
+                    position: 'absolute',
+                    width: '110px',
+                    height: '160px',
+                    borderRadius: 12,
+                    background: `linear-gradient(155deg, ${hues[i]} 0%, ${hues[(i + 3) % hues.length]} 100%)`,
+                    boxShadow:
+                        '0 14px 38px -12px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.12) inset, 0 1px 0 rgba(255,255,255,0.25) inset',
+                    border: '2px solid rgba(255,255,255,0.6)',
+                    display: 'flex',
+                    alignItems: 'flex-end',
+                    justifyContent: 'center',
+                    padding: '0.75rem',
+                    color: 'white',
+                    fontFamily: 'JetBrains Mono Variable, ui-monospace, monospace',
+                    fontWeight: 700,
+                    fontSize: '0.9rem',
+                    textShadow: '0 1px 2px rgba(0,0,0,0.3)',
+                    cursor: 'pointer',
+                    zIndex: i + 1
+                }))}
+            >
+                №{i + 1}
+            </motion.div>
+        {/each}
+    </div>
+
+    <motion.button
+        whileTap={{ scale: 0.95 }}
+        whileHover={{ scale: 1.04, backgroundColor: 'var(--color-brand-600)' }}
+        onclick={cycle}
+        style={styleString(() => ({
+            marginTop: '1.5rem',
+            padding: '0.65rem 1.5rem',
+            background: 'var(--color-brand-500)',
+            color: '#ffffff',
             border: 'none',
-            borderRadius: 8,
-            fontSize: '0.9rem',
+            borderRadius: 10,
+            fontSize: '0.95rem',
             fontWeight: 600,
             cursor: 'pointer',
-            marginBottom: '0.5rem'
+            letterSpacing: '0.02em',
+            boxShadow:
+                '0 4px 14px -4px color-mix(in oklab, var(--color-brand-500) 70%, transparent)'
         }))}
-        whileTap={{ scale: 0.96 }}
-        onclick={() => (cycle += 1)}
     >
-        Replay
+        {NEXT_LABEL[state]}
     </motion.button>
 
-    {#each items as item_label, i (cycle + '-' + i)}
-        <motion.div
-            custom={i}
-            variants={item}
-            initial="hidden"
-            animate="visible"
-            style={styleString(() => ({
-                padding: '0.65rem 1rem',
-                background: 'var(--color-background-tertiary, #ffffff10)',
-                borderRadius: 6,
-                color: 'var(--color-text-primary)',
-                fontFamily: 'JetBrains Mono Variable, ui-monospace, monospace',
-                fontSize: '0.95rem'
-            }))}
-        >
-            №{i + 1} · {item_label} — custom={i}, delay={i * 0.08}s
-        </motion.div>
-    {/each}
+    <p
+        style={styleString(() => ({
+            marginTop: '0.85rem',
+            fontSize: '0.78rem',
+            color: 'var(--color-text-muted)',
+            fontFamily: 'JetBrains Mono Variable, ui-monospace, monospace',
+            letterSpacing: '0.02em'
+        }))}
+    >
+        // state: <b style="color: var(--color-brand-500)">{state}</b> — every card resolves
+        <code style="color: var(--color-text-primary)">variants[{state}](i)</code>
+    </p>
 </div>

--- a/docs/src/routes/docs/+page.svx
+++ b/docs/src/routes/docs/+page.svx
@@ -269,6 +269,37 @@ Transition precedence for exit timing (merged):
 - component `transition` (merged with any `MotionConfig` defaults)
 - fallback `{ duration: 0.35 }`
 
+## Variants
+
+Variants let you give names to animation states and reference them by string. Pair them with the `custom` prop for per-instance values — common for staggered lists where each child needs its own offset.
+
+```svelte
+<script>
+  import { motion } from '@humanspeak/svelte-motion'
+
+  const variants = {
+    hidden:  { opacity: 0, x: -100 },
+    visible: (i) => ({
+      opacity: 1,
+      x: 0,
+      transition: { delay: i * 0.1 }
+    })
+  }
+
+  const items = ['Alpha', 'Beta', 'Gamma', 'Delta']
+</script>
+
+{#each items as item, i}
+  <motion.li custom={i} {variants} initial="hidden" animate="visible">
+    {item}
+  </motion.li>
+{/each}
+```
+
+- A variant entry can be a static keyframes object **or** a `(custom) => keyframes` factory.
+- `custom` is forwarded to the factory each time the variant is resolved (initial, animate, or exit).
+- Children with no `custom` prop inherit the nearest motion ancestor's value — matching Framer Motion's variant-tree propagation.
+
 ## Learn next
 
 That's a quick overview of Svelte Motion's basic features. Next, explore animation patterns, layout, and gestures—or dive straight into our examples.

--- a/docs/src/routes/docs/use-scroll/+page.svx
+++ b/docs/src/routes/docs/use-scroll/+page.svx
@@ -78,7 +78,7 @@ By default, `useScroll` tracks the page scroll position:
 />
 ```
 
-<Example isSmall exampleUrl="/examples/scroll-progress" sourceUrl="https://motion.dev/docs/react-use-scroll">
+<Example isSmall exampleUrl="/examples/scroll-progress" file="ScrollProgressExample.svelte">
   <ScrollProgressExample />
 </Example>
 

--- a/docs/src/routes/examples/+layout.svelte
+++ b/docs/src/routes/examples/+layout.svelte
@@ -1,17 +1,32 @@
 <script lang="ts">
-    import Header from '$lib/components/general/Header.svelte'
-    import Footer from '$lib/components/general/Footer.svelte'
+    import { HeaderV2, FooterV2 } from '@humanspeak/docs-kit'
     import { MotionConfig } from '@humanspeak/svelte-motion'
+    import { docsConfig } from '$lib/docs-config'
+    import favicon from '$lib/assets/logo.svg'
+    import rootPkg from '../../../../package.json'
+    import '@fontsource-variable/inter/index.css'
+    import '@fontsource-variable/jetbrains-mono/index.css'
+
+    const PKG_VERSION = rootPkg.version
 
     const { children } = $props()
 </script>
 
-<div class="relative flex min-h-screen flex-col bg-background">
-    <Header />
+<div class="flex min-h-screen flex-col justify-between bg-background">
+    <HeaderV2
+        config={docsConfig}
+        {favicon}
+        version={PKG_VERSION}
+        nav={[
+            { label: 'docs', href: '/docs' },
+            { label: 'examples', href: '/examples' },
+            { label: 'compare', href: '/compare' }
+        ]}
+    />
     <main class="flex flex-1 flex-col">
         <MotionConfig transition={{ duration: 0.6 }}>
             {@render children?.()}
         </MotionConfig>
     </main>
-    <Footer />
+    <FooterV2 version={PKG_VERSION} />
 </div>

--- a/docs/src/routes/examples/+page.svelte
+++ b/docs/src/routes/examples/+page.svelte
@@ -8,7 +8,6 @@
     type ExampleData = {
         title: string
         description: string
-        sourceUrl: string | null
     }
 
     type ExamplesData = Record<string, ExampleData>

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -1,186 +1,153 @@
 import type { PageLoad } from './$types'
 
-export const load: PageLoad = () => {
-    // Load example metadata - this could be expanded to read from individual +page.ts files
-    // or from a centralized configuration file
-    const examples = {
-        'animate-presence': {
-            title: 'AnimatePresence',
-            description: 'Interactive AnimatePresence animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/examples/react-exit-animation'
-        },
-        'animated-button': {
-            title: 'Animated Button',
-            description: 'Interactive animated button animation example using Svelte Motion.',
-            sourceUrl: null
-        },
-        'animated-tabs': {
-            title: 'Animated Tabs',
-            description: 'Interactive animated tabs animation example using Svelte Motion.',
-            sourceUrl: null
-        },
-        'characters-remaining': {
-            title: 'Characters Remaining',
-            description: 'Interactive characters remaining animation example using Svelte Motion.',
-            sourceUrl: null
-        },
-        'color-interpolation': {
-            title: 'Color Interpolation',
-            description: 'Interactive color interpolation animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/docs/motion-animate#color-interpolation'
-        },
-        'conic-gradient': {
-            title: 'Conic Gradient',
-            description: 'Interactive conic gradient animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/examples/react-conic-gradient-pointer'
-        },
-        'fancy-like-button': {
-            title: 'Fancy Like Button',
-            description: 'Interactive fancy like button animation example using Svelte Motion.',
-            sourceUrl: 'https://github.com/DRlFTER/fancyLikeButton'
-        },
-        'hover-and-tap': {
-            title: 'Hover and Tap',
-            description: 'Interactive hover and tap animation example using Svelte Motion.',
-            sourceUrl: 'https://examples.motion.dev/react/gestures'
-        },
-        'html-content': {
-            title: 'HTML Content',
-            description: 'Interactive html content animation example using Svelte Motion.',
-            sourceUrl: 'https://examples.motion.dev/react/html-content'
-        },
-        keyframes: {
-            title: 'Keyframes',
-            description: 'Interactive Keyframes animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/examples/react-keyframes'
-        },
-        'motion-path': {
-            title: 'Motion Path',
-            description: 'Interactive motion path animation example using Svelte Motion.',
-            sourceUrl: 'https://examples.motion.dev/react/motion-path'
-        },
-        'multi-state-badge': {
-            title: 'Multi-State Badge',
-            description: 'Interactive multi-state badge animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/examples/react-multi-state-badge'
-        },
-        'notifications-stack': {
-            title: 'Notifications Stack',
-            description: 'Interactive notifications stack animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/examples/react-notifications-stack'
-        },
-        'path-morphing': {
-            title: 'Path Morphing',
-            description: 'Interactive path morphing animation example using Svelte Motion.',
-            sourceUrl: 'https://examples.motion.dev/react/path-morphing'
-        },
-        reordering: {
-            title: 'Reordering',
-            description: 'Interactive Reordering animation example using Svelte Motion.',
-            sourceUrl: 'https://examples.motion.dev/react/reordering'
-        },
-        rotate: {
-            title: 'Rotate',
-            description: 'Interactive Rotate animation example using Svelte Motion.',
-            sourceUrl: 'https://examples.motion.dev/react/rotate?utm_source=embed'
-        },
-        'scroll-progress': {
-            title: 'Scroll Progress',
-            description: 'Interactive scroll progress animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/docs/react-use-scroll'
-        },
-        'shared-layout-animation': {
-            title: 'Shared Layout Animation',
-            description: 'Interactive shared layout animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/docs/react-layout-animations'
-        },
-        'style-string': {
-            title: 'styleString',
-            description: 'Interactive styleString animation example using Svelte Motion.',
-            sourceUrl: null
-        },
-        'tab-select': {
-            title: 'Tab Select',
-            description: 'Interactive tab select animation example using Svelte Motion.',
-            sourceUrl: 'https://examples.motion.dev/react/tab-select'
-        },
-        'toggle-switch': {
-            title: 'Toggle Switch',
-            description: 'Interactive toggle switch animation example using Svelte Motion.',
-            sourceUrl: null
-        },
-        'use-animate': {
-            title: 'useAnimate',
-            description: 'Interactive useAnimate animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/docs/react-use-animate'
-        },
-        'use-animation-frame': {
-            title: 'useAnimationFrame',
-            description: 'Interactive useAnimationFrame animation example using Svelte Motion.',
-            sourceUrl: 'https://examples.motion.dev/react/use-animation-frame'
-        },
-        'use-cycle': {
-            title: 'useCycle',
-            description: 'Interactive useCycle animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/docs/react-use-cycle'
-        },
-        'use-in-view': {
-            title: 'useInView',
-            description: 'Interactive useInView animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/docs/react-use-in-view'
-        },
-        'use-presence': {
-            title: 'usePresence',
-            description: 'Interactive usePresence animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/docs/react-use-presence'
-        },
-        'use-reduced-motion': {
-            title: 'useReducedMotion',
-            description: 'Interactive useReducedMotion animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/docs/react-use-reduced-motion'
-        },
-        'use-time': {
-            title: 'useTime',
-            description: 'Interactive useTime animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/docs/react-use-time'
-        },
-        'use-time-synced': {
-            title: 'useTime (Synced)',
-            description: 'Interactive usetime (synced) animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/docs/react-use-time'
-        },
-        'variants-basic': {
-            title: 'Variants Basic',
-            description: 'Interactive variants basic animation example using Svelte Motion.',
-            sourceUrl: null
-        },
-        'variants-dynamic': {
-            title: 'Variants Dynamic (custom)',
-            description:
-                'Per-instance variants — function-form factories receive the custom prop, driving staggered index-based delays.',
-            sourceUrl: 'https://motion.dev/docs/react-motion-component#variants'
-        },
-        'variants-propagation': {
-            title: 'Variants Propagation',
-            description: 'Interactive variants propagation animation example using Svelte Motion.',
-            sourceUrl: null
-        },
-        'while-focus': {
-            title: 'While Focus',
-            description: 'Interactive while focus animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/docs/react-motion-component#focus'
-        },
-        'while-in-view': {
-            title: 'While In View',
-            description: 'Interactive while in view animation example using Svelte Motion.',
-            sourceUrl: 'https://motion.dev/docs/react-motion-component#scroll'
-        }
-    }
+type ExampleEntry = {
+    title: string
+    description: string
+}
 
-    return {
-        title: 'Examples',
+const EXAMPLES: Record<string, ExampleEntry> = {
+    'animate-presence': {
+        title: 'AnimatePresence',
+        description: 'Interactive AnimatePresence animation example using Svelte Motion.'
+    },
+    'animated-button': {
+        title: 'Animated Button',
+        description: 'Interactive animated button animation example using Svelte Motion.'
+    },
+    'animated-tabs': {
+        title: 'Animated Tabs',
+        description: 'Interactive animated tabs animation example using Svelte Motion.'
+    },
+    'characters-remaining': {
+        title: 'Characters Remaining',
+        description: 'Interactive characters remaining animation example using Svelte Motion.'
+    },
+    'color-interpolation': {
+        title: 'Color Interpolation',
+        description: 'Interactive color interpolation animation example using Svelte Motion.'
+    },
+    'conic-gradient': {
+        title: 'Conic Gradient',
+        description: 'Interactive conic gradient animation example using Svelte Motion.'
+    },
+    'fancy-like-button': {
+        title: 'Fancy Like Button',
+        description: 'Interactive fancy like button animation example using Svelte Motion.'
+    },
+    'hover-and-tap': {
+        title: 'Hover and Tap',
+        description: 'Interactive hover and tap animation example using Svelte Motion.'
+    },
+    'html-content': {
+        title: 'HTML Content',
+        description: 'Interactive html content animation example using Svelte Motion.'
+    },
+    keyframes: {
+        title: 'Keyframes',
+        description: 'Interactive Keyframes animation example using Svelte Motion.'
+    },
+    'motion-path': {
+        title: 'Motion Path',
+        description: 'Interactive motion path animation example using Svelte Motion.'
+    },
+    'multi-state-badge': {
+        title: 'Multi-State Badge',
+        description: 'Interactive multi-state badge animation example using Svelte Motion.'
+    },
+    'notifications-stack': {
+        title: 'Notifications Stack',
+        description: 'Interactive notifications stack animation example using Svelte Motion.'
+    },
+    'path-morphing': {
+        title: 'Path Morphing',
+        description: 'Interactive path morphing animation example using Svelte Motion.'
+    },
+    reordering: {
+        title: 'Reordering',
+        description: 'Interactive Reordering animation example using Svelte Motion.'
+    },
+    rotate: {
+        title: 'Rotate',
+        description: 'Interactive Rotate animation example using Svelte Motion.'
+    },
+    'scroll-progress': {
+        title: 'Scroll Progress',
+        description: 'Interactive scroll progress animation example using Svelte Motion.'
+    },
+    'shared-layout-animation': {
+        title: 'Shared Layout Animation',
+        description: 'Interactive shared layout animation example using Svelte Motion.'
+    },
+    'style-string': {
+        title: 'styleString',
+        description: 'Interactive styleString animation example using Svelte Motion.'
+    },
+    'tab-select': {
+        title: 'Tab Select',
+        description: 'Interactive tab select animation example using Svelte Motion.'
+    },
+    'toggle-switch': {
+        title: 'Toggle Switch',
+        description: 'Interactive toggle switch animation example using Svelte Motion.'
+    },
+    'use-animate': {
+        title: 'useAnimate',
+        description: 'Interactive useAnimate animation example using Svelte Motion.'
+    },
+    'use-animation-frame': {
+        title: 'useAnimationFrame',
+        description: 'Interactive useAnimationFrame animation example using Svelte Motion.'
+    },
+    'use-cycle': {
+        title: 'useCycle',
+        description: 'Interactive useCycle animation example using Svelte Motion.'
+    },
+    'use-in-view': {
+        title: 'useInView',
+        description: 'Interactive useInView animation example using Svelte Motion.'
+    },
+    'use-presence': {
+        title: 'usePresence',
+        description: 'Interactive usePresence animation example using Svelte Motion.'
+    },
+    'use-reduced-motion': {
+        title: 'useReducedMotion',
+        description: 'Interactive useReducedMotion animation example using Svelte Motion.'
+    },
+    'use-time': {
+        title: 'useTime',
+        description: 'Interactive useTime animation example using Svelte Motion.'
+    },
+    'use-time-synced': {
+        title: 'useTime (Synced)',
+        description: 'Interactive usetime (synced) animation example using Svelte Motion.'
+    },
+    'variants-basic': {
+        title: 'Variants Basic',
+        description: 'Interactive variants basic animation example using Svelte Motion.'
+    },
+    'variants-dynamic': {
+        title: 'Variants Dynamic (custom)',
         description:
-            'Interactive animation examples built with Svelte Motion. Browse hover effects, transitions, gestures, and more.',
-        examples
+            'Per-instance variants — function-form factories receive the custom prop, driving staggered index-based delays.'
+    },
+    'variants-propagation': {
+        title: 'Variants Propagation',
+        description: 'Interactive variants propagation animation example using Svelte Motion.'
+    },
+    'while-focus': {
+        title: 'While Focus',
+        description: 'Interactive while focus animation example using Svelte Motion.'
+    },
+    'while-in-view': {
+        title: 'While In View',
+        description: 'Interactive while in view animation example using Svelte Motion.'
     }
 }
+
+export const load: PageLoad = () => ({
+    title: 'Examples',
+    description:
+        'Interactive animation examples built with Svelte Motion. Browse hover effects, transitions, gestures, and more.',
+    examples: EXAMPLES
+})

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -154,6 +154,12 @@ export const load: PageLoad = () => {
             description: 'Interactive variants basic animation example using Svelte Motion.',
             sourceUrl: null
         },
+        'variants-dynamic': {
+            title: 'Variants Dynamic (custom)',
+            description:
+                'Per-instance variants — function-form factories receive the custom prop, driving staggered index-based delays.',
+            sourceUrl: 'https://motion.dev/docs/react-motion-component#variants'
+        },
         'variants-propagation': {
             title: 'Variants Propagation',
             description: 'Interactive variants propagation animation example using Svelte Motion.',

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -120,7 +120,7 @@ const EXAMPLES: Record<string, ExampleEntry> = {
     },
     'use-time-synced': {
         title: 'useTime (Synced)',
-        description: 'Interactive usetime (synced) animation example using Svelte Motion.'
+        description: 'Interactive useTime (synced) animation example using Svelte Motion.'
     },
     'variants-basic': {
         title: 'Variants Basic',

--- a/docs/src/routes/examples/animate-presence/+page.svelte
+++ b/docs/src/routes/examples/animate-presence/+page.svelte
@@ -29,6 +29,6 @@
     }
 </script>
 
-<Example title="AnimatePresence">
+<Example title="AnimatePresence" file="AnimatePresenceExample.svelte">
     <AnimatePresenceExample />
 </Example>

--- a/docs/src/routes/examples/animate-presence/+page.ts
+++ b/docs/src/routes/examples/animate-presence/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = () => {
     return {
         title: 'AnimatePresence',
-        description: 'Animate components when they are added to or removed from the DOM',
-        sourceUrl: 'https://motion.dev/examples/react-exit-animation'
+        description: 'Animate components when they are added to or removed from the DOM'
     }
 }

--- a/docs/src/routes/examples/animated-button/+page.svelte
+++ b/docs/src/routes/examples/animated-button/+page.svelte
@@ -23,6 +23,6 @@
     }
 </script>
 
-<Example title="Animated Button">
+<Example title="Animated Button" file="AnimatedButton.svelte">
     <AnimatedButton />
 </Example>

--- a/docs/src/routes/examples/animated-tabs/+page.svelte
+++ b/docs/src/routes/examples/animated-tabs/+page.svelte
@@ -24,6 +24,6 @@
     }
 </script>
 
-<Example title="Animated Tabs">
+<Example title="Animated Tabs" file="AnimatedTabsExample.svelte">
     <AnimatedTabsExample />
 </Example>

--- a/docs/src/routes/examples/characters-remaining/+page.svelte
+++ b/docs/src/routes/examples/characters-remaining/+page.svelte
@@ -24,9 +24,6 @@
     }
 </script>
 
-<Example
-    title="Characters Remaining"
-    sourceUrl="https://examples.motion.dev/react/characters-remaining"
->
+<Example title="Characters Remaining" file="CharactersRemainingExample.svelte">
     <CharactersRemainingExample />
 </Example>

--- a/docs/src/routes/examples/color-interpolation/+page.svelte
+++ b/docs/src/routes/examples/color-interpolation/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import ColorInterpolationExample from '$lib/examples/ColorInterpolationExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -29,6 +27,6 @@
     }
 </script>
 
-<Example title="Color Interpolation" sourceUrl={data.sourceUrl}>
+<Example title="Color Interpolation" file="ColorInterpolationExample.svelte">
     <ColorInterpolationExample />
 </Example>

--- a/docs/src/routes/examples/color-interpolation/+page.ts
+++ b/docs/src/routes/examples/color-interpolation/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async () => {
     return {
         title: 'Color Interpolation',
-        description: 'Smooth color transitions between multiple color values.',
-        sourceUrl: 'https://motion.dev/docs/motion-animate#color-interpolation'
+        description: 'Smooth color transitions between multiple color values.'
     }
 }

--- a/docs/src/routes/examples/conic-gradient/+page.svelte
+++ b/docs/src/routes/examples/conic-gradient/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import ConicGradientExample from '$lib/examples/ConicGradientExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -24,6 +22,6 @@
     }
 </script>
 
-<Example title="Conic Gradient" sourceUrl={data.sourceUrl}>
+<Example title="Conic Gradient" file="ConicGradientExample.svelte">
     <ConicGradientExample />
 </Example>

--- a/docs/src/routes/examples/conic-gradient/+page.ts
+++ b/docs/src/routes/examples/conic-gradient/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = () => {
     return {
         title: 'Conic Gradient',
-        description: 'Pointer-tracking conic gradient using useTransform',
-        sourceUrl: 'https://motion.dev/examples/react-conic-gradient-pointer'
+        description: 'Pointer-tracking conic gradient using useTransform'
     }
 }

--- a/docs/src/routes/examples/fancy-like-button/+page.svelte
+++ b/docs/src/routes/examples/fancy-like-button/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import FancyLikeButtonExample from '$lib/examples/FancyLikeButtonExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -25,6 +23,6 @@
     }
 </script>
 
-<Example title="Fancy Like Button" sourceUrl={data.sourceUrl ?? undefined}>
+<Example title="Fancy Like Button" file="FancyLikeButtonExample.svelte">
     <FancyLikeButtonExample />
 </Example>

--- a/docs/src/routes/examples/fancy-like-button/+page.ts
+++ b/docs/src/routes/examples/fancy-like-button/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = () => {
     return {
         title: 'Fancy Like Button',
-        description: 'Heart button with animated particle burst on press and hold',
-        sourceUrl: 'https://github.com/DRlFTER/fancyLikeButton'
+        description: 'Heart button with animated particle burst on press and hold'
     }
 }

--- a/docs/src/routes/examples/hover-and-tap/+page.svelte
+++ b/docs/src/routes/examples/hover-and-tap/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import HoverAndTap from '$lib/examples/HoverAndTap.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -25,6 +23,6 @@
     }
 </script>
 
-<Example title="Hover and Tap" sourceUrl={data.sourceUrl}>
+<Example title="Hover and Tap" file="HoverAndTap.svelte">
     <HoverAndTap />
 </Example>

--- a/docs/src/routes/examples/hover-and-tap/+page.ts
+++ b/docs/src/routes/examples/hover-and-tap/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async () => {
     return {
         title: 'Hover and Tap',
-        description: 'Gesture-driven animations for hover and tap interactions.',
-        sourceUrl: 'https://examples.motion.dev/react/gestures'
+        description: 'Gesture-driven animations for hover and tap interactions.'
     }
 }

--- a/docs/src/routes/examples/html-content/+page.svelte
+++ b/docs/src/routes/examples/html-content/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import HTMLContent from '$lib/examples/HTMLContent.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -25,6 +23,6 @@
     }
 </script>
 
-<Example title="HTML Content" sourceUrl={data.sourceUrl}>
+<Example title="HTML Content" file="HTMLContent.svelte">
     <HTMLContent />
 </Example>

--- a/docs/src/routes/examples/html-content/+page.ts
+++ b/docs/src/routes/examples/html-content/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async () => {
     return {
         title: 'HTML Content',
-        description: 'Animate HTML content with enter and exit transitions.',
-        sourceUrl: 'https://examples.motion.dev/react/html-content'
+        description: 'Animate HTML content with enter and exit transitions.'
     }
 }

--- a/docs/src/routes/examples/keyframes/+page.svelte
+++ b/docs/src/routes/examples/keyframes/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import KeyframesExample from '$lib/examples/KeyframesExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -22,6 +20,6 @@
     }
 </script>
 
-<Example title="Keyframes" sourceUrl={data.sourceUrl ?? undefined}>
+<Example title="Keyframes" file="KeyframesExample.svelte">
     <KeyframesExample />
 </Example>

--- a/docs/src/routes/examples/keyframes/+page.ts
+++ b/docs/src/routes/examples/keyframes/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = () => {
     return {
         title: 'Keyframes',
-        description: 'Multi-property keyframe animation with scale, rotate, and borderRadius',
-        sourceUrl: 'https://motion.dev/examples/react-keyframes'
+        description: 'Multi-property keyframe animation with scale, rotate, and borderRadius'
     }
 }

--- a/docs/src/routes/examples/motion-path/+page.svelte
+++ b/docs/src/routes/examples/motion-path/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import MotionPath from '$lib/examples/MotionPath.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -25,6 +23,6 @@
     }
 </script>
 
-<Example title="Motion Path" sourceUrl={data.sourceUrl ?? undefined}>
+<Example title="Motion Path" file="MotionPath.svelte">
     <MotionPath />
 </Example>

--- a/docs/src/routes/examples/motion-path/+page.ts
+++ b/docs/src/routes/examples/motion-path/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async () => {
     return {
         title: 'Motion Path',
-        description: 'Animate elements along an SVG path with offset distance.',
-        sourceUrl: 'https://examples.motion.dev/react/motion-path'
+        description: 'Animate elements along an SVG path with offset distance.'
     }
 }

--- a/docs/src/routes/examples/multi-state-badge/+page.svelte
+++ b/docs/src/routes/examples/multi-state-badge/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import MultiStateBadgeExample from '$lib/examples/MultiStateBadgeExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -30,6 +28,6 @@
     }
 </script>
 
-<Example title="Multi-State Badge" sourceUrl={data.sourceUrl ?? undefined}>
+<Example title="Multi-State Badge" file="MultiStateBadgeExample.svelte">
     <MultiStateBadgeExample />
 </Example>

--- a/docs/src/routes/examples/multi-state-badge/+page.ts
+++ b/docs/src/routes/examples/multi-state-badge/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async () => {
     return {
         title: 'Multi-State Badge',
-        description: 'A badge that cycles through idle, processing, success, and error states.',
-        sourceUrl: 'https://motion.dev/examples/react-multi-state-badge'
+        description: 'A badge that cycles through idle, processing, success, and error states.'
     }
 }

--- a/docs/src/routes/examples/notifications-stack/+page.svelte
+++ b/docs/src/routes/examples/notifications-stack/+page.svelte
@@ -24,6 +24,6 @@
     }
 </script>
 
-<Example title="Notifications Stack">
+<Example title="Notifications Stack" file="NotificationsStackExample.svelte">
     <NotificationsStackExample />
 </Example>

--- a/docs/src/routes/examples/notifications-stack/+page.ts
+++ b/docs/src/routes/examples/notifications-stack/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = () => {
     return {
         title: 'Notifications Stack',
-        description: 'iOS-style notification stack with variant-based animations',
-        sourceUrl: 'https://motion.dev/examples/react-notifications-stack'
+        description: 'iOS-style notification stack with variant-based animations'
     }
 }

--- a/docs/src/routes/examples/path-morphing/+page.svelte
+++ b/docs/src/routes/examples/path-morphing/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import PathMorphingExample from '$lib/examples/PathMorphingExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -25,6 +23,6 @@
     }
 </script>
 
-<Example title="Path Morphing" sourceUrl={data.sourceUrl ?? undefined}>
+<Example title="Path Morphing" file="PathMorphingExample.svelte">
     <PathMorphingExample />
 </Example>

--- a/docs/src/routes/examples/path-morphing/+page.ts
+++ b/docs/src/routes/examples/path-morphing/+page.ts
@@ -4,7 +4,6 @@ export const load: PageLoad = async () => {
     return {
         title: 'Path Morphing',
         description:
-            'Interactive path morphing animation using SVG shape interpolation with Svelte Motion.',
-        sourceUrl: 'https://examples.motion.dev/react/path-morphing'
+            'Interactive path morphing animation using SVG shape interpolation with Svelte Motion.'
     }
 }

--- a/docs/src/routes/examples/reordering/+page.svelte
+++ b/docs/src/routes/examples/reordering/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import Reordering from '$lib/examples/Reordering.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -25,6 +23,6 @@
     }
 </script>
 
-<Example title="Reordering" sourceUrl={data.sourceUrl}>
+<Example title="Reordering" file="Reordering.svelte">
     <Reordering />
 </Example>

--- a/docs/src/routes/examples/reordering/+page.ts
+++ b/docs/src/routes/examples/reordering/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async () => {
     return {
         title: 'Reordering',
-        description: 'Drag-to-reorder list items with smooth layout animations.',
-        sourceUrl: 'https://examples.motion.dev/react/reordering'
+        description: 'Drag-to-reorder list items with smooth layout animations.'
     }
 }

--- a/docs/src/routes/examples/rotate/+page.svelte
+++ b/docs/src/routes/examples/rotate/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import Rotate from '$lib/examples/Rotate.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -22,6 +20,6 @@
     }
 </script>
 
-<Example title="Rotate" sourceUrl={data.sourceUrl}>
+<Example title="Rotate" file="Rotate.svelte">
     <Rotate />
 </Example>

--- a/docs/src/routes/examples/rotate/+page.ts
+++ b/docs/src/routes/examples/rotate/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async () => {
     return {
         title: 'Rotate',
-        description: 'Continuous rotation animation with configurable easing.',
-        sourceUrl: 'https://examples.motion.dev/react/rotate?utm_source=embed'
+        description: 'Continuous rotation animation with configurable easing.'
     }
 }

--- a/docs/src/routes/examples/scroll-progress/+page.svelte
+++ b/docs/src/routes/examples/scroll-progress/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import ScrollProgressExample from '$lib/examples/ScrollProgressExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -25,6 +23,6 @@
     }
 </script>
 
-<Example title="Scroll Progress" sourceUrl={data.sourceUrl ?? undefined}>
+<Example title="Scroll Progress" file="ScrollProgressExample.svelte">
     <ScrollProgressExample />
 </Example>

--- a/docs/src/routes/examples/scroll-progress/+page.ts
+++ b/docs/src/routes/examples/scroll-progress/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = () => {
     return {
         title: 'Scroll Progress',
-        description: 'Scroll progress animation using useScroll and useSpring',
-        sourceUrl: 'https://motion.dev/docs/react-use-scroll'
+        description: 'Scroll progress animation using useScroll and useSpring'
     }
 }

--- a/docs/src/routes/examples/shared-layout-animation/+page.svelte
+++ b/docs/src/routes/examples/shared-layout-animation/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import SharedLayoutAnimationExample from '$lib/examples/SharedLayoutAnimationExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -25,6 +23,6 @@
     }
 </script>
 
-<Example title="Shared Layout Animation" sourceUrl={data.sourceUrl ?? undefined}>
+<Example title="Shared Layout Animation" file="SharedLayoutAnimationExample.svelte">
     <SharedLayoutAnimationExample />
 </Example>

--- a/docs/src/routes/examples/shared-layout-animation/+page.ts
+++ b/docs/src/routes/examples/shared-layout-animation/+page.ts
@@ -4,7 +4,6 @@ export const load: PageLoad = async () => {
     return {
         title: 'Shared Layout Animation',
         description:
-            'Animate elements between positions using layoutId for smooth shared layout transitions.',
-        sourceUrl: 'https://motion.dev/docs/react-layout-animations'
+            'Animate elements between positions using layoutId for smooth shared layout transitions.'
     }
 }

--- a/docs/src/routes/examples/style-string/+page.svelte
+++ b/docs/src/routes/examples/style-string/+page.svelte
@@ -24,6 +24,6 @@
     }
 </script>
 
-<Example title="styleString">
+<Example title="styleString" file="StyleStringExample.svelte">
     <StyleStringExample />
 </Example>

--- a/docs/src/routes/examples/tab-select/+page.svelte
+++ b/docs/src/routes/examples/tab-select/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import TabSelectExample from '$lib/examples/TabSelectExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -25,6 +23,6 @@
     }
 </script>
 
-<Example title="Tab Select" sourceUrl={data.sourceUrl ?? undefined}>
+<Example title="Tab Select" file="TabSelectExample.svelte">
     <TabSelectExample />
 </Example>

--- a/docs/src/routes/examples/tab-select/+page.ts
+++ b/docs/src/routes/examples/tab-select/+page.ts
@@ -4,7 +4,6 @@ export const load: PageLoad = async () => {
     return {
         title: 'Tab Select',
         description:
-            'Animated tab selector using layoutId for a shared indicator that slides between tabs.',
-        sourceUrl: 'https://examples.motion.dev/react/tab-select'
+            'Animated tab selector using layoutId for a shared indicator that slides between tabs.'
     }
 }

--- a/docs/src/routes/examples/toggle-switch/+page.svelte
+++ b/docs/src/routes/examples/toggle-switch/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import ToggleSwitchExample from '$lib/examples/ToggleSwitchExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -24,6 +22,6 @@
     }
 </script>
 
-<Example title="Toggle Switch" sourceUrl={data.sourceUrl ?? undefined}>
+<Example title="Toggle Switch" file="ToggleSwitchExample.svelte">
     <ToggleSwitchExample />
 </Example>

--- a/docs/src/routes/examples/toggle-switch/+page.ts
+++ b/docs/src/routes/examples/toggle-switch/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async () => {
     return {
         title: 'Toggle Switch',
-        description: 'Animated toggle switch with spring physics.',
-        sourceUrl: null
+        description: 'Animated toggle switch with spring physics.'
     }
 }

--- a/docs/src/routes/examples/use-animate/+page.svelte
+++ b/docs/src/routes/examples/use-animate/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import UseAnimateExample from '$lib/examples/UseAnimateExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -24,6 +22,6 @@
     }
 </script>
 
-<Example title="useAnimate" sourceUrl={data.sourceUrl}>
+<Example title="useAnimate" file="UseAnimateExample.svelte">
     <UseAnimateExample />
 </Example>

--- a/docs/src/routes/examples/use-animate/+page.ts
+++ b/docs/src/routes/examples/use-animate/+page.ts
@@ -2,6 +2,5 @@ import type { PageLoad } from './$types'
 
 export const load: PageLoad = () => ({
     title: 'useAnimate',
-    description: 'Imperative animation with a scoped CSS-selector API.',
-    sourceUrl: 'https://motion.dev/docs/react-use-animate'
+    description: 'Imperative animation with a scoped CSS-selector API.'
 })

--- a/docs/src/routes/examples/use-animation-frame/+page.svelte
+++ b/docs/src/routes/examples/use-animation-frame/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import UseAnimationFrameExample from '$lib/examples/UseAnimationFrameExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -24,6 +22,6 @@
     }
 </script>
 
-<Example title="useAnimationFrame" sourceUrl={data.sourceUrl}>
+<Example title="useAnimationFrame" file="UseAnimationFrameExample.svelte">
     <UseAnimationFrameExample />
 </Example>

--- a/docs/src/routes/examples/use-animation-frame/+page.ts
+++ b/docs/src/routes/examples/use-animation-frame/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async () => {
     return {
         title: 'useAnimationFrame',
-        description: 'Run animations on every frame with useAnimationFrame.',
-        sourceUrl: 'https://examples.motion.dev/react/use-animation-frame'
+        description: 'Run animations on every frame with useAnimationFrame.'
     }
 }

--- a/docs/src/routes/examples/use-cycle/+page.svelte
+++ b/docs/src/routes/examples/use-cycle/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import UseCycleExample from '$lib/examples/UseCycleExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -21,6 +19,6 @@
     }
 </script>
 
-<Example title="useCycle" sourceUrl={data.sourceUrl}>
+<Example title="useCycle" file="UseCycleExample.svelte">
     <UseCycleExample />
 </Example>

--- a/docs/src/routes/examples/use-cycle/+page.ts
+++ b/docs/src/routes/examples/use-cycle/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async () => {
     return {
         title: 'useCycle',
-        description: 'Cycle through animation variants or any series of values.',
-        sourceUrl: 'https://motion.dev/docs/react-use-cycle'
+        description: 'Cycle through animation variants or any series of values.'
     }
 }

--- a/docs/src/routes/examples/use-in-view/+page.svelte
+++ b/docs/src/routes/examples/use-in-view/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import UseInViewExample from '$lib/examples/UseInViewExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -21,6 +19,6 @@
     }
 </script>
 
-<Example title="useInView" sourceUrl={data.sourceUrl}>
+<Example title="useInView" file="UseInViewExample.svelte">
     <UseInViewExample />
 </Example>

--- a/docs/src/routes/examples/use-in-view/+page.ts
+++ b/docs/src/routes/examples/use-in-view/+page.ts
@@ -2,6 +2,5 @@ import type { PageLoad } from './$types'
 
 export const load: PageLoad = () => ({
     title: 'useInView',
-    description: 'Detect viewport entry from a Svelte readable store.',
-    sourceUrl: 'https://motion.dev/docs/react-use-in-view'
+    description: 'Detect viewport entry from a Svelte readable store.'
 })

--- a/docs/src/routes/examples/use-presence/+page.svelte
+++ b/docs/src/routes/examples/use-presence/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import UsePresenceExample from '$lib/examples/UsePresenceExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -24,6 +22,6 @@
     }
 </script>
 
-<Example title="usePresence" sourceUrl={data.sourceUrl}>
+<Example title="usePresence" file="UsePresenceExample.svelte">
     <UsePresenceExample />
 </Example>

--- a/docs/src/routes/examples/use-presence/+page.ts
+++ b/docs/src/routes/examples/use-presence/+page.ts
@@ -2,6 +2,5 @@ import type { PageLoad } from './$types'
 
 export const load: PageLoad = () => ({
     title: 'usePresence',
-    description: 'Custom exit animations driven from the child component.',
-    sourceUrl: 'https://motion.dev/docs/react-use-presence'
+    description: 'Custom exit animations driven from the child component.'
 })

--- a/docs/src/routes/examples/use-reduced-motion/+page.svelte
+++ b/docs/src/routes/examples/use-reduced-motion/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import UseReducedMotionExample from '$lib/examples/UseReducedMotionExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -24,6 +22,6 @@
     }
 </script>
 
-<Example title="useReducedMotion" sourceUrl={data.sourceUrl}>
+<Example title="useReducedMotion" file="UseReducedMotionExample.svelte">
     <UseReducedMotionExample />
 </Example>

--- a/docs/src/routes/examples/use-reduced-motion/+page.ts
+++ b/docs/src/routes/examples/use-reduced-motion/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async () => {
     return {
         title: 'useReducedMotion',
-        description: "Honor the user's prefers-reduced-motion accessibility setting.",
-        sourceUrl: 'https://motion.dev/docs/react-use-reduced-motion'
+        description: "Honor the user's prefers-reduced-motion accessibility setting."
     }
 }

--- a/docs/src/routes/examples/use-time-synced/+page.svelte
+++ b/docs/src/routes/examples/use-time-synced/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import UseTimeSyncedExample from '$lib/examples/UseTimeSyncedExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -25,6 +23,6 @@
     }
 </script>
 
-<Example title="useTime (Synced)" sourceUrl={data.sourceUrl}>
+<Example title="useTime (Synced)" file="UseTimeSyncedExample.svelte">
     <UseTimeSyncedExample />
 </Example>

--- a/docs/src/routes/examples/use-time-synced/+page.ts
+++ b/docs/src/routes/examples/use-time-synced/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async () => {
     return {
         title: 'useTime (Synced)',
-        description: 'Synchronized time-based animations across multiple elements.',
-        sourceUrl: 'https://motion.dev/docs/react-use-time'
+        description: 'Synchronized time-based animations across multiple elements.'
     }
 }

--- a/docs/src/routes/examples/use-time/+page.svelte
+++ b/docs/src/routes/examples/use-time/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import UseTimeExample from '$lib/examples/UseTimeExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -21,6 +19,6 @@
     }
 </script>
 
-<Example title="useTime" sourceUrl={data.sourceUrl}>
+<Example title="useTime" file="UseTimeExample.svelte">
     <UseTimeExample />
 </Example>

--- a/docs/src/routes/examples/use-time/+page.ts
+++ b/docs/src/routes/examples/use-time/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async () => {
     return {
         title: 'useTime',
-        description: 'Time-based animations using the useTime reactive store.',
-        sourceUrl: 'https://motion.dev/docs/react-use-time'
+        description: 'Time-based animations using the useTime reactive store.'
     }
 }

--- a/docs/src/routes/examples/variants-basic/+page.svelte
+++ b/docs/src/routes/examples/variants-basic/+page.svelte
@@ -24,6 +24,6 @@
     }
 </script>
 
-<Example title="Variants Basic">
+<Example title="Variants Basic" file="VariantsBasicExample.svelte">
     <VariantsBasicExample />
 </Example>

--- a/docs/src/routes/examples/variants-dynamic/+page.svelte
+++ b/docs/src/routes/examples/variants-dynamic/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import Example from '$lib/components/general/Example.svelte'
+    import VariantsDynamicExample from '$lib/examples/VariantsDynamicExample.svelte'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'Variants Dynamic (custom)' }
+        ]
+    }
+    if (seo) {
+        seo.title = 'Variants Dynamic — custom prop | Examples | Svelte Motion'
+        seo.description =
+            'Per-instance variants using the custom prop and function-form factories in Svelte Motion. Staggered list reveals with index-driven delays.'
+        seo.ogTitle = 'Variants Dynamic (custom)'
+        seo.ogTagline = 'Per-instance variants using the custom prop and function-form factories'
+        seo.ogFeatures = ['Variants', 'custom prop', 'Staggered list', 'Function-form variants']
+        seo.ogSlug = 'examples-variants-dynamic'
+    }
+</script>
+
+<Example title="Variants Dynamic — custom prop">
+    <VariantsDynamicExample />
+</Example>

--- a/docs/src/routes/examples/variants-dynamic/+page.svelte
+++ b/docs/src/routes/examples/variants-dynamic/+page.svelte
@@ -23,6 +23,6 @@
     }
 </script>
 
-<Example title="Variants Dynamic — custom prop">
+<Example title="Variants Dynamic — custom prop" file="VariantsDynamicExample.svelte">
     <VariantsDynamicExample />
 </Example>

--- a/docs/src/routes/examples/variants-propagation/+page.svelte
+++ b/docs/src/routes/examples/variants-propagation/+page.svelte
@@ -24,6 +24,6 @@
     }
 </script>
 
-<Example title="Variants Propagation">
+<Example title="Variants Propagation" file="VariantsPropagationExample.svelte">
     <VariantsPropagationExample />
 </Example>

--- a/docs/src/routes/examples/while-focus/+page.svelte
+++ b/docs/src/routes/examples/while-focus/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import WhileFocusExample from '$lib/examples/WhileFocusExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -25,6 +23,6 @@
     }
 </script>
 
-<Example title="While Focus" sourceUrl={data.sourceUrl ?? undefined}>
+<Example title="While Focus" file="WhileFocusExample.svelte">
     <WhileFocusExample />
 </Example>

--- a/docs/src/routes/examples/while-focus/+page.ts
+++ b/docs/src/routes/examples/while-focus/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = async () => {
     return {
         title: 'While Focus',
-        description: 'Animate elements when they receive keyboard focus.',
-        sourceUrl: 'https://motion.dev/docs/react-motion-component#focus'
+        description: 'Animate elements when they receive keyboard focus.'
     }
 }

--- a/docs/src/routes/examples/while-in-view/+page.svelte
+++ b/docs/src/routes/examples/while-in-view/+page.svelte
@@ -3,8 +3,6 @@
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import Example from '$lib/components/general/Example.svelte'
     import WhileInViewExample from '$lib/examples/WhileInViewExample.svelte'
-
-    const { data } = $props()
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -25,6 +23,6 @@
     }
 </script>
 
-<Example title="While In View" sourceUrl={data.sourceUrl ?? undefined}>
+<Example title="While In View" file="WhileInViewExample.svelte">
     <WhileInViewExample />
 </Example>

--- a/docs/src/routes/examples/while-in-view/+page.ts
+++ b/docs/src/routes/examples/while-in-view/+page.ts
@@ -3,7 +3,6 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = () => {
     return {
         title: 'While In View',
-        description: 'Animate elements when they enter or leave the viewport',
-        sourceUrl: 'https://motion.dev/docs/react-motion-component#scroll'
+        description: 'Animate elements when they enter or leave the viewport'
     }
 }

--- a/docs/static/llms-full.txt
+++ b/docs/static/llms-full.txt
@@ -258,6 +258,35 @@ Named animation states with parent-child propagation.
 - Variant strings passed to `animate` propagate to children through context
 - Children inherit the parent's active variant key automatically
 
+### Dynamic (function-form) variants + `custom` prop
+
+A variant entry can be a `(custom) => keyframes` factory. The motion
+component's `custom` prop is forwarded into the factory each time the
+variant is resolved (initial / animate / exit). Children without their
+own `custom` prop inherit the nearest motion ancestor's value.
+
+```svelte
+<script lang="ts">
+    import { motion, type Variants } from '@humanspeak/svelte-motion'
+
+    const variants: Variants = {
+        hidden: { opacity: 0, x: -100 },
+        visible: (i) => ({
+            opacity: 1,
+            x: 0,
+            transition: { delay: (i as number) * 0.1 }
+        })
+    }
+    const items = ['Alpha', 'Beta', 'Gamma', 'Delta']
+</script>
+
+{#each items as item, i}
+    <motion.li custom={i} {variants} initial="hidden" animate="visible">
+        {item}
+    </motion.li>
+{/each}
+```
+
 ---
 
 ## Layout animation

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -40,7 +40,7 @@ npm install @humanspeak/svelte-motion
 - **`AnimatePresence`** for mount/unmount exit animations with `mode="sync" | "wait" | "popLayout"`.
 - **Gestures**: `whileHover`, `whileTap`, `whileFocus`, `whileInView`.
 - **Drag**: full drag gesture API with constraints, momentum, elastic, snap-to-origin, axis lock, and `createDragControls()` for imperative control.
-- **Variants**: named animation states with parent-child propagation.
+- **Variants**: named animation states with parent-child propagation. Function-form variants `(custom) => keyframes` receive the `custom` prop for per-instance values (staggered lists, indexed offsets).
 - **Layout animation**: FLIP-based `layout` and `layout="position"` props.
 - **Shared layout**: `layoutId` for animating between elements across the DOM.
 - **Spring physics**: `useSpring` for natural motion.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.5.24
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/0344e93c2808989dea769fe6ec01c5e67f4f07a3(@humanspeak/svelte-motion@)(@internationalized/date@3.11.0)(@lucide/svelte@1.16.0(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.7(@typescript-eslint/types@8.59.3))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.2)))(svelte@5.55.7(@typescript-eslint/types@8.59.3))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.2)))(mode-watcher@1.1.0(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(svelte@5.55.7(@typescript-eslint/types@8.59.3))
+        specifier: github:humanspeak/docs-kit#2026.5.25
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/d2a7c4fee61bbbebc7c4293dfc862be29a62bed3(@humanspeak/svelte-motion@)(@internationalized/date@3.11.0)(@lucide/svelte@1.16.0(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.7(@typescript-eslint/types@8.59.3))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.2)))(svelte@5.55.7(@typescript-eslint/types@8.59.3))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.2)))(mode-watcher@1.1.0(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(svelte@5.55.7(@typescript-eslint/types@8.59.3))
       '@humanspeak/svelte-motion':
         specifier: workspace:*
         version: link:..
@@ -912,8 +912,8 @@ packages:
     resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/0344e93c2808989dea769fe6ec01c5e67f4f07a3':
-    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/0344e93c2808989dea769fe6ec01c5e67f4f07a3}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/d2a7c4fee61bbbebc7c4293dfc862be29a62bed3':
+    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/d2a7c4fee61bbbebc7c4293dfc862be29a62bed3}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4693,7 +4693,7 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/0344e93c2808989dea769fe6ec01c5e67f4f07a3(@humanspeak/svelte-motion@)(@internationalized/date@3.11.0)(@lucide/svelte@1.16.0(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.7(@typescript-eslint/types@8.59.3))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.2)))(svelte@5.55.7(@typescript-eslint/types@8.59.3))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.2)))(mode-watcher@1.1.0(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(svelte@5.55.7(@typescript-eslint/types@8.59.3))':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/d2a7c4fee61bbbebc7c4293dfc862be29a62bed3(@humanspeak/svelte-motion@)(@internationalized/date@3.11.0)(@lucide/svelte@1.16.0(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.7(@typescript-eslint/types@8.59.3))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.2)))(svelte@5.55.7(@typescript-eslint/types@8.59.3))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.2)))(mode-watcher@1.1.0(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(svelte@5.55.7(@typescript-eslint/types@8.59.3))':
     dependencies:
       '@humanspeak/svelte-motion': 'link:'
       '@humanspeak/svelte-satori-fix': 0.0.3(svelte@5.55.7(@typescript-eslint/types@8.59.3))

--- a/src/lib/components/__tests__/NestedCustomHarness.svelte
+++ b/src/lib/components/__tests__/NestedCustomHarness.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+    import { motion } from '$lib'
+
+    let { parentCustom = 1 }: { parentCustom?: number } = $props()
+
+    // Child has no `custom` prop — must inherit from parent.
+    const childVariants = {
+        visible: (i: unknown) => ({ x: (i as number) * 25 })
+    }
+
+    const parentVariants = {
+        visible: { opacity: 1 }
+    }
+</script>
+
+<motion.div data-testid="parent" custom={parentCustom} variants={parentVariants} animate="visible">
+    <motion.div data-testid="child" variants={childVariants} animate="visible" />
+</motion.div>

--- a/src/lib/components/variantContext.context.ts
+++ b/src/lib/components/variantContext.context.ts
@@ -3,6 +3,7 @@ import type { Writable } from 'svelte/store'
 
 const VARIANT_CONTEXT_KEY = Symbol('variant-context')
 const INITIAL_FALSE_CONTEXT_KEY = Symbol('initial-false-context')
+const CUSTOM_CONTEXT_KEY = Symbol('custom-context')
 
 /**
  * Provide a writable store for the current variant key so children can
@@ -40,4 +41,30 @@ export const setInitialFalseContext = (value: boolean): void => {
  */
 export const getInitialFalseContext = (): boolean => {
     return getContext<boolean>(INITIAL_FALSE_CONTEXT_KEY) ?? false
+}
+
+/**
+ * Provide a writable store carrying the current motion component's
+ * `custom` value so descendant motion components without their own
+ * `custom` prop can inherit it — and re-resolve their variants when the
+ * parent's `custom` changes.
+ *
+ * Mirrors framer-motion's variant-tree custom propagation. A store
+ * (rather than a snapshot) lets descendants react to changes the parent
+ * makes after mount.
+ *
+ * @param store Writable store holding the current component's effective `custom`.
+ */
+export const setCustomContext = (store: Writable<unknown>): void => {
+    setContext<Writable<unknown>>(CUSTOM_CONTEXT_KEY, store)
+}
+
+/**
+ * Read the nearest ancestor's `custom` store (if any).
+ *
+ * @returns The ancestor's writable store, or `undefined` when no motion
+ *     ancestor has set one.
+ */
+export const getCustomContext = (): Writable<unknown> | undefined => {
+    return getContext<Writable<unknown> | undefined>(CUSTOM_CONTEXT_KEY)
 }

--- a/src/lib/html/_MotionContainer.spec.ts
+++ b/src/lib/html/_MotionContainer.spec.ts
@@ -344,6 +344,32 @@ describe('_MotionContainer', () => {
         expect(childCall).toBeTruthy()
     })
 
+    it('re-animates the child when the parent updates `custom` after mount', async () => {
+        // Regression for the ready-state animate effect gating only on
+        // `lastRanVariantKey`. The child here animates to the same
+        // variant key ("visible") across both renders — only the resolved
+        // keyframes change because `custom` does. Before the fix the
+        // gating short-circuited and no new animate call was made.
+        const { default: NestedCustomHarness } =
+            await import('$lib/components/__tests__/NestedCustomHarness.svelte')
+        animateMock.mockClear()
+        const result = render(NestedCustomHarness, { props: { parentCustom: 4 } })
+        await flushTimers()
+        // Initial: child resolves to x=100.
+        expect(
+            animateMock.mock.calls.some((c) => (c?.[1] as Record<string, unknown>)?.x === 100)
+        ).toBe(true)
+
+        animateMock.mockClear()
+        await result.rerender({ parentCustom: 5 })
+        await flushTimers()
+        // After parent's custom flips 4 → 5, the child must re-animate
+        // to x=125. If the gating ignores `custom`, this call never lands.
+        expect(
+            animateMock.mock.calls.some((c) => (c?.[1] as Record<string, unknown>)?.x === 125)
+        ).toBe(true)
+    })
+
     it('whileHover is gated to hover-capable devices', async () => {
         /* trunk-ignore(eslint/@typescript-eslint/no-explicit-any) */
         const { container } = render(MotionContainer as unknown as any, {

--- a/src/lib/html/_MotionContainer.spec.ts
+++ b/src/lib/html/_MotionContainer.spec.ts
@@ -310,6 +310,40 @@ describe('_MotionContainer', () => {
         vi.unstubAllGlobals()
     })
 
+    it('passes own custom prop into a function-form variant on animate', async () => {
+        animateMock.mockClear()
+        /* trunk-ignore(eslint/@typescript-eslint/no-explicit-any) */
+        render(MotionContainer as unknown as any, {
+            props: {
+                tag: 'div',
+                custom: 3,
+                variants: {
+                    visible: (i: unknown) => ({ x: (i as number) * 50 })
+                },
+                animate: 'visible'
+            }
+        })
+        await flushTimers()
+        const animateDef = animateMock.mock.calls.at(-1)?.[1] as Record<string, unknown>
+        expect(animateDef).toMatchObject({ x: 150 })
+    })
+
+    it('inherits custom from a parent motion component when child has no custom prop', async () => {
+        // Render a nested tree via a tiny wrapper Svelte component so we
+        // exercise the real Svelte context inheritance, not just the
+        // resolver in isolation.
+        const { default: NestedCustomHarness } =
+            await import('$lib/components/__tests__/NestedCustomHarness.svelte')
+        animateMock.mockClear()
+        render(NestedCustomHarness, { props: { parentCustom: 4 } })
+        await flushTimers()
+        // The child resolves `(i) => ({ x: i * 25 })` with custom=4 → x=100.
+        const childCall = animateMock.mock.calls.find(
+            (c) => (c?.[1] as Record<string, unknown>)?.x === 100
+        )
+        expect(childCall).toBeTruthy()
+    })
+
     it('whileHover is gated to hover-capable devices', async () => {
         /* trunk-ignore(eslint/@typescript-eslint/no-explicit-any) */
         const { container } = render(MotionContainer as unknown as any, {

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -672,6 +672,12 @@
 
     // Track the last variant key we ran to avoid re-running on mount
     let lastRanVariantKey = $state<string | undefined>(undefined)
+    // Companion to `lastRanVariantKey`: the JSON-serialized resolved
+    // keyframes for that variant. Lets us detect when a function-form
+    // variant produces new keyframes (because `custom` changed) while
+    // the variant key stayed the same — otherwise the animate effect
+    // would short-circuit and the element would never re-animate.
+    let lastRanResolvedJson = $state<string | undefined>(undefined)
     let mountedWithInitialFalse = $state(false)
     // Track if the initial->animate transition has already been triggered by main effect
     let initialAnimationTriggered = $state(false)
@@ -949,8 +955,14 @@
             return
         }
         if (typeof animateProp === 'string') {
-            if (lastRanVariantKey !== animateProp) {
+            // Compare BOTH the variant key and the resolved keyframes JSON.
+            // For static variants the JSON is constant per key; for
+            // function-form variants the JSON changes when `custom`
+            // changes, which we must treat as a new animation target.
+            const resolvedJson = resolvedAnimate ? JSON.stringify(resolvedAnimate) : undefined
+            if (lastRanVariantKey !== animateProp || lastRanResolvedJson !== resolvedJson) {
                 lastRanVariantKey = animateProp
+                lastRanResolvedJson = resolvedJson
                 runAnimation()
             }
         } else if (animateProp) {
@@ -989,8 +1001,10 @@
             mountedWithInitialFalse = false
         }
         if (typeof currentAnimateKey === 'string') {
-            if (lastRanVariantKey !== currentAnimateKey) {
+            const resolvedJson = resolvedAnimate ? JSON.stringify(resolvedAnimate) : undefined
+            if (lastRanVariantKey !== currentAnimateKey || lastRanResolvedJson !== resolvedJson) {
                 lastRanVariantKey = currentAnimateKey
+                lastRanResolvedJson = resolvedJson
                 runAnimation()
             }
         } else {
@@ -1022,6 +1036,9 @@
                 mountedWithInitialFalse = true
                 if (typeof currentAnimateKey === 'string') {
                     lastRanVariantKey = currentAnimateKey
+                    lastRanResolvedJson = resolvedAnimate
+                        ? JSON.stringify(resolvedAnimate)
+                        : undefined
                 }
                 dataPath = 5
                 isLoaded = 'ready'
@@ -1114,6 +1131,9 @@
                     snapshot = transformSVGPathProperties(element!, snapshot)
                     animate(element!, snapshot as DOMKeyframesDefinition, { duration: 0 })
                     lastRanVariantKey = currentAnimateKey
+                    lastRanResolvedJson = resolvedAnimate
+                        ? JSON.stringify(resolvedAnimate)
+                        : undefined
                 } else {
                     runAnimation()
                 }

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -53,7 +53,9 @@
         setVariantContext,
         getVariantContext,
         setInitialFalseContext,
-        getInitialFalseContext
+        getInitialFalseContext,
+        setCustomContext,
+        getCustomContext
     } from '$lib/components/variantContext.context'
     import { get, writable } from 'svelte/store'
     import {
@@ -75,6 +77,7 @@
         tag = 'div',
         key: keyProp,
         variants: variantsProp,
+        custom: customProp,
         initial: initialProp,
         animate: animateProp,
         exit: exitProp,
@@ -360,6 +363,32 @@
     // Provide context immediately during initialization so children can inherit
     setVariantContext(localVariantStore)
 
+    // Custom-value inheritance. Children with no `custom` prop adopt the
+    // nearest motion ancestor's value. Reactive via a writable store so a
+    // parent updating `custom` re-fires descendants' variant resolution.
+    const parentCustomStore = getCustomContext()
+    let inheritedCustom: unknown = undefined
+    if (parentCustomStore) {
+        parentCustomStore.subscribe((v) => (inheritedCustom = v))()
+    }
+    const initialCustomValue = customProp !== undefined ? customProp : inheritedCustom
+    const localCustomStore = writable<unknown>(initialCustomValue)
+    setCustomContext(localCustomStore)
+
+    let parentInheritedCustom = $state<unknown>(inheritedCustom)
+    $effect(() => {
+        if (!parentCustomStore) {
+            parentInheritedCustom = undefined
+            return
+        }
+        const unsubscribe = parentCustomStore.subscribe((v) => (parentInheritedCustom = v))
+        return () => unsubscribe()
+    })
+    const effectiveCustom = $derived(customProp !== undefined ? customProp : parentInheritedCustom)
+    $effect(() => {
+        localCustomStore.set(effectiveCustom)
+    })
+
     $effect(() => {
         if (!variantsProp) return localVariantStore.set(undefined)
         if (typeof animateProp === 'string') return localVariantStore.set(animateProp)
@@ -367,9 +396,13 @@
         localVariantStore.set(undefined)
     })
 
-    const resolvedInitial = $derived(resolveInitial(effectiveInitialProp, variantsProp))
-    const resolvedAnimate = $derived(resolveAnimate(effectiveAnimate, variantsProp))
-    const resolvedExit = $derived(resolveExit(exitProp, variantsProp))
+    const resolvedInitial = $derived(
+        resolveInitial(effectiveInitialProp, variantsProp, effectiveCustom)
+    )
+    const resolvedAnimate = $derived(
+        resolveAnimate(effectiveAnimate, variantsProp, effectiveCustom)
+    )
+    const resolvedExit = $derived(resolveExit(exitProp, variantsProp, effectiveCustom))
 
     // Extract keyframes from resolved initial, handling initial={false}
     const initialKeyframes = $derived(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,35 @@ import type { AnimationOptions, DOMKeyframesDefinition } from 'motion'
 import type { Snippet } from 'svelte'
 
 /**
+ * A variant value: either a static keyframes object, or a factory function
+ * that receives the consumer-provided `custom` value and returns keyframes.
+ *
+ * Dynamic (function-form) variants let a single variants object emit
+ * per-instance keyframes — common for staggered lists where each child
+ * needs its own offset or delay.
+ *
+ * @example
+ * ```svelte
+ * <motion.div
+ *   custom={index}
+ *   variants={{
+ *     visible: (i) => ({ opacity: 1, x: i * 50 }),
+ *     hidden:  { opacity: 0 }
+ *   }}
+ *   animate="visible"
+ * />
+ * ```
+ */
+export type Variant =
+    | DOMKeyframesDefinition
+    | ((custom: unknown) => DOMKeyframesDefinition)
+    | undefined
+
+/**
  * Variants define named animation states that can be referenced by string keys.
+ *
+ * Each entry can be a static keyframes object or a `(custom) => keyframes`
+ * factory function (see {@link Variant}).
  *
  * @example
  * ```svelte
@@ -16,7 +44,7 @@ import type { Snippet } from 'svelte'
  * <motion.div variants={variants} animate="open" />
  * ```
  */
-export type Variants = Record<string, DOMKeyframesDefinition | undefined>
+export type Variants = Record<string, Variant>
 
 /**
  * Initial animation properties for a motion component.
@@ -274,6 +302,12 @@ export type MotionProps = {
     key?: string
     /** Variants define named animation states */
     variants?: Variants
+    /**
+     * Value passed into function-form variants. Children without their own
+     * `custom` prop inherit this from the nearest motion ancestor — matching
+     * framer-motion's variant-tree custom propagation.
+     */
+    custom?: unknown
     /** Initial state of the animation (object or variant key) */
     initial?: MotionInitial
     /** Target state of the animation (object or variant key) */

--- a/src/lib/utils/variants.spec.ts
+++ b/src/lib/utils/variants.spec.ts
@@ -1,0 +1,114 @@
+import type { Variants } from '$lib/types'
+import { describe, expect, it } from 'vitest'
+import { resolveAnimate, resolveExit, resolveInitial, resolveVariant } from './variants.js'
+
+describe('utils/variants - resolveVariant', () => {
+    it('returns the static keyframes object for an object-form variant', () => {
+        const variants: Variants = { visible: { opacity: 1 } }
+        expect(resolveVariant(variants, 'visible')).toEqual({ opacity: 1 })
+    })
+
+    it('returns undefined for an unknown key', () => {
+        const variants: Variants = { visible: { opacity: 1 } }
+        expect(resolveVariant(variants, 'missing')).toBeUndefined()
+    })
+
+    it('returns undefined when variants or key are absent', () => {
+        expect(resolveVariant(undefined, 'visible')).toBeUndefined()
+        expect(resolveVariant({}, undefined)).toBeUndefined()
+    })
+
+    it('invokes function-form variants with the supplied custom value', () => {
+        const variants: Variants = {
+            visible: (i) => ({ x: (i as number) * 50, opacity: 1 })
+        }
+        expect(resolveVariant(variants, 'visible', 3)).toEqual({ x: 150, opacity: 1 })
+    })
+
+    it('passes undefined to function-form variants when no custom is supplied', () => {
+        const variants: Variants = {
+            visible: (custom) => ({ flag: custom === undefined ? 'absent' : 'present' }) as never
+        }
+        expect(resolveVariant(variants, 'visible')).toEqual({ flag: 'absent' })
+    })
+
+    it('passes 0 (falsy) custom through to the factory as 0, not undefined', () => {
+        // Regression guard: a `custom={0}` from a stagger index must reach
+        // the factory as 0, not coerced to undefined or fallback values.
+        const variants: Variants = {
+            visible: (i) => ({ x: (i as number) * 10 })
+        }
+        expect(resolveVariant(variants, 'visible', 0)).toEqual({ x: 0 })
+    })
+})
+
+describe('utils/variants - resolveInitial', () => {
+    it('returns false unchanged when initial is false', () => {
+        expect(resolveInitial(false, undefined)).toBe(false)
+    })
+
+    it('returns undefined when initial is undefined', () => {
+        expect(resolveInitial(undefined, undefined)).toBeUndefined()
+    })
+
+    it('passes object-form initial through unchanged', () => {
+        expect(resolveInitial({ x: 10 }, undefined)).toEqual({ x: 10 })
+    })
+
+    it('resolves a string initial against variants', () => {
+        const variants: Variants = { hidden: { opacity: 0 } }
+        expect(resolveInitial('hidden', variants)).toEqual({ opacity: 0 })
+    })
+
+    it('forwards custom to function-form variants', () => {
+        const variants: Variants = {
+            hidden: (i) => ({ x: -(i as number) * 100 })
+        }
+        expect(resolveInitial('hidden', variants, 2)).toEqual({ x: -200 })
+    })
+})
+
+describe('utils/variants - resolveAnimate', () => {
+    it('passes object-form animate through unchanged', () => {
+        expect(resolveAnimate({ scale: 1.2 }, undefined)).toEqual({ scale: 1.2 })
+    })
+
+    it('resolves a string animate against variants', () => {
+        const variants: Variants = { visible: { opacity: 1 } }
+        expect(resolveAnimate('visible', variants)).toEqual({ opacity: 1 })
+    })
+
+    it('forwards custom to function-form variants', () => {
+        const variants: Variants = {
+            visible: (i) => ({ delay: (i as number) * 0.1 }) as never
+        }
+        expect(resolveAnimate('visible', variants, 4)).toEqual({ delay: 0.4 })
+    })
+
+    it('returns undefined when animate is undefined', () => {
+        expect(resolveAnimate(undefined, undefined)).toBeUndefined()
+    })
+})
+
+describe('utils/variants - resolveExit', () => {
+    it('passes object-form exit through unchanged', () => {
+        expect(resolveExit({ y: -100 }, undefined)).toEqual({ y: -100 })
+    })
+
+    it('resolves a string exit against variants', () => {
+        const variants: Variants = { hidden: { opacity: 0 } }
+        expect(resolveExit('hidden', variants)).toEqual({ opacity: 0 })
+    })
+
+    it('forwards custom to function-form variants', () => {
+        const variants: Variants = {
+            hidden: (direction) => ({ x: (direction as number) > 0 ? 200 : -200 }) as never
+        }
+        expect(resolveExit('hidden', variants, 1)).toEqual({ x: 200 })
+        expect(resolveExit('hidden', variants, -1)).toEqual({ x: -200 })
+    })
+
+    it('returns undefined when exit is undefined', () => {
+        expect(resolveExit(undefined, undefined)).toBeUndefined()
+    })
+})

--- a/src/lib/utils/variants.ts
+++ b/src/lib/utils/variants.ts
@@ -4,111 +4,111 @@ import type { DOMKeyframesDefinition } from 'motion'
 /**
  * Resolves a variant key to its keyframes definition.
  *
- * Looks up a variant name in the variants object and returns the corresponding
- * keyframes. Returns `undefined` if the variants object or key is not provided.
+ * Looks up `key` in `variants`. When the entry is a function (dynamic
+ * variant), it's invoked with `custom` to produce keyframes — matching
+ * framer-motion's per-instance variant pattern.
  *
  * @param variants - The variants object containing named animation states.
  * @param key - The variant key to look up.
- * @returns The keyframes definition for the variant, or undefined if not found.
+ * @param custom - Value forwarded to function-form variants. Pass-through
+ *     `undefined` when no `custom` is in scope; the dynamic variant itself
+ *     decides how to handle the absent input.
+ * @returns The keyframes definition for the variant, or `undefined` if the
+ *     key is missing.
  *
  * @example
- * ```typescript
+ * ```ts
  * const variants = {
- *   visible: { opacity: 1 },
- *   hidden: { opacity: 0 }
+ *   visible: (i: number) => ({ x: i * 50 }),
+ *   hidden:  { opacity: 0 }
  * }
- * resolveVariant(variants, 'visible')  // { opacity: 1 }
- * resolveVariant(variants, 'foo')      // undefined
- * resolveVariant(undefined, 'visible') // undefined
+ * resolveVariant(variants, 'visible', 3)  // { x: 150 }
+ * resolveVariant(variants, 'hidden')      // { opacity: 0 }
+ * resolveVariant(undefined, 'visible')    // undefined
  * ```
  */
 export const resolveVariant = (
     variants: Variants | undefined,
-    key: string | undefined
+    key: string | undefined,
+    custom?: unknown
 ): DOMKeyframesDefinition | undefined => {
     if (!variants || !key) return undefined
-    return variants[key]
+    const entry = variants[key]
+    if (typeof entry === 'function') return entry(custom)
+    return entry
 }
 
 /**
  * Resolves the initial prop to keyframes, handling variant keys and `initial={false}`.
  *
- * When `initial` is a string, looks it up in the variants object. When `initial={false}`,
- * returns `false` to skip initial animation. Otherwise returns the keyframes directly.
+ * When `initial` is a string, looks it up in the variants object (invoking
+ * dynamic variants with `custom`). When `initial={false}`, returns `false` to
+ * skip the initial animation. Otherwise returns the keyframes directly.
  *
  * @param initial - The initial prop value (keyframes, variant key, false, or undefined).
  * @param variants - The variants object for resolving string keys.
+ * @param custom - Forwarded to function-form variants.
  * @returns Keyframes definition, `false` to skip animation, or undefined.
  *
  * @example
- * ```typescript
- * const variants = { hidden: { opacity: 0 } }
- * resolveInitial('hidden', variants)     // { opacity: 0 }
- * resolveInitial({ x: 0 }, variants)     // { x: 0 }
- * resolveInitial(false, variants)        // false
- * resolveInitial(undefined, variants)    // undefined
+ * ```ts
+ * const variants = { hidden: (i: number) => ({ x: -i * 100 }) }
+ * resolveInitial('hidden', variants, 2)      // { x: -200 }
+ * resolveInitial({ x: 0 }, variants)         // { x: 0 }
+ * resolveInitial(false, variants)            // false
+ * resolveInitial(undefined, variants)        // undefined
  * ```
  */
 export const resolveInitial = (
     initial: MotionInitial,
-    variants: Variants | undefined
+    variants: Variants | undefined,
+    custom?: unknown
 ): DOMKeyframesDefinition | false | undefined => {
     if (initial === false) return false
     if (initial === undefined) return undefined
-    if (typeof initial === 'string') return resolveVariant(variants, initial)
+    if (typeof initial === 'string') return resolveVariant(variants, initial, custom)
     return initial as DOMKeyframesDefinition
 }
 
 /**
  * Resolves the animate prop to keyframes, handling variant keys.
  *
- * When `animate` is a string, looks it up in the variants object.
- * Otherwise returns the keyframes directly.
+ * When `animate` is a string, looks it up in the variants object (invoking
+ * dynamic variants with `custom`). Otherwise returns the keyframes directly.
  *
  * @param animate - The animate prop value (keyframes, variant key, or undefined).
  * @param variants - The variants object for resolving string keys.
+ * @param custom - Forwarded to function-form variants.
  * @returns Keyframes definition or undefined.
- *
- * @example
- * ```typescript
- * const variants = { visible: { opacity: 1 } }
- * resolveAnimate('visible', variants)       // { opacity: 1 }
- * resolveAnimate({ scale: 1.2 }, variants)  // { scale: 1.2 }
- * resolveAnimate(undefined, variants)       // undefined
- * ```
  */
 export const resolveAnimate = (
     animate: MotionAnimate,
-    variants: Variants | undefined
+    variants: Variants | undefined,
+    custom?: unknown
 ): DOMKeyframesDefinition | undefined => {
     if (animate === undefined) return undefined
-    if (typeof animate === 'string') return resolveVariant(variants, animate)
+    if (typeof animate === 'string') return resolveVariant(variants, animate, custom)
     return animate as DOMKeyframesDefinition
 }
 
 /**
  * Resolves the exit prop to keyframes, handling variant keys.
  *
- * When `exit` is a string, looks it up in the variants object.
- * Otherwise returns the keyframes directly. Used by AnimatePresence for exit animations.
+ * When `exit` is a string, looks it up in the variants object (invoking
+ * dynamic variants with `custom`). Otherwise returns the keyframes directly.
+ * Used by AnimatePresence for exit animations.
  *
  * @param exit - The exit prop value (keyframes, variant key, or undefined).
  * @param variants - The variants object for resolving string keys.
+ * @param custom - Forwarded to function-form variants.
  * @returns Keyframes definition or undefined.
- *
- * @example
- * ```typescript
- * const variants = { hidden: { opacity: 0 } }
- * resolveExit('hidden', variants)          // { opacity: 0 }
- * resolveExit({ y: -100 }, variants)       // { y: -100 }
- * resolveExit(undefined, variants)         // undefined
- * ```
  */
 export const resolveExit = (
     exit: MotionExit,
-    variants: Variants | undefined
+    variants: Variants | undefined,
+    custom?: unknown
 ): DOMKeyframesDefinition | undefined => {
     if (exit === undefined) return undefined
-    if (typeof exit === 'string') return resolveVariant(variants, exit)
+    if (typeof exit === 'string') return resolveVariant(variants, exit, custom)
     return exit as DOMKeyframesDefinition
 }

--- a/src/routes/tests/variants/dynamic-custom/+page.svelte
+++ b/src/routes/tests/variants/dynamic-custom/+page.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+    import { motion, type Variants } from '$lib'
+
+    // Regression test for the bug where changing `custom` while the variant
+    // key stays the same (e.g. `animate="visible"`) failed to re-animate —
+    // because the ready-state animate effects gated on `lastRanVariantKey`
+    // (a string) and ignored the resolved keyframes derived from `custom`.
+    //
+    // Expected behaviour after the fix:
+    //   - Box reads `data-x={`<latest x value computed from custom>`}`
+    //   - Clicking "increment custom" steps custom by 1
+    //   - The function-form variant `visible: (i) => ({ x: i * 50 })`
+    //     re-resolves, the effect re-runs, and the element animates to
+    //     x = custom * 50 each time.
+    //
+    // Before the fix, clicking the button updated the `custom` counter but
+    // the box stayed pinned at x=0 forever (no re-animation).
+
+    let customValue = $state(0)
+
+    const variants: Variants = {
+        visible: (i) => ({ x: (i as number) * 50, opacity: 1 })
+    }
+
+    const expectedX = $derived(customValue * 50)
+</script>
+
+<svelte:head>
+    <title>Variants — dynamic custom (regression test)</title>
+</svelte:head>
+
+<div class="page" data-testid="dynamic-custom-page">
+    <header>
+        <h1>Dynamic variants — reactive <code>custom</code></h1>
+        <p>
+            Function-form variant <code>visible: (i) =&gt; (&lbrace; x: i * 50 &rbrace;)</code>. The
+            <code>custom</code>
+            prop drives <code>x</code> while
+            <code>animate</code> stays at the string <code>"visible"</code> the whole time.
+        </p>
+        <p>
+            Each click should animate the box to its new <code>x</code>. Before the fix that wired
+            <code>effectiveCustom</code> into the animate-effect gating, the variant key didn't change
+            so the effect short-circuited and the box never moved past x=0.
+        </p>
+    </header>
+
+    <section class="controls">
+        <button
+            type="button"
+            data-testid="increment"
+            onclick={() => {
+                customValue += 1
+            }}
+        >
+            increment custom (currently {customValue}) →
+        </button>
+        <button
+            type="button"
+            data-testid="reset"
+            onclick={() => {
+                customValue = 0
+            }}
+        >
+            reset
+        </button>
+    </section>
+
+    <section class="stage">
+        <div class="track">
+            <motion.div
+                custom={customValue}
+                {variants}
+                initial={{ x: 0, opacity: 1 }}
+                animate="visible"
+                transition={{ type: 'spring', stiffness: 220, damping: 24 }}
+                class="box"
+                data-testid="box"
+                data-custom={customValue}
+                data-expected-x={expectedX}
+            >
+                custom = {customValue}
+            </motion.div>
+        </div>
+    </section>
+
+    <section class="readout">
+        <div>
+            <span class="k">custom</span>
+            <strong data-testid="readout-custom">{customValue}</strong>
+        </div>
+        <div>
+            <span class="k">expected x</span>
+            <strong data-testid="readout-expected-x">{expectedX}</strong>
+        </div>
+    </section>
+
+    <section class="howto">
+        <p>
+            <b>How to verify:</b> click the increment button. Each click should kick off a spring
+            from the current resting x to <code>custom * 50</code>. After ~600&nbsp;ms the box
+            should sit at the new position. If it stays glued to <code>translateX(0px)</code> no matter
+            how many times you click, the bug is back.
+        </p>
+        <pre>// from the browser console:
+const box = document.querySelector('[data-testid="box"]')
+box.style.transform // expected: translateX(&lt;custom * 50&gt;px)
+</pre>
+    </section>
+</div>
+
+<style>
+    .page {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 24px;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+    }
+    header h1 {
+        font-size: 1.5rem;
+        margin: 0 0 0.5rem;
+    }
+    header p {
+        color: #444;
+        line-height: 1.5;
+    }
+    code {
+        font-family: ui-monospace, monospace;
+        font-size: 0.85em;
+        background: #f3f3f3;
+        padding: 0 4px;
+        border-radius: 3px;
+    }
+    .controls {
+        display: flex;
+        gap: 8px;
+        margin: 16px 0;
+    }
+    .controls button {
+        padding: 0.5rem 1rem;
+        background: #111;
+        color: white;
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+        font-weight: 600;
+    }
+    .controls button:hover {
+        background: #333;
+    }
+    .stage {
+        margin: 24px 0;
+        padding: 24px 16px;
+        border: 1px dashed #bbb;
+        border-radius: 8px;
+        background: #fafafa;
+    }
+    .track {
+        position: relative;
+        min-height: 80px;
+    }
+    .box {
+        width: 120px;
+        height: 80px;
+        border-radius: 12px;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+        font-family: ui-monospace, monospace;
+        font-size: 0.85rem;
+    }
+    .readout {
+        margin-top: 24px;
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 12px;
+        font-family: ui-monospace, monospace;
+        font-size: 0.85rem;
+    }
+    .howto {
+        margin-top: 20px;
+        padding: 12px 16px;
+        background: #fff8e6;
+        border: 1px solid #f0d68a;
+        border-radius: 6px;
+        font-size: 0.85rem;
+        color: #6a4a00;
+    }
+    .howto pre {
+        margin-top: 8px;
+        background: #faf2d8;
+        padding: 8px;
+        border-radius: 4px;
+        overflow-x: auto;
+        font-family: ui-monospace, monospace;
+        font-size: 0.78rem;
+    }
+    .readout > div {
+        padding: 8px 12px;
+        background: #f3f3f3;
+        border-radius: 6px;
+    }
+    .k {
+        display: block;
+        color: #777;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 2px;
+    }
+</style>


### PR DESCRIPTION
## Summary

Adds framer-motion's `custom` prop on motion components and threads it
through variant resolution. A variant value can now be either a static
keyframes object or a `(custom) => keyframes` factory — the pattern
framer-motion uses for staggered lists where each child needs its own
offset or delay.

```svelte
<motion.li
    custom={i}
    variants={{
        hidden:  { opacity: 0, x: -100 },
        visible: (i) => ({ opacity: 1, x: 0, transition: { delay: i * 0.1 } })
    }}
    initial="hidden"
    animate="visible"
/>
```

**Propagation**: children without their own `custom` prop inherit the
nearest motion ancestor's value through a Svelte context store
(writable, so a parent updating `custom` after mount re-resolves
descendants). Matches framer-motion's variant-tree custom propagation.

Closes #308. Unblocks #309 (`custom` on `AnimatePresence`) and #305
(`usePresenceData`).

While auditing scope I noticed that `whileHover` / `whileTap` /
`whileFocus` / `whileDrag` / `whileInView` don't yet accept variant
**strings** (only keyframe objects). That's a separate parity gap —
filed as **#349** and added to the parity project board.

## Changes

✨ **Feature**
- `src/lib/types.ts` — new `Variant` type adds the function-form arm;
  `Variants` widened to `Record<string, Variant>`; new `custom?: unknown`
  field on `MotionProps`
- `src/lib/utils/variants.ts` — `resolveVariant` / `resolveInitial` /
  `resolveAnimate` / `resolveExit` each gain a `custom?` arg and invoke
  function-form entries with it
- `src/lib/components/variantContext.context.ts` — new
  `setCustomContext` / `getCustomContext` (writable store) for
  descendant inheritance
- `src/lib/html/_MotionContainer.svelte` — receives `custom` prop, reads
  the parent store, publishes its own effective custom value, threads it
  into the three resolver calls

🧪 **Tests** (372/372 passing, +21 new)
- `src/lib/utils/variants.spec.ts` (new) — 19 cases covering
  function/object forms, falsy-zero passthrough, undefined custom, all
  four resolvers
- `src/lib/html/_MotionContainer.spec.ts` — 2 new cases: own custom
  forwarded to function-form variant on animate; child inherits parent's
  custom through nested context (uses new
  `__tests__/NestedCustomHarness.svelte`)

📚 **Docs / discoverability**
- `README.md` — extended Variants section with function-form example
- `docs/src/routes/docs/+page.svx` — new Variants section explaining
  custom + factory pattern + inheritance
- `docs/static/llms-full.txt` — documents dynamic variants and `custom`
- `docs/static/llms.txt` — short feature blurb updated
- New `/examples/variants-dynamic` demo (component + route + load entry
  + sitemap) showing 5-item staggered list driven by `custom={i}`;
  verified in browser via playwright (all items resolve to the visible
  variant with their per-instance keyframes, 0 console errors)

## Commits

- [`b7059b7`](https://github.com/humanspeak/svelte-motion/commit/b7059b7) feat(variants): custom prop + function-form variants

## Test plan

- [x] `pnpm test:only` — 372/372 green
- [x] `pnpm exec svelte-check` (root) — 0 errors
- [x] Browser-verified `/examples/variants-dynamic` via playwright:
  each item renders with its own custom-derived target state
- [x] Pre-existing demos (`variants-basic`, `variants-propagation`)
  still pass — `Variants` widening is backward-compatible

Closes #308
