### PR TITLE
feat(layout): add layoutScroll prop for FLIP inside scroll containers (+ nested ancestor support)

### DIFF
--- a/docs/src/lib/examples/LayoutScrollExample.svelte
+++ b/docs/src/lib/examples/LayoutScrollExample.svelte
@@ -11,6 +11,10 @@
     const sizeRest = '120px'
     const sizeExpanded = '220px'
 
+    // Slow tween so the user has time to drag the scrollbar mid-animation
+    // and actually see the difference between the two panels.
+    const slowTransition = { duration: 1.8, ease: 'easeInOut' as const }
+
     function toggle() {
         expanded = !expanded
     }
@@ -67,10 +71,10 @@
                     background: 'var(--color-background, #fff)'
                 }))}
             >
-                <div style="height: 240px;"></div>
+                <div style="height: 60px;"></div>
                 <motion.div
                     layout
-                    transition={{ type: 'spring', stiffness: 220, damping: 26 }}
+                    transition={slowTransition}
                     style={styleString(() => ({
                         width: expanded ? sizeExpanded : sizeRest,
                         height: expanded ? sizeExpanded : sizeRest,
@@ -79,7 +83,7 @@
                         margin: '0 auto'
                     }))}
                 ></motion.div>
-                <div style="height: 240px;"></div>
+                <div style="height: 360px;"></div>
             </div>
         </article>
 
@@ -102,10 +106,10 @@
                     background: 'var(--color-background, #fff)'
                 }))}
             >
-                <div style="height: 240px;"></div>
+                <div style="height: 60px;"></div>
                 <motion.div
                     layout
-                    transition={{ type: 'spring', stiffness: 220, damping: 26 }}
+                    transition={slowTransition}
                     style={styleString(() => ({
                         width: expanded ? sizeExpanded : sizeRest,
                         height: expanded ? sizeExpanded : sizeRest,
@@ -114,20 +118,31 @@
                         margin: '0 auto'
                     }))}
                 ></motion.div>
-                <div style="height: 240px;"></div>
+                <div style="height: 360px;"></div>
             </motion.div>
         </article>
     </div>
 
-    <p
+    <ol
         style={styleString(() => ({
             margin: 0,
-            fontSize: '0.78rem',
+            paddingLeft: '1.1rem',
+            fontSize: '0.82rem',
             color: 'var(--color-text-muted)',
-            fontFamily: 'JetBrains Mono Variable, ui-monospace, monospace',
-            letterSpacing: '0.02em'
+            lineHeight: 1.55
         }))}
     >
-        // click expand, then scroll either panel mid-animation
-    </p>
+        <li>
+            Click <strong>expand box</strong> (animation runs over 1.8 s — plenty of time).
+        </li>
+        <li>
+            <em>While the boxes are still animating</em>, drag the scrollbar of either panel down by
+            ~80 px.
+        </li>
+        <li>
+            Left panel — the red box jumps / drifts as the FLIP transform fights the scroll. Right
+            panel — the teal box keeps animating smoothly to its new size and stays anchored to its
+            place in the scrolled-content coordinate space.
+        </li>
+    </ol>
 </div>

--- a/docs/src/lib/examples/LayoutScrollExample.svelte
+++ b/docs/src/lib/examples/LayoutScrollExample.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+    import { motion, styleString } from '@humanspeak/svelte-motion'
+
+    // Live demo of `layoutScroll`. Two side-by-side scroll containers,
+    // identical FLIP animations inside. Only the right one has the prop.
+    // Click "Resize" then scroll either panel mid-animation: the left one
+    // drifts (FLIP measures viewport-relative rects, so the scroll offset
+    // leaks into the delta), the right stays anchored.
+
+    let expanded = $state(false)
+    const sizeRest = '120px'
+    const sizeExpanded = '220px'
+
+    function toggle() {
+        expanded = !expanded
+    }
+</script>
+
+<div
+    style={styleString(() => ({
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1rem',
+        padding: '1.5rem',
+        background: 'var(--color-background-secondary)',
+        borderRadius: 8
+    }))}
+>
+    <motion.button
+        whileTap={{ scale: 0.96 }}
+        whileHover={{ scale: 1.03, backgroundColor: 'var(--color-brand-600)' }}
+        onclick={toggle}
+        style={styleString(() => ({
+            alignSelf: 'flex-start',
+            padding: '0.55rem 1.1rem',
+            background: 'var(--color-brand-500)',
+            color: '#ffffff',
+            border: 'none',
+            borderRadius: 8,
+            fontSize: '0.9rem',
+            fontWeight: 600,
+            cursor: 'pointer',
+            letterSpacing: '0.02em',
+            boxShadow:
+                '0 4px 14px -4px color-mix(in oklab, var(--color-brand-500) 70%, transparent)'
+        }))}
+    >
+        {expanded ? 'shrink box' : 'expand box →'}
+    </motion.button>
+
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+        <article>
+            <header style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem;">
+                <strong style="font-size: 0.85rem;">without <code>layoutScroll</code></strong>
+                <span
+                    style="font-size: 0.72rem; padding: 1px 6px; border-radius: 4px; color: #b91c1c; background: #fee2e2;"
+                >
+                    drifts on scroll
+                </span>
+            </header>
+            <div
+                style={styleString(() => ({
+                    overflow: 'auto',
+                    height: '240px',
+                    border: '1px solid var(--color-border, #bbb)',
+                    borderRadius: 8,
+                    background: 'var(--color-background, #fff)'
+                }))}
+            >
+                <div style="height: 240px;"></div>
+                <motion.div
+                    layout
+                    transition={{ type: 'spring', stiffness: 220, damping: 26 }}
+                    style={styleString(() => ({
+                        width: expanded ? sizeExpanded : sizeRest,
+                        height: expanded ? sizeExpanded : sizeRest,
+                        borderRadius: 12,
+                        background: 'linear-gradient(135deg,#ef4444 0%,#f97316 100%)',
+                        margin: '0 auto'
+                    }))}
+                ></motion.div>
+                <div style="height: 240px;"></div>
+            </div>
+        </article>
+
+        <article>
+            <header style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem;">
+                <strong style="font-size: 0.85rem;">with <code>layoutScroll</code></strong>
+                <span
+                    style="font-size: 0.72rem; padding: 1px 6px; border-radius: 4px; color: #047857; background: #d1fae5;"
+                >
+                    stays anchored
+                </span>
+            </header>
+            <motion.div
+                layoutScroll
+                style={styleString(() => ({
+                    overflow: 'auto',
+                    height: '240px',
+                    border: '1px solid var(--color-border, #bbb)',
+                    borderRadius: 8,
+                    background: 'var(--color-background, #fff)'
+                }))}
+            >
+                <div style="height: 240px;"></div>
+                <motion.div
+                    layout
+                    transition={{ type: 'spring', stiffness: 220, damping: 26 }}
+                    style={styleString(() => ({
+                        width: expanded ? sizeExpanded : sizeRest,
+                        height: expanded ? sizeExpanded : sizeRest,
+                        borderRadius: 12,
+                        background: 'linear-gradient(135deg,#22c55e 0%,#06b6d4 100%)',
+                        margin: '0 auto'
+                    }))}
+                ></motion.div>
+                <div style="height: 240px;"></div>
+            </motion.div>
+        </article>
+    </div>
+
+    <p
+        style={styleString(() => ({
+            margin: 0,
+            fontSize: '0.78rem',
+            color: 'var(--color-text-muted)',
+            fontFamily: 'JetBrains Mono Variable, ui-monospace, monospace',
+            letterSpacing: '0.02em'
+        }))}
+    >
+        // click expand, then scroll either panel mid-animation
+    </p>
+</div>

--- a/docs/src/routes/docs/layout-animations/+page.svx
+++ b/docs/src/routes/docs/layout-animations/+page.svx
@@ -102,11 +102,11 @@ The fix is to mark the scroll container with `layoutScroll`. Descendant `layout`
 </motion.div>
 ```
 
-Apply `layoutScroll` on the same `motion.*` element that owns the scrolling — the same element you'd set `overflow: scroll` (or `auto`) on. Descendants walk up the context to find the nearest `layoutScroll` ancestor automatically.
+Apply `layoutScroll` on the same `motion.*` element that owns the scrolling — the same element you'd set `overflow: scroll` (or `auto`) on. Nested `layoutScroll` containers stack: a `layout` descendant accounts for the scroll offset of every `layoutScroll` ancestor in its path, so you can wrap a scrollable list inside a scrollable panel and both contribute to the FLIP measurement.
 
 | Prop | Type | Description |
 |---|---|---|
-| `layoutScroll` | `boolean` | Mark this element as a scroll container so descendant `layout` measurements account for its scroll offset. |
+| `layoutScroll` | `boolean` | Mark this element as a scroll container so descendant `layout` measurements account for its scroll offset. Nested `layoutScroll` ancestors stack. |
 
 ## API reference
 

--- a/docs/src/routes/docs/layout-animations/+page.svx
+++ b/docs/src/routes/docs/layout-animations/+page.svx
@@ -90,6 +90,24 @@ The most common use case is a tab indicator that slides between tabs:
 <SharedLayoutAnimationExample />
 </Example>
 
+## Inside scroll containers — `layoutScroll`
+
+By default, FLIP measures elements using `getBoundingClientRect()`, which returns viewport-relative coordinates. If a `motion.div` with `layout` lives inside an `overflow: scroll` container and the user scrolls during the animation, the scroll offset shows up as an unwanted translate — the box visibly drifts.
+
+The fix is to mark the scroll container with `layoutScroll`. Descendant `layout` animations then measure rects in that container's coordinate space, so a mid-animation scroll cancels out instead of leaking into the FLIP delta.
+
+```svelte
+<motion.div layoutScroll style="overflow: auto; height: 320px;">
+    <motion.div layout>Resize me — scroll the container mid-animation</motion.div>
+</motion.div>
+```
+
+Apply `layoutScroll` on the same `motion.*` element that owns the scrolling — the same element you'd set `overflow: scroll` (or `auto`) on. Descendants walk up the context to find the nearest `layoutScroll` ancestor automatically.
+
+| Prop | Type | Description |
+|---|---|---|
+| `layoutScroll` | `boolean` | Mark this element as a scroll container so descendant `layout` measurements account for its scroll offset. |
+
 ## API reference
 
 ### `layout`

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -46,6 +46,11 @@ const EXAMPLES: Record<string, ExampleEntry> = {
         title: 'Keyframes',
         description: 'Interactive Keyframes animation example using Svelte Motion.'
     },
+    'layout-scroll': {
+        title: 'layoutScroll',
+        description:
+            'Keep FLIP layout animations anchored when the parent container scrolls mid-animation.'
+    },
     'motion-path': {
         title: 'Motion Path',
         description: 'Interactive motion path animation example using Svelte Motion.'

--- a/docs/src/routes/examples/layout-scroll/+page.svelte
+++ b/docs/src/routes/examples/layout-scroll/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import Example from '$lib/components/general/Example.svelte'
+    import LayoutScrollExample from '$lib/examples/LayoutScrollExample.svelte'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'layoutScroll' }
+        ]
+    }
+    if (seo) {
+        seo.title = 'layoutScroll — FLIP inside scroll containers | Examples | Svelte Motion'
+        seo.description =
+            'Use layoutScroll to keep FLIP layout animations anchored when the user scrolls the parent container mid-animation. Side-by-side demo of the drift vs the fix.'
+        seo.ogTitle = 'layoutScroll'
+        seo.ogTagline = 'Keep layout animations anchored across container scroll'
+        seo.ogFeatures = ['FLIP layout', 'layoutScroll', 'Scroll containers', 'Anchored animations']
+        seo.ogSlug = 'examples-layout-scroll'
+    }
+</script>
+
+<Example title="layoutScroll — FLIP inside scroll containers" file="LayoutScrollExample.svelte">
+    <LayoutScrollExample />
+</Example>

--- a/docs/static/llms-full.txt
+++ b/docs/static/llms-full.txt
@@ -336,8 +336,8 @@ happen in container coordinates and stay anchored.
 ```
 
 Apply `layoutScroll` on the same `motion.*` element that owns the
-scrolling. Descendants walk up the Svelte context to find the nearest
-`layoutScroll` ancestor.
+scrolling. Nested `layoutScroll` ancestors stack: a `layout` descendant
+accounts for every `layoutScroll` ancestor's scroll offset.
 
 ---
 

--- a/docs/static/llms-full.txt
+++ b/docs/static/llms-full.txt
@@ -322,6 +322,23 @@ Animate between different elements that share a `layoutId`:
 {/each}
 ```
 
+### Inside scroll containers — `layoutScroll`
+
+By default FLIP measures viewport-relative rects, so scrolling a parent
+container mid-animation makes the layout animation drift. Mark the
+scroll container with `layoutScroll` so descendant `layout` measurements
+happen in container coordinates and stay anchored.
+
+```svelte
+<motion.div layoutScroll style="overflow: auto; height: 320px;">
+    <motion.div layout>resize me, then scroll the container</motion.div>
+</motion.div>
+```
+
+Apply `layoutScroll` on the same `motion.*` element that owns the
+scrolling. Descendants walk up the Svelte context to find the nearest
+`layoutScroll` ancestor.
+
 ---
 
 ## MotionConfig

--- a/e2e/layout/nested-scroll.spec.ts
+++ b/e2e/layout/nested-scroll.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Regression for #353 — nested `layoutScroll` containers must sum offsets,
+ * not just consult the nearest ancestor.
+ *
+ * Scenario: outer `layoutScroll` container, inner `layoutScroll` container,
+ * `layout` motion.div inside. Resize the box, then scroll the OUTER
+ * container mid-animation. With the chain-walking fix the box stays
+ * anchored; without it, the outer scroll leaks into the FLIP delta.
+ */
+test.describe('layout/nested-scroll', () => {
+    test('outer scroll mid-animation is cancelled by the FLIP delta', async ({ page }) => {
+        await page.goto('/tests/layout/nested-scroll?@isPlaywright=true')
+
+        const outer = page.getByTestId('outer')
+        const box = page.getByTestId('box')
+        const toggle = page.getByTestId('toggle')
+        await box.waitFor({ state: 'visible' })
+
+        // Reset outer scroll
+        await outer.evaluate((el) => {
+            el.scrollTop = 0
+        })
+
+        await toggle.click()
+        // Mid-animation, scroll the OUTER container (not the inner one
+        // the box's direct parent — that would be the single-container case).
+        await page.waitForTimeout(80)
+        await outer.evaluate((el) => {
+            el.scrollTop = 80
+        })
+
+        // Wait for the 1.8s tween to settle.
+        await page.waitForTimeout(2000)
+
+        // After settle, the FLIP delta should be zero (transform clears)
+        // because the outer scroll was accounted for in both measurements.
+        const transform = await box.evaluate((el) => (el as HTMLElement).style.transform || '')
+        const drift = transform.match(/translateY\(([-\d.]+)px\)/)?.[1]
+        if (drift !== undefined) {
+            expect(Math.abs(Number(drift))).toBeLessThan(1)
+        }
+
+        // Sanity: box reached its expanded size.
+        const rect = await box.boundingBox()
+        if (!rect) throw new Error('no boundingBox')
+        expect(rect.width).toBeGreaterThan(200)
+        expect(rect.height).toBeGreaterThan(200)
+    })
+
+    test('regression page renders both containers + box', async ({ page }) => {
+        await page.goto('/tests/layout/nested-scroll?@isPlaywright=true')
+        await expect(page.getByTestId('outer')).toBeVisible()
+        await expect(page.getByTestId('inner')).toBeVisible()
+        await expect(page.getByTestId('box')).toBeVisible()
+    })
+})

--- a/e2e/layout/nested-scroll.spec.ts
+++ b/e2e/layout/nested-scroll.spec.ts
@@ -37,10 +37,8 @@ test.describe('layout/nested-scroll', () => {
         // After settle, the FLIP delta should be zero (transform clears)
         // because the outer scroll was accounted for in both measurements.
         const transform = await box.evaluate((el) => (el as HTMLElement).style.transform || '')
-        const drift = transform.match(/translateY\(([-\d.]+)px\)/)?.[1]
-        if (drift !== undefined) {
-            expect(Math.abs(Number(drift))).toBeLessThan(1)
-        }
+        const drift = Number(transform.match(/translateY\(([-\d.]+)px\)/)?.[1] ?? '0')
+        expect(Math.abs(drift)).toBeLessThan(1)
 
         // Sanity: box reached its expanded size.
         const rect = await box.boundingBox()

--- a/e2e/layout/nested-scroll.spec.ts
+++ b/e2e/layout/nested-scroll.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { readTransform } from '../_helpers/transform'
 
 /**
  * Regression for #353 — nested `layoutScroll` containers must sum offsets,
@@ -18,7 +19,9 @@ test.describe('layout/nested-scroll', () => {
         const toggle = page.getByTestId('toggle')
         await box.waitFor({ state: 'visible' })
 
-        // Reset outer scroll
+        const before = await box.boundingBox()
+        if (!before) throw new Error('no initial boundingBox')
+
         await outer.evaluate((el) => {
             el.scrollTop = 0
         })
@@ -31,20 +34,32 @@ test.describe('layout/nested-scroll', () => {
             el.scrollTop = 80
         })
 
-        // Wait for the 1.8s tween to settle.
-        await page.waitForTimeout(2000)
+        // Poll until the 1.8s tween settles. Box must reach its expanded
+        // size with no residual translate from the FLIP delta — the outer
+        // scroll was accounted for in both measurements.
+        await expect
+            .poll(
+                async () => {
+                    const t = await readTransform(page, '[data-testid="box"]')
+                    const rect = await box.boundingBox()
+                    return {
+                        translateAtRest: Math.abs(t.tx) < 0.5 && Math.abs(t.ty) < 0.5,
+                        scaleAtRest: Math.abs(t.a - 1) < 0.01 && Math.abs(t.d - 1) < 0.01,
+                        widthGrew: (rect?.width ?? 0) > before.width + 20
+                    }
+                },
+                { timeout: 4000, message: 'nested box did not settle with identity transform' }
+            )
+            .toEqual({ translateAtRest: true, scaleAtRest: true, widthGrew: true })
 
-        // After settle, the FLIP delta should be zero (transform clears)
-        // because the outer scroll was accounted for in both measurements.
-        const transform = await box.evaluate((el) => (el as HTMLElement).style.transform || '')
-        const drift = Number(transform.match(/translateY\(([-\d.]+)px\)/)?.[1] ?? '0')
-        expect(Math.abs(drift)).toBeLessThan(1)
+        const settled = await readTransform(page, '[data-testid="box"]')
+        expect(Math.abs(settled.tx)).toBeLessThan(0.5)
+        expect(Math.abs(settled.ty)).toBeLessThan(0.5)
 
-        // Sanity: box reached its expanded size.
-        const rect = await box.boundingBox()
-        if (!rect) throw new Error('no boundingBox')
-        expect(rect.width).toBeGreaterThan(200)
-        expect(rect.height).toBeGreaterThan(200)
+        const after = await box.boundingBox()
+        if (!after) throw new Error('no final boundingBox')
+        expect(after.width).toBeGreaterThan(200)
+        expect(after.height).toBeGreaterThan(200)
     })
 
     test('regression page renders both containers + box', async ({ page }) => {

--- a/e2e/layout/scroll.spec.ts
+++ b/e2e/layout/scroll.spec.ts
@@ -53,12 +53,11 @@ test.describe('layout/scroll', () => {
         const finalTransform = await boxWith.evaluate(
             (el) => (el as HTMLElement).style.transform || ''
         )
-        // Expect either an empty string (no transform applied), the literal
-        // "none", or a near-zero translate within sub-pixel rounding.
-        const drift = finalTransform.match(/translateX\(([-\d.]+)px\)/)?.[1]
-        if (drift !== undefined) {
-            expect(Math.abs(Number(drift))).toBeLessThan(1)
-        }
+        // An empty string or "none" both mean "no translate applied" (drift=0);
+        // a partial translate string means we kept some movement and need to
+        // verify it's within sub-pixel rounding.
+        const drift = Number(finalTransform.match(/translateX\(([-\d.]+)px\)/)?.[1] ?? '0')
+        expect(Math.abs(drift)).toBeLessThan(1)
 
         // Sanity: the box still exists at the expected expanded size (~240).
         const box = await boxWith.boundingBox()

--- a/e2e/layout/scroll.spec.ts
+++ b/e2e/layout/scroll.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Regression test for the `layoutScroll` prop.
+ *
+ * Scenario: two side-by-side scroll containers each with a `layout`
+ * animation inside. The user resizes the inner element and scrolls
+ * mid-animation. Without `layoutScroll`, FLIP measures viewport-relative
+ * rects and the scroll offset shows up as drift in the animation;
+ * with `layoutScroll`, measurements happen in container coordinates
+ * and the animation stays anchored.
+ *
+ * We assert that after the animation settles, the `layoutScroll` box
+ * is at its expected final position (no leftover translate), while
+ * the non-`layoutScroll` box may show a small artefact. We're not
+ * trying to pin down the exact drift value — that varies with timing
+ * — only to assert the `layoutScroll` path ends clean.
+ */
+test.describe('layout/scroll', () => {
+    test('layoutScroll container keeps animations anchored across scroll', async ({ page }) => {
+        await page.goto('/tests/layout/scroll?@isPlaywright=true')
+
+        const scrollWith = page.getByTestId('scroll-with')
+        const boxWith = page.getByTestId('box-with')
+        const toggle = page.getByTestId('toggle')
+
+        await boxWith.waitFor({ state: 'visible' })
+
+        // Scroll both containers to a known position before the animation.
+        await scrollWith.evaluate((el) => {
+            el.scrollTop = 0
+        })
+        const cWithout = page.getByTestId('scroll-without')
+        await cWithout.evaluate((el) => {
+            el.scrollTop = 0
+        })
+
+        // Fire the resize animation, then scroll mid-flight.
+        await toggle.click()
+        await page.waitForTimeout(40)
+        await scrollWith.evaluate((el) => {
+            el.scrollTop = 60
+        })
+        await cWithout.evaluate((el) => {
+            el.scrollTop = 60
+        })
+
+        // Let the spring settle.
+        await page.waitForTimeout(800)
+
+        // After settle, the layoutScroll box must have no residual transform —
+        // the resize completed cleanly without scroll-induced drift.
+        const finalTransform = await boxWith.evaluate(
+            (el) => (el as HTMLElement).style.transform || ''
+        )
+        // Expect either an empty string (no transform applied), the literal
+        // "none", or a near-zero translate within sub-pixel rounding.
+        const drift = finalTransform.match(/translateX\(([-\d.]+)px\)/)?.[1]
+        if (drift !== undefined) {
+            expect(Math.abs(Number(drift))).toBeLessThan(1)
+        }
+
+        // Sanity: the box still exists at the expected expanded size (~240).
+        const box = await boxWith.boundingBox()
+        if (!box) throw new Error('no boundingBox')
+        expect(box.width).toBeGreaterThan(200)
+        expect(box.height).toBeGreaterThan(200)
+    })
+
+    test('regression page renders both panels with their boxes', async ({ page }) => {
+        // Smoke test: both panels rendered, both containers scroll, both
+        // boxes are present and visible. Catches obvious regressions where
+        // the layoutScroll wiring breaks the page structure.
+        await page.goto('/tests/layout/scroll?@isPlaywright=true')
+
+        await expect(page.getByTestId('scroll-without')).toBeVisible()
+        await expect(page.getByTestId('scroll-with')).toBeVisible()
+        await expect(page.getByTestId('box-without')).toBeVisible()
+        await expect(page.getByTestId('box-with')).toBeVisible()
+    })
+})

--- a/e2e/layout/scroll.spec.ts
+++ b/e2e/layout/scroll.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { readTransform } from '../_helpers/transform'
 
 /**
  * Regression test for the `layoutScroll` prop.
@@ -9,12 +10,6 @@ import { expect, test } from '@playwright/test'
  * rects and the scroll offset shows up as drift in the animation;
  * with `layoutScroll`, measurements happen in container coordinates
  * and the animation stays anchored.
- *
- * We assert that after the animation settles, the `layoutScroll` box
- * is at its expected final position (no leftover translate), while
- * the non-`layoutScroll` box may show a small artefact. We're not
- * trying to pin down the exact drift value — that varies with timing
- * — only to assert the `layoutScroll` path ends clean.
  */
 test.describe('layout/scroll', () => {
     test('layoutScroll container keeps animations anchored across scroll', async ({ page }) => {
@@ -25,6 +20,10 @@ test.describe('layout/scroll', () => {
         const toggle = page.getByTestId('toggle')
 
         await boxWith.waitFor({ state: 'visible' })
+
+        // Capture initial size so we can later assert the box actually grew.
+        const before = await boxWith.boundingBox()
+        if (!before) throw new Error('no initial boundingBox')
 
         // Scroll both containers to a known position before the animation.
         await scrollWith.evaluate((el) => {
@@ -45,25 +44,43 @@ test.describe('layout/scroll', () => {
             el.scrollTop = 60
         })
 
-        // Let the spring settle.
-        await page.waitForTimeout(800)
+        // Poll until the spring settles. `[data-testid="box-with"]` reaches
+        // its expanded size when both the layout step and the FLIP "back to
+        // identity" finished — we wait until the box has both grown AND has
+        // a near-identity translate/scale.
+        await expect
+            .poll(
+                async () => {
+                    const t = await readTransform(page, '[data-testid="box-with"]')
+                    const rect = await boxWith.boundingBox()
+                    return {
+                        translateAtRest: Math.abs(t.tx) < 0.5 && Math.abs(t.ty) < 0.5,
+                        scaleAtRest: Math.abs(t.a - 1) < 0.01 && Math.abs(t.d - 1) < 0.01,
+                        widthGrew: (rect?.width ?? 0) > before.width + 20
+                    }
+                },
+                {
+                    timeout: 3000,
+                    message: 'box-with did not settle to its new size with identity transform'
+                }
+            )
+            .toEqual({ translateAtRest: true, scaleAtRest: true, widthGrew: true })
 
-        // After settle, the layoutScroll box must have no residual transform —
-        // the resize completed cleanly without scroll-induced drift.
-        const finalTransform = await boxWith.evaluate(
-            (el) => (el as HTMLElement).style.transform || ''
-        )
-        // An empty string or "none" both mean "no translate applied" (drift=0);
-        // a partial translate string means we kept some movement and need to
-        // verify it's within sub-pixel rounding.
-        const drift = Number(finalTransform.match(/translateX\(([-\d.]+)px\)/)?.[1] ?? '0')
-        expect(Math.abs(drift)).toBeLessThan(1)
+        // After settle, the layoutScroll box has no residual translate — the
+        // resize completed cleanly without scroll-induced drift. The poll
+        // above already enforced this, but assert one more time for
+        // documentation in the spec output.
+        const settled = await readTransform(page, '[data-testid="box-with"]')
+        expect(Math.abs(settled.tx)).toBeLessThan(0.5)
+        expect(Math.abs(settled.ty)).toBeLessThan(0.5)
 
-        // Sanity: the box still exists at the expected expanded size (~240).
-        const box = await boxWith.boundingBox()
-        if (!box) throw new Error('no boundingBox')
-        expect(box.width).toBeGreaterThan(200)
-        expect(box.height).toBeGreaterThan(200)
+        // Confirm the box actually reached its expanded size (~240 in the
+        // regression page). Anything well above the initial 120 confirms
+        // the layout animation produced the expected end state.
+        const after = await boxWith.boundingBox()
+        if (!after) throw new Error('no final boundingBox')
+        expect(after.width).toBeGreaterThan(200)
+        expect(after.height).toBeGreaterThan(200)
     })
 
     test('regression page renders both panels with their boxes', async ({ page }) => {

--- a/src/lib/components/layoutScroll.context.ts
+++ b/src/lib/components/layoutScroll.context.ts
@@ -2,14 +2,12 @@ import { getContext, setContext } from 'svelte'
 
 /**
  * Deferred references to the chain of `layoutScroll` ancestors for the
- * current subtree. Element refs are bound after mount, so we pass thunks;
- * descendants invoke them at measurement time.
+ * current subtree. Returned as a thunk because element refs are bound
+ * after mount; consumers invoke at measurement time.
  *
- * The chain is **bottom-up**: the closest ancestor first, then its
- * `layoutScroll` ancestor, and so on. Order doesn't matter for offset
- * summing — they're all combined — but the array is the chain so a
- * future feature (per-container `wasRoot` semantics, etc.) can iterate
- * in a defined direction.
+ * Order is closest-first. Order doesn't matter for the current scroll-
+ * offset sum, but is preserved so future per-container semantics (e.g.
+ * a `scroll.wasRoot` marker like framer-motion) can iterate deterministically.
  */
 export type LayoutScrollContainerRef = () => Array<HTMLElement | null | undefined>
 

--- a/src/lib/components/layoutScroll.context.ts
+++ b/src/lib/components/layoutScroll.context.ts
@@ -1,43 +1,47 @@
 import { getContext, setContext } from 'svelte'
 
 /**
- * A deferred reference to a scroll container element. The element isn't bound
- * until after mount, so we pass a thunk; descendants resolve the current
- * element at measurement time.
+ * Deferred references to the chain of `layoutScroll` ancestors for the
+ * current subtree. Element refs are bound after mount, so we pass thunks;
+ * descendants invoke them at measurement time.
+ *
+ * The chain is **bottom-up**: the closest ancestor first, then its
+ * `layoutScroll` ancestor, and so on. Order doesn't matter for offset
+ * summing — they're all combined — but the array is the chain so a
+ * future feature (per-container `wasRoot` semantics, etc.) can iterate
+ * in a defined direction.
  */
-export type LayoutScrollContainerRef = () => HTMLElement | null | undefined
+export type LayoutScrollContainerRef = () => Array<HTMLElement | null | undefined>
 
 const LAYOUT_SCROLL_CONTEXT_KEY = Symbol('layout-scroll-container')
 
 /**
- * Publish a scroll container reference for descendant motion components so
- * their FLIP measurements account for the container's scroll offset.
+ * Publish the scroll-container chain for descendant motion components.
  *
- * Called on a `motion.*` component with `layoutScroll` enabled during its
- * init phase. The element ref is bound later (after mount), so callers pass
- * a thunk; descendants invoke it at measure-time.
+ * Called on a `motion.*` component with `layoutScroll` enabled during
+ * its init phase. The provided thunk should resolve to `[...ancestorChain,
+ * ownElement]` — descendants get the full chain in one call.
  *
- * Mirrors framer-motion: any element with `layoutScroll` becomes a
- * measurement origin for nested `layout` animations.
+ * Mirrors framer-motion's `removeElementScroll`, which walks the path
+ * and sums every `layoutScroll` ancestor's offset.
  *
- * @param ref Thunk returning the scroll container element.
+ * @param ref Thunk returning the full ancestor chain (closest first).
  */
 export const setLayoutScrollContainer = (ref: LayoutScrollContainerRef): void => {
     setContext<LayoutScrollContainerRef>(LAYOUT_SCROLL_CONTEXT_KEY, ref)
 }
 
 /**
- * Capture the nearest ancestor scroll container's thunk at component init.
+ * Capture the ancestor chain thunk at component init.
  *
  * Important: call this **before** the same component calls
  * `setLayoutScrollContainer(...)`. Otherwise the lookup returns the
  * component's own thunk (Svelte `setContext` shadows from the call site
- * down) and measurements collapse to zero against the element itself.
+ * down) and the chain collapses.
  *
- * Returns `undefined` when no ancestor has `layoutScroll`. The caller
- * invokes the returned thunk at measure-time to resolve the element.
+ * Returns `undefined` when no ancestor has `layoutScroll`.
  *
- * @returns Ancestor's deferred element ref, or `undefined`.
+ * @returns Ancestor chain thunk, or `undefined`.
  */
 export const getLayoutScrollContainerRef = (): LayoutScrollContainerRef | undefined => {
     return getContext<LayoutScrollContainerRef | undefined>(LAYOUT_SCROLL_CONTEXT_KEY)

--- a/src/lib/components/layoutScroll.context.ts
+++ b/src/lib/components/layoutScroll.context.ts
@@ -1,0 +1,44 @@
+import { getContext, setContext } from 'svelte'
+
+/**
+ * A deferred reference to a scroll container element. The element isn't bound
+ * until after mount, so we pass a thunk; descendants resolve the current
+ * element at measurement time.
+ */
+export type LayoutScrollContainerRef = () => HTMLElement | null | undefined
+
+const LAYOUT_SCROLL_CONTEXT_KEY = Symbol('layout-scroll-container')
+
+/**
+ * Publish a scroll container reference for descendant motion components so
+ * their FLIP measurements account for the container's scroll offset.
+ *
+ * Called on a `motion.*` component with `layoutScroll` enabled during its
+ * init phase. The element ref is bound later (after mount), so callers pass
+ * a thunk; descendants invoke it at measure-time.
+ *
+ * Mirrors framer-motion: any element with `layoutScroll` becomes a
+ * measurement origin for nested `layout` animations.
+ *
+ * @param ref Thunk returning the scroll container element.
+ */
+export const setLayoutScrollContainer = (ref: LayoutScrollContainerRef): void => {
+    setContext<LayoutScrollContainerRef>(LAYOUT_SCROLL_CONTEXT_KEY, ref)
+}
+
+/**
+ * Capture the nearest ancestor scroll container's thunk at component init.
+ *
+ * Important: call this **before** the same component calls
+ * `setLayoutScrollContainer(...)`. Otherwise the lookup returns the
+ * component's own thunk (Svelte `setContext` shadows from the call site
+ * down) and measurements collapse to zero against the element itself.
+ *
+ * Returns `undefined` when no ancestor has `layoutScroll`. The caller
+ * invokes the returned thunk at measure-time to resolve the element.
+ *
+ * @returns Ancestor's deferred element ref, or `undefined`.
+ */
+export const getLayoutScrollContainerRef = (): LayoutScrollContainerRef | undefined => {
+    return getContext<LayoutScrollContainerRef | undefined>(LAYOUT_SCROLL_CONTEXT_KEY)
+}

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -65,6 +65,10 @@
         SVG_NAMESPACE
     } from '$lib/utils/svg'
     import { getLayoutIdRegistry } from '$lib/utils/layoutId'
+    import {
+        getLayoutScrollContainerRef,
+        setLayoutScrollContainer
+    } from '$lib/components/layoutScroll.context'
 
     type Props = MotionProps & {
         children?: Snippet
@@ -118,6 +122,7 @@
         dragControls: dragControlsProp,
         layout: layoutProp,
         layoutId: layoutIdProp,
+        layoutScroll: layoutScrollProp,
         ref: element = $bindable(null),
         ...rest
     }: Props = $props()
@@ -141,6 +146,17 @@
 
     // Get layoutId registry (provided by AnimatePresence or a parent LayoutGroup)
     const layoutIdRegistry = getLayoutIdRegistry()
+
+    // Capture the nearest `layoutScroll` ancestor (if any) BEFORE we
+    // potentially shadow the context with ourselves below — this element's
+    // own FLIP measurements must still resolve against the *ancestor*'s
+    // scroll container, not against itself.
+    const ancestorScrollContainerRef = getLayoutScrollContainerRef()
+    if (layoutScrollProp) {
+        setLayoutScrollContainer(() => element)
+    }
+    const resolveLayoutScrollAncestor = (): HTMLElement | undefined =>
+        ancestorScrollContainerRef?.() ?? undefined
 
     // Get current presence depth (0 = direct child of AnimatePresence, undefined = not in AnimatePresence)
     const presenceDepth = getPresenceDepth()
@@ -213,11 +229,14 @@
     $effect(() => {
         if (!(element && layoutIdProp && layoutIdRegistry)) return
 
-        // Capture rect on every frame while mounted
+        // Capture rect on every frame while mounted. Re-express in the
+        // nearest layoutScroll ancestor's coordinate space so the FLIP-from
+        // rect stored at unmount stays correct even if the scroll container
+        // moved between the snapshot and the next element's mount.
         let rafId: number
         const captureRect = () => {
             if (element) {
-                layoutIdLastRect = element.getBoundingClientRect()
+                layoutIdLastRect = measureRect(element, resolveLayoutScrollAncestor())
             }
             rafId = requestAnimationFrame(captureRect)
         }
@@ -701,17 +720,18 @@
         if (!(element && layoutProp && isLoaded === 'ready')) return
 
         // Initialize last rect on first ready frame
-        lastRect = measureRect(element!)
+        lastRect = measureRect(element!, resolveLayoutScrollAncestor())
         // Hint compositor for smoother FLIP transforms
         setCompositorHints(element!, true)
 
         let rafId: number | null = null
         const runFlip = () => {
+            const scrollContainer = resolveLayoutScrollAncestor()
             if (!lastRect) {
-                lastRect = measureRect(element!)
+                lastRect = measureRect(element!, scrollContainer)
                 return
             }
-            const next = measureRect(element!)
+            const next = measureRect(element!, scrollContainer)
             const transforms = computeFlipTransforms(lastRect, next, layoutProp ?? false)
             runFlipAnimation(element!, transforms, (mergedTransition ?? {}) as AnimationOptions)
             lastRect = next
@@ -745,7 +765,7 @@
         const prev = layoutIdRegistry.consume(layoutIdProp)
         if (!prev) return // First appearance, no animation needed
 
-        const next = measureRect(element)
+        const next = measureRect(element, resolveLayoutScrollAncestor())
         const transforms = computeFlipTransforms(prev.rect, next, true)
 
         setCompositorHints(element, true)

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -147,16 +147,29 @@
     // Get layoutId registry (provided by AnimatePresence or a parent LayoutGroup)
     const layoutIdRegistry = getLayoutIdRegistry()
 
-    // Capture the nearest `layoutScroll` ancestor (if any) BEFORE we
-    // potentially shadow the context with ourselves below — this element's
-    // own FLIP measurements must still resolve against the *ancestor*'s
-    // scroll container, not against itself.
+    // Capture the ancestor `layoutScroll` chain BEFORE we potentially shadow
+    // the context with ourselves below — this element's own FLIP measurements
+    // must resolve against the *ancestors*' scroll containers, not against
+    // itself.
+    //
+    // We walk the full chain (not just the nearest) so a `layoutScroll`
+    // outside another `layoutScroll` still contributes to descendant
+    // measurements — matches framer-motion's `removeElementScroll` walking
+    // `this.path`.
     const ancestorScrollContainerRef = getLayoutScrollContainerRef()
     if (layoutScrollProp) {
-        setLayoutScrollContainer(() => element)
+        // Publish [...ancestorChain, ownElement]. The chain is collected
+        // lazily because element refs bind after mount.
+        setLayoutScrollContainer(() => {
+            const inherited = ancestorScrollContainerRef?.() ?? []
+            return element ? [...inherited, element] : inherited
+        })
     }
-    const resolveLayoutScrollAncestor = (): HTMLElement | undefined =>
-        ancestorScrollContainerRef?.() ?? undefined
+    const resolveLayoutScrollAncestors = (): HTMLElement[] => {
+        const refs = ancestorScrollContainerRef?.() ?? []
+        // Filter out unbound refs (HTMLElement | null | undefined → HTMLElement[]).
+        return refs.filter((el): el is HTMLElement => Boolean(el))
+    }
 
     // Get current presence depth (0 = direct child of AnimatePresence, undefined = not in AnimatePresence)
     const presenceDepth = getPresenceDepth()
@@ -236,7 +249,7 @@
         let rafId: number
         const captureRect = () => {
             if (element) {
-                layoutIdLastRect = measureRect(element, resolveLayoutScrollAncestor())
+                layoutIdLastRect = measureRect(element, resolveLayoutScrollAncestors())
             }
             rafId = requestAnimationFrame(captureRect)
         }
@@ -720,18 +733,18 @@
         if (!(element && layoutProp && isLoaded === 'ready')) return
 
         // Initialize last rect on first ready frame
-        lastRect = measureRect(element!, resolveLayoutScrollAncestor())
+        lastRect = measureRect(element!, resolveLayoutScrollAncestors())
         // Hint compositor for smoother FLIP transforms
         setCompositorHints(element!, true)
 
         let rafId: number | null = null
         const runFlip = () => {
-            const scrollContainer = resolveLayoutScrollAncestor()
+            const scrollContainers = resolveLayoutScrollAncestors()
             if (!lastRect) {
-                lastRect = measureRect(element!, scrollContainer)
+                lastRect = measureRect(element!, scrollContainers)
                 return
             }
-            const next = measureRect(element!, scrollContainer)
+            const next = measureRect(element!, scrollContainers)
             const transforms = computeFlipTransforms(lastRect, next, layoutProp ?? false)
             runFlipAnimation(element!, transforms, (mergedTransition ?? {}) as AnimationOptions)
             lastRect = next
@@ -765,7 +778,7 @@
         const prev = layoutIdRegistry.consume(layoutIdProp)
         if (!prev) return // First appearance, no animation needed
 
-        const next = measureRect(element, resolveLayoutScrollAncestor())
+        const next = measureRect(element, resolveLayoutScrollAncestors())
         const transforms = computeFlipTransforms(prev.rect, next, true)
 
         setCompositorHints(element, true)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -368,6 +368,22 @@ export type MotionProps = {
     layout?: boolean | 'position'
     /** Shared layout animation identifier. Elements with matching layoutId animate between positions. */
     layoutId?: string
+    /**
+     * Mark this element as a scroll container so descendant `layout` animations
+     * measure rects in this container's coordinate space. Without it, scrolling
+     * mid-animation makes the FLIP transform fight the scroll and the layout
+     * animation drifts.
+     *
+     * Apply on the same element as `overflow: scroll` / `overflow: auto`.
+     *
+     * @example
+     * ```svelte
+     * <motion.div layoutScroll style="overflow: auto">
+     *   <motion.div layout />
+     * </motion.div>
+     * ```
+     */
+    layoutScroll?: boolean
     /** Ref to the element */
     ref?: HTMLElement | null
     /** Enable drag gestures. true for both axes, or lock to 'x'/'y'. */

--- a/src/lib/utils/layout.spec.ts
+++ b/src/lib/utils/layout.spec.ts
@@ -28,7 +28,7 @@ describe('utils/layout', () => {
         expect(el.style.transform).toBe(prev)
     })
 
-    it('measureRect: ignores scrollContainer when none is passed', () => {
+    it('measureRect: ignores scrollContainers when none is passed', () => {
         const el = document.createElement('div')
         const spy = vi
             .spyOn(el, 'getBoundingClientRect')
@@ -41,7 +41,18 @@ describe('utils/layout', () => {
         spy.mockRestore()
     })
 
-    it('measureRect: adds the scroll container offset to the returned rect', () => {
+    it('measureRect: ignores scrollContainers when an empty array is passed', () => {
+        const el = document.createElement('div')
+        const spy = vi
+            .spyOn(el, 'getBoundingClientRect')
+            .mockReturnValue(new DOMRect(10, 20, 100, 50))
+        const rect = measureRect(el, [])
+        expect(rect.left).toBe(10)
+        expect(rect.top).toBe(20)
+        spy.mockRestore()
+    })
+
+    it('measureRect: adds a single scroll container offset to the returned rect', () => {
         const el = document.createElement('div')
         const scroller = document.createElement('div')
         scroller.scrollTop = 80
@@ -49,11 +60,35 @@ describe('utils/layout', () => {
         const spy = vi
             .spyOn(el, 'getBoundingClientRect')
             .mockReturnValue(new DOMRect(10, 20, 100, 50))
-        const rect = measureRect(el, scroller)
+        const rect = measureRect(el, [scroller])
         // Rect is re-expressed in the scroll container's coordinate space:
         // viewport-relative + container's scroll offset.
         expect(rect.left).toBe(40)
         expect(rect.top).toBe(100)
+        expect(rect.width).toBe(100)
+        expect(rect.height).toBe(50)
+        spy.mockRestore()
+    })
+
+    it('measureRect: sums offsets from a chain of nested scroll containers', () => {
+        // Regression for #353 — two nested `layoutScroll` containers must
+        // both contribute their scroll offsets so the FLIP delta cancels
+        // out movement from either.
+        const el = document.createElement('div')
+        const outer = document.createElement('div')
+        const inner = document.createElement('div')
+        outer.scrollTop = 30
+        outer.scrollLeft = 0
+        inner.scrollTop = 50
+        inner.scrollLeft = 25
+        const spy = vi
+            .spyOn(el, 'getBoundingClientRect')
+            .mockReturnValue(new DOMRect(10, 20, 100, 50))
+        // Chain ordering matches what _MotionContainer publishes: closest
+        // (inner) first, then outer. Order doesn't affect the sum.
+        const rect = measureRect(el, [inner, outer])
+        expect(rect.left).toBe(10 + 25 + 0) // 35
+        expect(rect.top).toBe(20 + 50 + 30) // 100
         expect(rect.width).toBe(100)
         expect(rect.height).toBe(50)
         spy.mockRestore()
@@ -70,16 +105,45 @@ describe('utils/layout', () => {
         // Frame 1: scrollTop=0, element's viewport-relative top=100
         scroller.scrollTop = 0
         getRect.mockReturnValueOnce(new DOMRect(0, 100, 200, 80))
-        const before = measureRect(el, scroller)
+        const before = measureRect(el, [scroller])
 
         // Frame 2: user scrolled down 50px; viewport-relative top is now 50
         // but in container space it's the same (100 + 0 vs 50 + 50).
         scroller.scrollTop = 50
         getRect.mockReturnValueOnce(new DOMRect(0, 50, 200, 80))
-        const after = measureRect(el, scroller)
+        const after = measureRect(el, [scroller])
 
         const transforms = computeFlipTransforms(before, after, true)
         expect(transforms.dx).toBe(0)
+        expect(transforms.dy).toBe(0)
+        expect(transforms.shouldTranslate).toBe(false)
+
+        getRect.mockRestore()
+    })
+
+    it('measureRect + computeFlipTransforms: zero delta when nested containers both scroll', () => {
+        // Regression for #353 — the outer scroll-change also has to cancel
+        // out in the FLIP delta, not just the closest container's.
+        const el = document.createElement('div')
+        const outer = document.createElement('div')
+        const inner = document.createElement('div')
+        const getRect = vi.spyOn(el, 'getBoundingClientRect')
+
+        // Frame 1: both containers at scrollTop=0; element viewport top=200
+        outer.scrollTop = 0
+        inner.scrollTop = 0
+        getRect.mockReturnValueOnce(new DOMRect(0, 200, 200, 80))
+        const before = measureRect(el, [inner, outer])
+
+        // Frame 2: outer scrolled 20, inner scrolled 30. Element viewport
+        // top is now 200 - 50 = 150 (both scrolls reduce its viewport
+        // position). In combined scroll space, it's unchanged: 150 + 50 = 200.
+        outer.scrollTop = 20
+        inner.scrollTop = 30
+        getRect.mockReturnValueOnce(new DOMRect(0, 150, 200, 80))
+        const after = measureRect(el, [inner, outer])
+
+        const transforms = computeFlipTransforms(before, after, true)
         expect(transforms.dy).toBe(0)
         expect(transforms.shouldTranslate).toBe(false)
 

--- a/src/lib/utils/layout.spec.ts
+++ b/src/lib/utils/layout.spec.ts
@@ -28,6 +28,64 @@ describe('utils/layout', () => {
         expect(el.style.transform).toBe(prev)
     })
 
+    it('measureRect: ignores scrollContainer when none is passed', () => {
+        const el = document.createElement('div')
+        const spy = vi
+            .spyOn(el, 'getBoundingClientRect')
+            .mockReturnValue(new DOMRect(10, 20, 100, 50))
+        const rect = measureRect(el)
+        expect(rect.left).toBe(10)
+        expect(rect.top).toBe(20)
+        expect(rect.width).toBe(100)
+        expect(rect.height).toBe(50)
+        spy.mockRestore()
+    })
+
+    it('measureRect: adds the scroll container offset to the returned rect', () => {
+        const el = document.createElement('div')
+        const scroller = document.createElement('div')
+        scroller.scrollTop = 80
+        scroller.scrollLeft = 30
+        const spy = vi
+            .spyOn(el, 'getBoundingClientRect')
+            .mockReturnValue(new DOMRect(10, 20, 100, 50))
+        const rect = measureRect(el, scroller)
+        // Rect is re-expressed in the scroll container's coordinate space:
+        // viewport-relative + container's scroll offset.
+        expect(rect.left).toBe(40)
+        expect(rect.top).toBe(100)
+        expect(rect.width).toBe(100)
+        expect(rect.height).toBe(50)
+        spy.mockRestore()
+    })
+
+    it('measureRect + computeFlipTransforms: zero delta when only scroll changes', () => {
+        // Regression for layoutScroll: if the user scrolls the container
+        // between two measurements but the element doesn't actually move
+        // in the container's coordinate space, the FLIP delta must be zero.
+        const el = document.createElement('div')
+        const scroller = document.createElement('div')
+        const getRect = vi.spyOn(el, 'getBoundingClientRect')
+
+        // Frame 1: scrollTop=0, element's viewport-relative top=100
+        scroller.scrollTop = 0
+        getRect.mockReturnValueOnce(new DOMRect(0, 100, 200, 80))
+        const before = measureRect(el, scroller)
+
+        // Frame 2: user scrolled down 50px; viewport-relative top is now 50
+        // but in container space it's the same (100 + 0 vs 50 + 50).
+        scroller.scrollTop = 50
+        getRect.mockReturnValueOnce(new DOMRect(0, 50, 200, 80))
+        const after = measureRect(el, scroller)
+
+        const transforms = computeFlipTransforms(before, after, true)
+        expect(transforms.dx).toBe(0)
+        expect(transforms.dy).toBe(0)
+        expect(transforms.shouldTranslate).toBe(false)
+
+        getRect.mockRestore()
+    })
+
     it('computeFlipTransforms: flags translate/scale appropriately', () => {
         const prev = { left: 0, top: 0, width: 100, height: 100 } as unknown as DOMRect
         const next = { left: 10, top: 5, width: 200, height: 80 } as unknown as DOMRect

--- a/src/lib/utils/layout.ts
+++ b/src/lib/utils/layout.ts
@@ -6,28 +6,36 @@ import { animate, type AnimationOptions, type DOMKeyframesDefinition } from 'mot
  * Temporarily clears `transform` to avoid skewing measurements, restoring it
  * immediately after reading the rect.
  *
- * When `scrollContainer` is provided, the returned rect is shifted into that
- * container's scroll coordinate space (i.e. its `scrollLeft` / `scrollTop`
- * are added to `left` / `top`). FLIP deltas computed from two such measures
- * stay correct even when the user scrolls the container between measurements.
+ * When `scrollContainers` are provided, the returned rect is shifted by the
+ * **sum** of each container's `scrollLeft` / `scrollTop`. FLIP deltas
+ * computed from two such measures stay correct even when the user scrolls
+ * any of the containers between measurements — including a nested
+ * `layoutScroll` inside another `layoutScroll`. Mirrors framer-motion's
+ * `removeElementScroll`, which walks every ancestor in the path.
  *
- * Without a `scrollContainer`, behaviour is unchanged: viewport-relative rect.
+ * Pass an empty array (or omit) for viewport-relative behaviour.
  *
  * @param el Element to measure.
- * @param scrollContainer Optional ancestor with `layoutScroll` enabled.
+ * @param scrollContainers Optional ancestor chain with `layoutScroll` enabled.
  * @return DOMRect snapshot of the element.
  */
-export const measureRect = (el: HTMLElement, scrollContainer?: HTMLElement): DOMRect => {
+export const measureRect = (el: HTMLElement, scrollContainers?: HTMLElement[]): DOMRect => {
     const prev = el.style.transform
     try {
         el.style.transform = 'none'
         const rect = el.getBoundingClientRect()
-        if (!scrollContainer) return rect
-        // Re-express the rect in scroll-container coordinates so a subsequent
-        // scroll between measurements doesn't show up as movement. We can't
-        // assign to a DOMRect's left/top, so allocate a fresh DOMRect.
-        const { scrollLeft, scrollTop } = scrollContainer
-        return new DOMRect(rect.left + scrollLeft, rect.top + scrollTop, rect.width, rect.height)
+        if (!scrollContainers || scrollContainers.length === 0) return rect
+        // Re-express the rect in the *combined* scroll-container coordinate
+        // space so a subsequent scroll on any of them doesn't show up as
+        // movement. DOMRect's left/top are read-only, so allocate a fresh
+        // one with the summed offsets applied.
+        let offsetLeft = 0
+        let offsetTop = 0
+        for (const container of scrollContainers) {
+            offsetLeft += container.scrollLeft
+            offsetTop += container.scrollTop
+        }
+        return new DOMRect(rect.left + offsetLeft, rect.top + offsetTop, rect.width, rect.height)
     } finally {
         el.style.transform = prev
     }

--- a/src/lib/utils/layout.ts
+++ b/src/lib/utils/layout.ts
@@ -6,14 +6,28 @@ import { animate, type AnimationOptions, type DOMKeyframesDefinition } from 'mot
  * Temporarily clears `transform` to avoid skewing measurements, restoring it
  * immediately after reading the rect.
  *
+ * When `scrollContainer` is provided, the returned rect is shifted into that
+ * container's scroll coordinate space (i.e. its `scrollLeft` / `scrollTop`
+ * are added to `left` / `top`). FLIP deltas computed from two such measures
+ * stay correct even when the user scrolls the container between measurements.
+ *
+ * Without a `scrollContainer`, behaviour is unchanged: viewport-relative rect.
+ *
  * @param el Element to measure.
+ * @param scrollContainer Optional ancestor with `layoutScroll` enabled.
  * @return DOMRect snapshot of the element.
  */
-export const measureRect = (el: HTMLElement): DOMRect => {
+export const measureRect = (el: HTMLElement, scrollContainer?: HTMLElement): DOMRect => {
     const prev = el.style.transform
     try {
         el.style.transform = 'none'
-        return el.getBoundingClientRect()
+        const rect = el.getBoundingClientRect()
+        if (!scrollContainer) return rect
+        // Re-express the rect in scroll-container coordinates so a subsequent
+        // scroll between measurements doesn't show up as movement. We can't
+        // assign to a DOMRect's left/top, so allocate a fresh DOMRect.
+        const { scrollLeft, scrollTop } = scrollContainer
+        return new DOMRect(rect.left + scrollLeft, rect.top + scrollTop, rect.width, rect.height)
     } finally {
         el.style.transform = prev
     }

--- a/src/lib/utils/layout.ts
+++ b/src/lib/utils/layout.ts
@@ -17,7 +17,19 @@ import { animate, type AnimationOptions, type DOMKeyframesDefinition } from 'mot
  *
  * @param el Element to measure.
  * @param scrollContainers Optional ancestor chain with `layoutScroll` enabled.
- * @return DOMRect snapshot of the element.
+ * @returns DOMRect snapshot of the element.
+ *
+ * @example
+ * ```ts
+ * // No scroll containers — viewport-relative rect.
+ * const rect = measureRect(node)
+ *
+ * // Single ancestor scroll container (one `layoutScroll`).
+ * const rect = measureRect(node, [scrollPanel])
+ *
+ * // Nested `layoutScroll` ancestors — sums offsets from every container.
+ * const rect = measureRect(node, [innerScroll, outerScroll])
+ * ```
  */
 export const measureRect = (el: HTMLElement, scrollContainers?: HTMLElement[]): DOMRect => {
     const prev = el.style.transform

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -220,6 +220,22 @@
                         layoutId (shared layout)
                     </a>
                 </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/layout/scroll') + searchParams}
+                    >
+                        layoutScroll — single container
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/layout/nested-scroll') + searchParams}
+                    >
+                        layoutScroll — nested containers
+                    </a>
+                </li>
             </ul>
         </div>
         <div>

--- a/src/routes/tests/layout/nested-scroll/+page.svelte
+++ b/src/routes/tests/layout/nested-scroll/+page.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+    import { motion } from '$lib'
+
+    // Regression test for #353 — nested `layoutScroll` containers.
+    //
+    // Outer scroll container with `layoutScroll`. Inside it, an inner
+    // scroll container also with `layoutScroll`. Inside that, the
+    // animating `layout` motion.div.
+    //
+    // Click "Resize". While the box is animating, scroll the OUTER
+    // container. With the chain-walking fix, the FLIP delta cancels out
+    // the outer scroll (just like it already did for the inner). Without
+    // the fix, only the inner container's scroll was accounted for and
+    // the outer scroll showed up as drift.
+
+    let expanded = $state(false)
+    function toggle() {
+        expanded = !expanded
+    }
+</script>
+
+<svelte:head>
+    <title>nested layoutScroll · regression test</title>
+</svelte:head>
+
+<div class="page" data-testid="nested-layout-scroll-page">
+    <header>
+        <h1>Nested <code>layoutScroll</code> containers</h1>
+        <p>
+            An outer scroll container with <code>layoutScroll</code>, an inner one also with
+            <code>layoutScroll</code>, and a <code>layout</code> box inside.
+        </p>
+        <p>
+            Click <strong>Resize</strong> then scroll the <strong>outer</strong> container while the box
+            is animating. The box should stay anchored — both ancestors' scroll offsets are summed when
+            computing the FLIP delta.
+        </p>
+        <button data-testid="toggle" type="button" onclick={toggle}>
+            Resize box → {expanded ? 'shrink' : 'expand'}
+        </button>
+    </header>
+
+    <motion.div
+        layoutScroll
+        data-testid="outer"
+        style="overflow: auto; height: 380px; border: 2px solid #f59e0b; border-radius: 8px; background: #fff7ed; position: relative; margin-top: 16px;"
+    >
+        <div style="height: 80px; padding: 8px 12px; color: #92400e; font-size: 0.78rem;">
+            <strong>outer</strong> · <code>layoutScroll</code> · #f59e0b border
+        </div>
+        <motion.div
+            layoutScroll
+            data-testid="inner"
+            style="overflow: auto; height: 280px; margin: 0 16px; border: 2px solid #06b6d4; border-radius: 8px; background: #ecfeff; position: relative;"
+        >
+            <div style="height: 60px; padding: 8px 12px; color: #155e75; font-size: 0.78rem;">
+                <strong>inner</strong> · <code>layoutScroll</code> · #06b6d4 border
+            </div>
+            <motion.div
+                data-testid="box"
+                layout
+                transition={{ duration: 1.8, ease: 'easeInOut' }}
+                style="width: {expanded ? '220px' : '120px'}; height: {expanded
+                    ? '220px'
+                    : '120px'}; border-radius: 12px; background: linear-gradient(135deg,#8b5cf6 0%,#ec4899 100%); margin: 0 auto;"
+            ></motion.div>
+            <div style="height: 420px;"></div>
+        </motion.div>
+        <div style="height: 220px;"></div>
+    </motion.div>
+</div>
+
+<style>
+    .page {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 24px;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+    }
+    h1 {
+        font-size: 1.4rem;
+        margin: 0 0 0.5rem;
+    }
+    p {
+        color: #444;
+        line-height: 1.5;
+        margin: 0 0 0.5rem;
+    }
+    code {
+        font-family: ui-monospace, monospace;
+        font-size: 0.85em;
+        background: #f3f3f3;
+        padding: 0 4px;
+        border-radius: 3px;
+    }
+    button {
+        margin-top: 8px;
+        padding: 0.5rem 1rem;
+        background: #111;
+        color: #fff;
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+        font-weight: 600;
+    }
+</style>

--- a/src/routes/tests/layout/scroll/+page.svelte
+++ b/src/routes/tests/layout/scroll/+page.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+    import { motion } from '$lib'
+
+    // Regression test for the `layoutScroll` prop.
+    //
+    // Two side-by-side scroll containers, each with the same FLIP layout
+    // animation inside. The right one has `layoutScroll` on the container;
+    // the left one doesn't.
+    //
+    // Click "Resize" to grow the inner element. Then scroll either container
+    // mid-animation. The container without `layoutScroll` will drift (FLIP
+    // measures viewport-relative rects, so the scroll offset shows up as
+    // extra movement). The container with `layoutScroll` stays anchored —
+    // measurements happen in the container's coordinate space.
+    //
+    // Playwright e2e drives this exact scenario.
+
+    let expanded = $state(false)
+    function toggle() {
+        expanded = !expanded
+    }
+
+    let sizeRest = '120px'
+    let sizeExpanded = '240px'
+</script>
+
+<svelte:head>
+    <title>layout + layoutScroll · regression test</title>
+</svelte:head>
+
+<div class="page" data-testid="layout-scroll-page">
+    <header>
+        <h1>
+            <code>layout</code> +
+            <code>layoutScroll</code> regression test
+        </h1>
+        <p>
+            Each panel is an <code>overflow: auto</code> scroll container with the same FLIP
+            animation inside. The right panel has <code>layoutScroll</code> on the container; the left
+            does not.
+        </p>
+        <p>
+            Click <strong>Resize box</strong> to fire a layout animation. During the animation, scroll
+            either panel — the left one drifts, the right one stays anchored.
+        </p>
+        <button data-testid="toggle" type="button" onclick={toggle}>
+            Resize box → {expanded ? 'shrink' : 'expand'}
+        </button>
+    </header>
+
+    <section class="panels">
+        <article class="panel">
+            <h2>
+                without <code>layoutScroll</code>
+                <span class="bad">drifts on scroll</span>
+            </h2>
+            <div class="scroll" data-testid="scroll-without">
+                <div class="pad-top"></div>
+                <motion.div
+                    data-testid="box-without"
+                    layout
+                    transition={{ type: 'spring', stiffness: 220, damping: 26 }}
+                    style="width: {expanded ? sizeExpanded : sizeRest}; height: {expanded
+                        ? sizeExpanded
+                        : sizeRest}; border-radius: 12px; background: linear-gradient(135deg,#ef4444 0%,#f97316 100%); margin: 0 auto;"
+                ></motion.div>
+                <div class="pad-bottom"></div>
+            </div>
+        </article>
+
+        <article class="panel">
+            <h2>
+                with <code>layoutScroll</code>
+                <span class="good">stays anchored</span>
+            </h2>
+            <motion.div
+                layoutScroll
+                data-testid="scroll-with"
+                style="overflow: auto; height: 320px; border: 1px solid #bbb; border-radius: 8px; background: #fafafa; position: relative;"
+            >
+                <div class="pad-top"></div>
+                <motion.div
+                    data-testid="box-with"
+                    layout
+                    transition={{ type: 'spring', stiffness: 220, damping: 26 }}
+                    style="width: {expanded ? sizeExpanded : sizeRest}; height: {expanded
+                        ? sizeExpanded
+                        : sizeRest}; border-radius: 12px; background: linear-gradient(135deg,#22c55e 0%,#06b6d4 100%); margin: 0 auto;"
+                ></motion.div>
+                <div class="pad-bottom"></div>
+            </motion.div>
+        </article>
+    </section>
+</div>
+
+<style>
+    .page {
+        max-width: 920px;
+        margin: 0 auto;
+        padding: 24px;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+    }
+    header {
+        margin-bottom: 16px;
+    }
+    h1 {
+        font-size: 1.4rem;
+        margin: 0 0 0.5rem;
+    }
+    p {
+        color: #444;
+        line-height: 1.5;
+        margin: 0 0 0.5rem;
+    }
+    code {
+        font-family: ui-monospace, monospace;
+        font-size: 0.85em;
+        background: #f3f3f3;
+        padding: 0 4px;
+        border-radius: 3px;
+    }
+    button {
+        margin-top: 8px;
+        padding: 0.5rem 1rem;
+        background: #111;
+        color: #fff;
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+        font-weight: 600;
+    }
+    .panels {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+        margin-top: 16px;
+    }
+    .panel h2 {
+        font-size: 1rem;
+        margin: 0 0 0.5rem;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+    .panel h2 span {
+        font-size: 0.72rem;
+        font-weight: 400;
+        padding: 2px 6px;
+        border-radius: 4px;
+    }
+    .bad {
+        color: #b91c1c;
+        background: #fee2e2;
+    }
+    .good {
+        color: #047857;
+        background: #d1fae5;
+    }
+    .scroll {
+        overflow: auto;
+        height: 320px;
+        border: 1px solid #bbb;
+        border-radius: 8px;
+        background: #fafafa;
+        position: relative;
+    }
+    .pad-top {
+        height: 360px;
+        background: linear-gradient(to bottom, #f3f3f3, transparent);
+    }
+    .pad-bottom {
+        height: 360px;
+        background: linear-gradient(to top, #f3f3f3, transparent);
+    }
+</style>

--- a/src/routes/tests/layout/scroll/+page.svelte
+++ b/src/routes/tests/layout/scroll/+page.svelte
@@ -20,8 +20,14 @@
         expanded = !expanded
     }
 
-    let sizeRest = '120px'
-    let sizeExpanded = '240px'
+    const sizeRest = '120px'
+    const sizeExpanded = '240px'
+
+    // Svelte's scope hash is added to native elements but not to `motion.*`
+    // components, so a shared `.scroll` class wouldn't apply to both
+    // panels. Inline the style on both panels for parity instead.
+    const scrollPanelStyle =
+        'overflow: auto; height: 320px; border: 1px solid #bbb; border-radius: 8px; background: #fafafa; position: relative;'
 </script>
 
 <svelte:head>
@@ -54,7 +60,7 @@
                 without <code>layoutScroll</code>
                 <span class="bad">drifts on scroll</span>
             </h2>
-            <div class="scroll" data-testid="scroll-without">
+            <div style={scrollPanelStyle} data-testid="scroll-without">
                 <div class="pad-top"></div>
                 <motion.div
                     data-testid="box-without"
@@ -73,11 +79,7 @@
                 with <code>layoutScroll</code>
                 <span class="good">stays anchored</span>
             </h2>
-            <motion.div
-                layoutScroll
-                data-testid="scroll-with"
-                style="overflow: auto; height: 320px; border: 1px solid #bbb; border-radius: 8px; background: #fafafa; position: relative;"
-            >
+            <motion.div layoutScroll data-testid="scroll-with" style={scrollPanelStyle}>
                 <div class="pad-top"></div>
                 <motion.div
                     data-testid="box-with"
@@ -155,14 +157,6 @@
     .good {
         color: #047857;
         background: #d1fae5;
-    }
-    .scroll {
-        overflow: auto;
-        height: 320px;
-        border: 1px solid #bbb;
-        border-radius: 8px;
-        background: #fafafa;
-        position: relative;
     }
     .pad-top {
         height: 360px;


### PR DESCRIPTION
## Summary

Add framer-motion's **`layoutScroll`** prop. Mark a `motion.*` element as a
scroll container with `layoutScroll` so descendant `layout` animations
measure rects in that container's coordinate space. Without it, scrolling
the container mid-animation makes FLIP measurements read the
viewport-relative offset as movement and the animation visibly drifts.

```svelte
<motion.div layoutScroll style="overflow: auto; height: 320px;">
  <motion.div layout>resize me, then scroll the container</motion.div>
</motion.div>
```

**Closes #313** (layoutScroll prop) and **closes #353** (nested-ancestor
chain). Top of the layout-animation cluster pitched as the next parity
push — `LayoutGroup` (#311), `layoutDependency` (#314), and `layoutRoot`
(#315) will follow in their own PRs.

## Why this matters

motion.dev calls its layout-animation engine "industry-leading" on the
home page. Inside scroll containers — dropdowns, modals, virtualised
lists, anything with `overflow: auto` — our layout animations drifted
because FLIP measured viewport-relative rects. Now they don't, and
nested scroll containers stack correctly too.

## Changes

✨ **Feature**
- `src/lib/types.ts` — new `layoutScroll?: boolean` on `MotionProps` with JSDoc
- `src/lib/components/layoutScroll.context.ts` (new) — publish/consume a deferred element-ref chain via Svelte context. The thunk pattern is required because the parent's `element` ref binds after mount but descendants need to find it at measure-time. The ref returns `Array<HTMLElement | null | undefined>` so nested `layoutScroll` ancestors stack (matches framer-motion's `removeElementScroll` walking `this.path`).
- `src/lib/utils/layout.ts` — `measureRect(el, scrollContainers?: HTMLElement[])` sums `scrollLeft` / `scrollTop` from every container provided. Empty / absent = viewport-relative (unchanged behaviour). FLIP deltas across two such measurements stay zero when only scroll changes.
- `src/lib/html/_MotionContainer.svelte` — captures ancestor chain at init (BEFORE shadowing the context with its own), publishes `[...ancestorChain, ownElement]` lazily, threads the resolved array through all four `measureRect` call sites.

🧪 **Coverage**
- `src/lib/utils/layout.spec.ts` — 5 new unit tests covering: ignored when absent, ignored when empty array, single-container offset, multi-container sum, zero-delta when only scroll changes (single + nested). 379/379 total tests pass.
- `src/routes/tests/layout/scroll/+page.svelte` (new) — side-by-side single-container regression page, with/without `layoutScroll`.
- `src/routes/tests/layout/nested-scroll/+page.svelte` (new) — nested-container regression page (orange outer with `layoutScroll`, cyan inner with `layoutScroll`, animating purple box). Outer-scroll-mid-animation is the assertion that this PR fixes.
- `e2e/layout/scroll.spec.ts` (new, 2 tests) + `e2e/layout/nested-scroll.spec.ts` (new, 2 tests) — playwright drives both regression routes, asserts no residual transform after the spring settles, smoke-tests page structure.
- `src/routes/+page.svelte` — both regression routes linked from the **Layout** section of the dev-time demo index so they're discoverable next to `layoutId`.

📚 **Docs**
- `docs/src/routes/docs/layout-animations/+page.svx` — new section explaining when to use `layoutScroll`, with code example + props table, and a note that nested `layoutScroll` ancestors stack.
- `docs/src/lib/examples/LayoutScrollExample.svelte` (new) — polished side-by-side demo. 1.8 s easeInOut tween (originally a 0.3 s spring, way too fast to interact with) so users can actually drag the scrollbar mid-animation and see the difference. Numbered 3-step instructions below the panels.
- `docs/src/routes/examples/layout-scroll/+page.svelte` (new) — example route surfacing the demo
- `docs/src/routes/examples/+page.ts` — index entry
- `docs/static/llms-full.txt` — documents `layoutScroll` for AI consumers, including nested-ancestor support

🔧 **Cleanup (simplify pass)**
- `layoutScroll.context.ts`: trimmed a narrative comment that was explaining mechanics rather than intent
- `tests/layout/scroll/+page.svelte`: the left panel used a scoped `.scroll` class while the right used identical inline styles (Svelte's scope hash doesn't apply to `motion.*` components). Hoisted to a shared `scrollPanelStyle` const used by both — single source of truth, no scoped-CSS gotcha.
- e2e specs: replaced conditional `if (drift !== undefined) expect(...).toBeLessThan(1)` with `Number(... ?? '0')` so the assertion always runs and never silently skips on an empty transform string.

## Audit vs upstream

After implementing, audited against `~/Github/motion/packages/motion-dom/src/projection/node/create-projection-node.ts` (`removeElementScroll`, `applyTransform`). For the **common case (any number of `layoutScroll` ancestors)**, our math is functionally identical — both add scroll offset during measurement to cancel out scroll between two measurements.

**Pre-existing gaps this PR does not address** (out of scope, noted for the future):
- `scroll.wasRoot` semantics: framer-motion distinguishes a "scroll root" from inner scroll containers (handles document/window scroll explicitly). We don't.
- Phase-cached snapshots: framer-motion stores scroll offsets per animation phase so they're stable across one layout cycle. We read on demand at every `measureRect` call. Benign for our use case but less efficient at scale.
- Window/document-scroll handling for non-`layoutScroll` ancestors.

Each belongs to a future projection-tree port, not this PR.

## Commits

- [`fc4ee64`](https://github.com/humanspeak/svelte-motion/commit/fc4ee64) feat(layout): add layoutScroll prop for FLIP inside scroll containers
- [`30d49b0`](https://github.com/humanspeak/svelte-motion/commit/30d49b0) docs(layout-scroll): slow tween + clearer numbered instructions
- [`a9afe4d`](https://github.com/humanspeak/svelte-motion/commit/a9afe4d) fix(layout): layoutScroll walks the ancestor chain, not just the nearest
- [`281ed61`](https://github.com/humanspeak/svelte-motion/commit/281ed61) docs(tests): link layoutScroll regression routes from root demo index
- [`8cb8c1d`](https://github.com/humanspeak/svelte-motion/commit/8cb8c1d) refactor(layout): /simplify pass on layoutScroll

## Test plan

- [x] `pnpm test:only` — 379/379 green (+5 new layout cases)
- [x] `pnpm exec svelte-check` — 0 errors
- [x] `pnpm exec playwright test e2e/layout/` — 4/4 green
- [x] Manual: `/tests/layout/scroll` regression page works — left drifts, right anchored
- [x] Manual: `/tests/layout/nested-scroll` regression page works — outer-scroll mid-animation is cancelled by FLIP delta when both ancestors have `layoutScroll`
- [x] Manual: `/examples/layout-scroll` polished demo renders + animates correctly in light and dark
- [x] Audited implementation against framer-motion's `removeElementScroll` — matches behaviour for all `layoutScroll` ancestor cases

Closes #313
Closes #353
