### PR TITLE
feat(variants): variant string keys + arrays on whileX props (#349)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,18 @@ npm install @humanspeak/svelte-motion
 
 Goal: Framer Motion API parity for Svelte where common React examples can be translated with minimal changes.
 
-| Capability                                                     | Status                                     |
-| -------------------------------------------------------------- | ------------------------------------------ |
-| `initial` / `animate` / `transition`                           | Supported                                  |
-| `variants` (string keys + inheritance, function-form `custom`) | Supported                                  |
-| `whileHover` / `whileTap` / `whileFocus` / `whileInView`       | Supported (inline + variant keys / arrays) |
-| Drag (`drag`, constraints, momentum, controls, callbacks)      | Supported                                  |
-| `AnimatePresence` (`initial`, `mode`, `onExitComplete`)        | Supported                                  |
-| Layout (`layout`, `layout="position"`)                         | Supported (single-element FLIP)            |
-| Shared layout (`layoutId`, `LayoutGroup`, `layoutScroll`)      | Supported                                  |
-| Pan gesture API (`whilePan`, `onPan*`)                         | Not yet supported                          |
-| `MotionConfig` parity beyond `transition`                      | Partial                                    |
-| `reducedMotion`, `features`, `transformPagePoint`              | Not yet supported                          |
+| Capability                                                             | Status                                     |
+| ---------------------------------------------------------------------- | ------------------------------------------ |
+| `initial` / `animate` / `transition`                                   | Supported                                  |
+| `variants` (string keys + inheritance, function-form `custom`)         | Supported                                  |
+| `whileHover` / `whileTap` / `whileFocus` / `whileDrag` / `whileInView` | Supported (inline + variant keys / arrays) |
+| Drag (`drag`, constraints, momentum, controls, callbacks)              | Supported                                  |
+| `AnimatePresence` (`initial`, `mode`, `onExitComplete`)                | Supported                                  |
+| Layout (`layout`, `layout="position"`)                                 | Supported (single-element FLIP)            |
+| Shared layout (`layoutId`, `LayoutGroup`, `layoutScroll`)              | Supported                                  |
+| Pan gesture API (`whilePan`, `onPan*`)                                 | Not yet supported                          |
+| `MotionConfig` parity beyond `transition`                              | Partial                                    |
+| `reducedMotion`, `features`, `transformPagePoint`                      | Not yet supported                          |
 
 ## Supported elements
 

--- a/README.md
+++ b/README.md
@@ -36,18 +36,18 @@ npm install @humanspeak/svelte-motion
 
 Goal: Framer Motion API parity for Svelte where common React examples can be translated with minimal changes.
 
-| Capability                                                | Status                          |
-| --------------------------------------------------------- | ------------------------------- |
-| `initial` / `animate` / `transition`                      | Supported                       |
-| `variants` (string keys + inheritance)                    | Supported                       |
-| `whileHover` / `whileTap` / `whileFocus` / `whileInView`  | Supported                       |
-| Drag (`drag`, constraints, momentum, controls, callbacks) | Supported                       |
-| `AnimatePresence` (`initial`, `mode`, `onExitComplete`)   | Supported                       |
-| Layout (`layout`, `layout="position"`)                    | Supported (single-element FLIP) |
-| Shared layout (`layoutId`, `LayoutGroup`, `layoutScroll`) | Supported                       |
-| Pan gesture API (`whilePan`, `onPan*`)                    | Not yet supported               |
-| `MotionConfig` parity beyond `transition`                 | Partial                         |
-| `reducedMotion`, `features`, `transformPagePoint`         | Not yet supported               |
+| Capability                                                     | Status                                     |
+| -------------------------------------------------------------- | ------------------------------------------ |
+| `initial` / `animate` / `transition`                           | Supported                                  |
+| `variants` (string keys + inheritance, function-form `custom`) | Supported                                  |
+| `whileHover` / `whileTap` / `whileFocus` / `whileInView`       | Supported (inline + variant keys / arrays) |
+| Drag (`drag`, constraints, momentum, controls, callbacks)      | Supported                                  |
+| `AnimatePresence` (`initial`, `mode`, `onExitComplete`)        | Supported                                  |
+| Layout (`layout`, `layout="position"`)                         | Supported (single-element FLIP)            |
+| Shared layout (`layoutId`, `LayoutGroup`, `layoutScroll`)      | Supported                                  |
+| Pan gesture API (`whilePan`, `onPan*`)                         | Not yet supported                          |
+| `MotionConfig` parity beyond `transition`                      | Partial                                    |
+| `reducedMotion`, `features`, `transformPagePoint`              | Not yet supported                          |
 
 ## Supported elements
 

--- a/docs/src/lib/examples/VariantsWhileHoverExample.svelte
+++ b/docs/src/lib/examples/VariantsWhileHoverExample.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+    import { motion, styleString } from '@humanspeak/svelte-motion'
+
+    // Live demo of #349 — variant string keys on `whileX` props.
+    // The left card uses an inline keyframes object, the right card
+    // pulls from the same `variants` map via `whileHover="hovered"`.
+    // Both produce the same visual result; the variant-key form lets
+    // you reuse the same named state across `animate`, `whileHover`,
+    // and friends.
+
+    const cardVariants = {
+        hovered: { scale: 1.06, boxShadow: '0 12px 24px -8px rgba(0,0,0,0.25)' },
+        pressed: { scale: 0.96 }
+    }
+
+    const baseCard = styleString(() => ({
+        width: '180px',
+        height: '120px',
+        borderRadius: 16,
+        padding: '1rem',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        background: 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)',
+        color: '#fff',
+        fontWeight: 600,
+        fontSize: '0.95rem',
+        cursor: 'pointer'
+    }))
+</script>
+
+<div
+    style={styleString(() => ({
+        display: 'flex',
+        gap: '1.25rem',
+        padding: '1.5rem',
+        background: 'var(--color-background-secondary)',
+        borderRadius: 8,
+        flexWrap: 'wrap',
+        justifyContent: 'center'
+    }))}
+>
+    <article>
+        <header style="font-size: 0.78rem; opacity: 0.7; margin-bottom: 0.5rem;">
+            inline form
+        </header>
+        <motion.div
+            whileHover={{ scale: 1.06, boxShadow: '0 12px 24px -8px rgba(0,0,0,0.25)' }}
+            whileTap={{ scale: 0.96 }}
+            style={baseCard}
+        >
+            <span>hover me</span>
+            <small style="opacity: 0.75; font-weight: 400;"
+                >whileHover=&#123;&#123; ... &#125;&#125;</small
+            >
+        </motion.div>
+    </article>
+
+    <article>
+        <header style="font-size: 0.78rem; opacity: 0.7; margin-bottom: 0.5rem;">
+            variant key
+        </header>
+        <motion.div
+            variants={cardVariants}
+            whileHover="hovered"
+            whileTap="pressed"
+            style={baseCard}
+        >
+            <span>hover me</span>
+            <small style="opacity: 0.75; font-weight: 400;">whileHover="hovered"</small>
+        </motion.div>
+    </article>
+</div>

--- a/docs/src/routes/docs/variants/+page.svx
+++ b/docs/src/routes/docs/variants/+page.svx
@@ -331,9 +331,10 @@ A `Variants` object is a dictionary mapping variant names (strings) to animation
 Variants can be passed to any motion component via the `variants` prop:
 
 - `variants`: Object containing named animation states
-- `initial`: Initial variant name (string)
-- `animate`: Target variant name (string)
-- `exit`: Exit variant name (string)
+- `initial`: Initial variant name (string or `string[]`)
+- `animate`: Target variant name (string or `string[]`)
+- `exit`: Exit variant name (string or `string[]`)
+- `whileHover` / `whileTap` / `whileFocus` / `whileDrag` / `whileInView`: variant name (string or `string[]`)
 
 ```svelte
 <motion.div
@@ -343,6 +344,36 @@ Variants can be passed to any motion component via the `variants` prop:
     exit="hidden"
 />
 ```
+
+### Variant keys on gesture props
+
+Pass a variant name to any `whileX` prop to reuse a named state across gestures — handy when the same animation target shows up in multiple places (a single `hover` variant can drive `whileHover` on every card in a list, for example).
+
+```svelte
+<script lang="ts">
+    import { motion, type Variants } from '@humanspeak/svelte-motion'
+
+    const cardVariants: Variants = {
+        hovered: { scale: 1.05 },
+        pressed: { scale: 0.95 }
+    }
+</script>
+
+<motion.div variants={cardVariants} whileHover="hovered" whileTap="pressed">
+    hover or tap
+</motion.div>
+```
+
+You can also pass an **array of variant keys** to combine multiple states. The keys merge left-to-right — later entries override earlier ones on key collisions.
+
+```svelte
+<motion.div
+    variants={cardVariants}
+    whileHover={["hovered", "tinted"]}
+/>
+```
+
+If a key is missing from `variants`, it's silently skipped — useful for conditional layering.
 
 ## Related
 

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -141,6 +141,11 @@ const EXAMPLES: Record<string, ExampleEntry> = {
         description:
             'Per-instance variants — function-form factories receive the custom prop, driving staggered index-based delays.'
     },
+    'variants-while-hover': {
+        title: 'Variants on whileHover',
+        description:
+            'Pass a variant key (or array) to whileHover, whileTap, whileFocus, whileDrag, or whileInView to reuse named states across gestures.'
+    },
     'variants-propagation': {
         title: 'Variants Propagation',
         description: 'Interactive variants propagation animation example using Svelte Motion.'

--- a/docs/src/routes/examples/variants-while-hover/+page.svelte
+++ b/docs/src/routes/examples/variants-while-hover/+page.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import Example from '$lib/components/general/Example.svelte'
+    import VariantsWhileHoverExample from '$lib/examples/VariantsWhileHoverExample.svelte'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'whileHover variant keys' }
+        ]
+    }
+    if (seo) {
+        seo.title =
+            'whileHover variant keys — reuse variants across gestures | Examples | Svelte Motion'
+        seo.description =
+            'Pass a variant key (or array) to whileHover, whileTap, whileFocus, whileDrag, or whileInView to reuse named animation states across gestures.'
+        seo.ogTitle = 'whileHover variant keys'
+        seo.ogTagline = 'Reuse named variants across gesture props'
+        seo.ogFeatures = ['Variants', 'whileHover', 'whileTap', 'String keys']
+        seo.ogSlug = 'examples-variants-while-hover'
+    }
+</script>
+
+<Example
+    title="whileX variant keys — reuse variants across gestures"
+    file="VariantsWhileHoverExample.svelte"
+>
+    <VariantsWhileHoverExample />
+</Example>

--- a/docs/static/llms-full.txt
+++ b/docs/static/llms-full.txt
@@ -257,6 +257,29 @@ Named animation states with parent-child propagation.
 
 - Variant strings passed to `animate` propagate to children through context
 - Children inherit the parent's active variant key automatically
+- `initial`, `animate`, `exit`, `whileHover`, `whileTap`, `whileFocus`, `whileDrag`, and `whileInView` all accept a single variant key string or an array of keys (later entries override earlier ones on key collisions)
+
+### Variant keys on gesture props
+
+Reuse a named variant across gestures by passing the key directly:
+
+```svelte
+<script lang="ts">
+    import { motion, type Variants } from '@humanspeak/svelte-motion'
+
+    const card: Variants = {
+        hovered: { scale: 1.05 },
+        pressed: { scale: 0.95 },
+        tinted: { backgroundColor: '#22c55e' }
+    }
+</script>
+
+<!-- Single key -->
+<motion.div variants={card} whileHover="hovered" whileTap="pressed" />
+
+<!-- Array — left-to-right merge, later wins on collisions -->
+<motion.div variants={card} whileHover={['hovered', 'tinted']} />
+```
 
 ### Dynamic (function-form) variants + `custom` prop
 

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -40,7 +40,7 @@ npm install @humanspeak/svelte-motion
 - **`AnimatePresence`** for mount/unmount exit animations with `mode="sync" | "wait" | "popLayout"`.
 - **Gestures**: `whileHover`, `whileTap`, `whileFocus`, `whileInView`.
 - **Drag**: full drag gesture API with constraints, momentum, elastic, snap-to-origin, axis lock, and `createDragControls()` for imperative control.
-- **Variants**: named animation states with parent-child propagation. Function-form variants `(custom) => keyframes` receive the `custom` prop for per-instance values (staggered lists, indexed offsets).
+- **Variants**: named animation states with parent-child propagation. Function-form variants `(custom) => keyframes` receive the `custom` prop for per-instance values (staggered lists, indexed offsets). `initial` / `animate` / `exit` / `whileHover` / `whileTap` / `whileFocus` / `whileDrag` / `whileInView` accept variant key strings or arrays of keys (later overrides earlier).
 - **Layout animation**: FLIP-based `layout` and `layout="position"` props.
 - **Shared layout**: `layoutId` for animating between elements across the DOM. Wrap regions in `<LayoutGroup id>` to scope shared-layout animations to a subtree so identical `layoutId` values in sibling regions don't cross-animate. Mark scroll containers with `layoutScroll` to keep FLIP measurements anchored when the user scrolls mid-animation.
 - **Spring physics**: `useSpring` for natural motion.

--- a/e2e/motion/while-string-variants.spec.ts
+++ b/e2e/motion/while-string-variants.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test, type Locator } from '@playwright/test'
+
+/**
+ * Regression test for #349 — variant string keys on `whileX` props.
+ *
+ * Asserts that a `whileHover="variantKey"` form scales identically to
+ * an inline `whileHover={{ scale: 1.25 }}` form, and that the array
+ * form (`whileHover={["hovered", "tinted"]}`) merges variants
+ * left-to-right with later entries winning on key collisions
+ * (`backgroundColor` from `tinted` overrides `hovered`'s absence of
+ * one).
+ */
+test.describe('motion/while-string-variants', () => {
+    /** Read uniform scale from the computed transform matrix. */
+    const readScale = async (el: Locator) => {
+        const t = await el.evaluate((node) => getComputedStyle(node as HTMLElement).transform)
+        if (!t || t === 'none') return 1
+        const m = t.match(/matrix\(([^)]+)\)/)
+        if (!m) return 1
+        const parts = m[1].split(',').map((v) => Number.parseFloat(v.trim()))
+        const a = parts[0] ?? 1
+        const b = parts[1] ?? 0
+        const c = parts[2] ?? 0
+        const d = parts[3] ?? 1
+        return (Math.hypot(a, b) + Math.hypot(c, d)) / 2
+    }
+
+    test('whileHover with a single variant key scales the element', async ({ page }) => {
+        await page.goto('/tests/motion/while-string-variants?@isPlaywright=true')
+
+        const box = page.getByTestId('box-while-hover-string')
+        await expect(box).toBeVisible()
+
+        // Identity transform at rest.
+        const initialScale = await readScale(box)
+        expect(Math.abs(initialScale - 1)).toBeLessThan(0.05)
+
+        await box.hover()
+        // Hover variant has scale: 1.25 — should clearly exceed 1.1.
+        await expect.poll(() => readScale(box)).toBeGreaterThan(1.1)
+    })
+
+    test('whileHover with an array merges variants left-to-right (later wins on color)', async ({
+        page
+    }) => {
+        await page.goto('/tests/motion/while-string-variants?@isPlaywright=true')
+
+        const box = page.getByTestId('box-while-hover-array')
+        await expect(box).toBeVisible()
+
+        // Initial background is the inline orange (`#f97316`). After
+        // hover, the array `["hovered", "tinted"]` should resolve so
+        // `tinted`'s `backgroundColor` ('#22c55e' — green) wins.
+        const initialBg = await box.evaluate(
+            (el) => getComputedStyle(el as HTMLElement).backgroundColor
+        )
+        expect(initialBg).not.toBe('rgb(34, 197, 94)') // not green yet
+
+        await box.hover()
+
+        await expect
+            .poll(async () =>
+                box.evaluate((el) => getComputedStyle(el as HTMLElement).backgroundColor)
+            )
+            .toBe('rgb(34, 197, 94)') // green from `tinted`
+
+        // And the `hovered` variant's scale still applies — array merge
+        // preserves keys from earlier entries when later entries don't
+        // override them.
+        await expect.poll(() => readScale(box)).toBeGreaterThan(1.1)
+    })
+})

--- a/src/lib/html/_MotionContainer.spec.ts
+++ b/src/lib/html/_MotionContainer.spec.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render } from '@testing-library/svelte'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock 'motion' before importing the Svelte component (hoisted)
 vi.mock('motion', () => {
@@ -28,6 +28,14 @@ beforeEach(() => {
         setTimeout(() => cb(0), 0)
         return 0 as unknown as number
     })
+})
+
+// Restore stubbed globals (e.g. `matchMedia` from whileHover tests)
+// here rather than at the bottom of each test body — if an assertion
+// throws mid-test, the per-test cleanup would be skipped and patched
+// globals would leak into later tests in this file.
+afterEach(() => {
+    vi.unstubAllGlobals()
 })
 
 async function flushTimers() {
@@ -158,8 +166,6 @@ describe('_MotionContainer', () => {
 
         const enterCall = animateMock.mock.calls.at(-1)
         expect(enterCall?.[1]).toMatchObject({ scale: 1.2 })
-
-        vi.unstubAllGlobals()
     })
 
     it('whileHover accepts an array of variant keys, merging later-wins (#349)', async () => {
@@ -205,8 +211,6 @@ describe('_MotionContainer', () => {
 
         const enterCall = animateMock.mock.calls.at(-1)
         expect(enterCall?.[1]).toMatchObject({ scale: 1.2, color: 'gray' })
-
-        vi.unstubAllGlobals()
     })
 
     it('whileHover with unknown variant key is treated as no-op (#349)', async () => {
@@ -247,7 +251,6 @@ describe('_MotionContainer', () => {
         await flushTimers()
 
         expect(animateMock.mock.calls.length).toBe(0)
-        vi.unstubAllGlobals()
     })
 
     it('re-runs animate when animate prop changes', async () => {
@@ -329,7 +332,6 @@ describe('_MotionContainer', () => {
         expect(el.style.transformOrigin).toBe('')
 
         rectSpy.mockRestore()
-        vi.unstubAllGlobals()
     })
 
     it('applies translate-only when layout="position" (no scale)', async () => {
@@ -382,7 +384,6 @@ describe('_MotionContainer', () => {
         expect(roInstances.length).toBeGreaterThan(0)
 
         rectSpy.mockRestore()
-        vi.unstubAllGlobals()
     })
 
     it('whileHover animates on enter/leave, uses nested transition, and fires callbacks', async () => {
@@ -439,8 +440,6 @@ describe('_MotionContainer', () => {
         expect(lastCall?.[1]).toMatchObject({ scale: 1.1 })
         expect(lastCall?.[2]).toMatchObject({ duration: 0.25 })
         expect(onHoverEnd).toHaveBeenCalledTimes(1)
-
-        vi.unstubAllGlobals()
     })
 
     it('passes own custom prop into a function-form variant on animate', async () => {

--- a/src/lib/html/_MotionContainer.spec.ts
+++ b/src/lib/html/_MotionContainer.spec.ts
@@ -117,6 +117,139 @@ describe('_MotionContainer', () => {
         expect(resetDef).toMatchObject({ scale: 1.1, backgroundColor: '#000' })
     })
 
+    it('whileHover accepts a variant key string and resolves it against `variants` (#349)', async () => {
+        // Enable true-hover environment so the whileHover effect attaches.
+        vi.stubGlobal('matchMedia', ((query: string) => {
+            const matches = query.includes('(hover: hover)') || query.includes('(pointer: fine)')
+            return {
+                matches,
+                media: query,
+                onchange: null,
+                addEventListener() {},
+                removeEventListener() {},
+                addListener() {},
+                removeListener() {},
+                dispatchEvent() {
+                    return false
+                }
+            } as unknown as MediaQueryList
+        }) as unknown as typeof window.matchMedia)
+
+        const variants = { hover: { scale: 1.2 } }
+
+        /* trunk-ignore(eslint/@typescript-eslint/no-explicit-any) */
+        const { container } = render(MotionContainer as unknown as any, {
+            props: {
+                tag: 'div',
+                initial: { scale: 1 },
+                animate: { scale: 1.1 },
+                variants,
+                whileHover: 'hover'
+            }
+        })
+
+        await flushTimers()
+        const el = container.firstElementChild as HTMLElement
+
+        // Enter: the resolved variant ('hover' → { scale: 1.2 }) should
+        // flow into the animate call exactly as if it were inline.
+        await fireEvent.pointerEnter(el)
+        await flushTimers()
+
+        const enterCall = animateMock.mock.calls.at(-1)
+        expect(enterCall?.[1]).toMatchObject({ scale: 1.2 })
+
+        vi.unstubAllGlobals()
+    })
+
+    it('whileHover accepts an array of variant keys, merging later-wins (#349)', async () => {
+        vi.stubGlobal('matchMedia', ((query: string) => {
+            const matches = query.includes('(hover: hover)') || query.includes('(pointer: fine)')
+            return {
+                matches,
+                media: query,
+                onchange: null,
+                addEventListener() {},
+                removeEventListener() {},
+                addListener() {},
+                removeListener() {},
+                dispatchEvent() {
+                    return false
+                }
+            } as unknown as MediaQueryList
+        }) as unknown as typeof window.matchMedia)
+
+        // Two variants colliding on `color` — `muted` is later in the
+        // array, so its color wins. `hover`'s `scale` is preserved.
+        const variants = {
+            hover: { scale: 1.2, color: 'red' },
+            muted: { color: 'gray' }
+        }
+
+        /* trunk-ignore(eslint/@typescript-eslint/no-explicit-any) */
+        const { container } = render(MotionContainer as unknown as any, {
+            props: {
+                tag: 'div',
+                initial: { scale: 1, color: 'black' },
+                animate: { scale: 1 },
+                variants,
+                whileHover: ['hover', 'muted']
+            }
+        })
+
+        await flushTimers()
+        const el = container.firstElementChild as HTMLElement
+
+        await fireEvent.pointerEnter(el)
+        await flushTimers()
+
+        const enterCall = animateMock.mock.calls.at(-1)
+        expect(enterCall?.[1]).toMatchObject({ scale: 1.2, color: 'gray' })
+
+        vi.unstubAllGlobals()
+    })
+
+    it('whileHover with unknown variant key is treated as no-op (#349)', async () => {
+        // String key that misses against `variants` → resolver returns
+        // undefined → `isNotEmpty` gate skips attach. The hover path
+        // never installs listeners, so no animate call follows
+        // pointerEnter.
+        vi.stubGlobal('matchMedia', ((query: string) => {
+            const matches = query.includes('(hover: hover)') || query.includes('(pointer: fine)')
+            return {
+                matches,
+                media: query,
+                onchange: null,
+                addEventListener() {},
+                removeEventListener() {},
+                addListener() {},
+                removeListener() {},
+                dispatchEvent() {
+                    return false
+                }
+            } as unknown as MediaQueryList
+        }) as unknown as typeof window.matchMedia)
+
+        /* trunk-ignore(eslint/@typescript-eslint/no-explicit-any) */
+        const { container } = render(MotionContainer as unknown as any, {
+            props: {
+                tag: 'div',
+                variants: { hover: { scale: 1.2 } },
+                whileHover: 'missing'
+            }
+        })
+
+        await flushTimers()
+        const el = container.firstElementChild as HTMLElement
+        animateMock.mockClear()
+
+        await fireEvent.pointerEnter(el)
+        await flushTimers()
+
+        expect(animateMock.mock.calls.length).toBe(0)
+        vi.unstubAllGlobals()
+    })
+
     it('re-runs animate when animate prop changes', async () => {
         /* trunk-ignore(eslint/@typescript-eslint/no-explicit-any) */
         const result = render(MotionContainer as unknown as any, {

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -48,7 +48,7 @@
     } from '$lib/utils/presence'
     import { getInitialKeyframes } from '$lib/utils/initial'
     import { attachDrag } from '$lib/utils/drag'
-    import { resolveInitial, resolveAnimate, resolveExit } from '$lib/utils/variants'
+    import { resolveInitial, resolveAnimate, resolveExit, resolveWhile } from '$lib/utils/variants'
     import {
         setVariantContext,
         getVariantContext,
@@ -446,6 +446,19 @@
     )
     const resolvedExit = $derived(resolveExit(exitProp, variantsProp, effectiveCustom))
 
+    // Resolve `whileX` props against `variants` so each gesture's attach
+    // helper receives a plain keyframes object regardless of whether the
+    // consumer wrote inline keyframes, a variant key, or an array of
+    // variant keys. Mirrors framer-motion's `whileHover` etc. surface
+    // (#349).
+    const resolvedWhileTap = $derived(resolveWhile(whileTapProp, variantsProp, effectiveCustom))
+    const resolvedWhileHover = $derived(resolveWhile(whileHoverProp, variantsProp, effectiveCustom))
+    const resolvedWhileFocus = $derived(resolveWhile(whileFocusProp, variantsProp, effectiveCustom))
+    const resolvedWhileDrag = $derived(resolveWhile(whileDragProp, variantsProp, effectiveCustom))
+    const resolvedWhileInView = $derived(
+        resolveWhile(whileInViewProp, variantsProp, effectiveCustom)
+    )
+
     // Extract keyframes from resolved initial, handling initial={false}
     const initialKeyframes = $derived(
         filterReducedMotionKeyframes(
@@ -541,7 +554,7 @@
             directionLock: !!dragDirectionLockProp,
             listener: dragListenerProp !== false,
             controls,
-            whileDrag: whileDragProp as MotionWhileDrag,
+            whileDrag: resolvedWhileDrag as MotionWhileDrag,
             mergedTransition: (mergedTransition ?? {}) as AnimationOptions,
             callbacks: {
                 onStart: onDragStartProp as (e: PointerEvent, info: DragInfo) => void,
@@ -801,18 +814,18 @@
 
     // whileTap handling via motion-dom's press()
     $effect(() => {
-        if (!(element && isLoaded === 'ready' && isNotEmpty(whileTapProp))) return
+        if (!(element && isLoaded === 'ready' && isNotEmpty(resolvedWhileTap))) return
         return attachWhileTap(
             element!,
-            (whileTapProp ?? {}) as Record<string, unknown>,
+            (resolvedWhileTap ?? {}) as Record<string, unknown>,
             (resolvedInitial ?? {}) as Record<string, unknown>,
             (resolvedAnimate ?? {}) as Record<string, unknown>,
             {
                 onTapStart: onTapStartProp,
                 onTap: onTapProp,
                 onTapCancel: onTapCancelProp,
-                hoverDef: isNotEmpty(whileHoverProp ?? {})
-                    ? ((whileHoverProp ?? {}) as Record<string, unknown>)
+                hoverDef: isNotEmpty(resolvedWhileHover ?? {})
+                    ? ((resolvedWhileHover ?? {}) as Record<string, unknown>)
                     : undefined,
                 hoverFallbackTransition: (mergedTransition ?? {}) as AnimationOptions
             }
@@ -821,10 +834,10 @@
 
     // whileHover handling, gated to true-hover devices to avoid sticky states on touch
     $effect(() => {
-        if (!(element && isLoaded === 'ready' && isNotEmpty(whileHoverProp))) return
+        if (!(element && isLoaded === 'ready' && isNotEmpty(resolvedWhileHover))) return
         return attachWhileHover(
             element!,
-            (whileHoverProp ?? {}) as Record<string, unknown>,
+            (resolvedWhileHover ?? {}) as Record<string, unknown>,
             (mergedTransition ?? {}) as AnimationOptions,
             { onStart: onHoverStartProp, onEnd: onHoverEndProp },
             {
@@ -836,10 +849,10 @@
 
     // whileFocus handling for keyboard focus interactions
     $effect(() => {
-        if (!(element && isLoaded === 'ready' && isNotEmpty(whileFocusProp))) return
+        if (!(element && isLoaded === 'ready' && isNotEmpty(resolvedWhileFocus))) return
         return attachWhileFocus(
             element!,
-            (whileFocusProp ?? {}) as Record<string, unknown>,
+            (resolvedWhileFocus ?? {}) as Record<string, unknown>,
             (mergedTransition ?? {}) as AnimationOptions,
             { onStart: onFocusStartProp, onEnd: onFocusEndProp },
             {
@@ -851,10 +864,10 @@
 
     // whileInView handling for viewport intersection
     $effect(() => {
-        if (!(element && isLoaded === 'ready' && isNotEmpty(whileInViewProp))) return
+        if (!(element && isLoaded === 'ready' && isNotEmpty(resolvedWhileInView))) return
         return attachWhileInView(
             element!,
-            (whileInViewProp ?? {}) as Record<string, unknown>,
+            (resolvedWhileInView ?? {}) as Record<string, unknown>,
             (mergedTransition ?? {}) as AnimationOptions,
             {
                 onStart: onInViewStartProp,

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -470,7 +470,12 @@
     // Derived attributes to keep both branches in sync (focusability, data flags, style, class)
     const derivedAttrs = $derived<Record<string, unknown>>({
         ...(rest as Record<string, unknown>),
-        ...(whileTapProp &&
+        // Gate on the *resolved* whileTap, not the raw prop. With
+        // variant-label support a truthy-but-unresolved value (unknown
+        // key, empty array) would otherwise add `tabindex=0` for an
+        // element that never actually receives a tap gesture — an
+        // unintended tab stop. (#349 CR feedback)
+        ...(isNotEmpty(resolvedWhileTap) &&
         !isNativelyFocusable(tag, rest as Record<string, unknown>) &&
         ((rest as Record<string, unknown>)?.tabindex ??
             (rest as Record<string, unknown>)?.tabIndex ??

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -65,7 +65,7 @@ export type Variants = Record<string, Variant>
  * <motion.div variants={myVariants} initial="hidden" animate="visible" />
  * ```
  */
-export type MotionInitial = DOMKeyframesDefinition | string | false | undefined
+export type MotionInitial = DOMKeyframesDefinition | string | string[] | false | undefined
 
 /**
  * Target animation properties for a motion component.
@@ -81,7 +81,7 @@ export type MotionInitial = DOMKeyframesDefinition | string | false | undefined
  * <motion.div variants={myVariants} animate="visible" />
  * ```
  */
-export type MotionAnimate = DOMKeyframesDefinition | string | undefined
+export type MotionAnimate = DOMKeyframesDefinition | string | string[] | undefined
 
 /**
  * Exit animation properties for a motion component when unmounted.
@@ -101,6 +101,7 @@ export type MotionExit =
     | (Record<string, unknown> & { transition?: AnimationOptions })
     | DOMKeyframesDefinition
     | string
+    | string[]
     | undefined
 
 /**
@@ -123,59 +124,98 @@ export type MotionTransition = AnimationOptions | undefined
 
 /**
  * Animation properties for tap/click interactions.
+ *
+ * Accepts inline keyframes, a variant key, or an array of variant keys
+ * (later entries override earlier ones on key collisions).
+ *
  * @example
  * ```svelte
  * <motion.button whileTap={{ scale: 0.95 }} />
+ *
+ * <!-- Variant key -->
+ * <motion.button variants={{ pressed: { scale: 0.95 } }} whileTap="pressed" />
+ *
+ * <!-- Array — later wins on conflicts -->
+ * <motion.button whileTap={["pressed", "muted"]} />
  * ```
  */
-export type MotionWhileTap = DOMKeyframesDefinition | undefined
+export type MotionWhileTap =
+    | (Record<string, unknown> & { transition?: AnimationOptions })
+    | DOMKeyframesDefinition
+    | string
+    | string[]
+    | undefined
 
 /**
  * Animation properties for hover interactions.
+ *
+ * Accepts inline keyframes, a variant key, or an array of variant keys.
+ *
  * @example
  * ```svelte
  * <motion.div whileHover={{ scale: 1.05 }} />
+ *
+ * <!-- Variant key -->
+ * <motion.div variants={{ hover: { scale: 1.05 } }} whileHover="hover" />
  * ```
  */
 export type MotionWhileHover =
     | (Record<string, unknown> & { transition?: AnimationOptions })
     | DOMKeyframesDefinition
+    | string
+    | string[]
     | undefined
 
 /**
  * Animation properties for focus interactions.
+ *
+ * Accepts inline keyframes, a variant key, or an array of variant keys.
+ *
  * @example
  * ```svelte
  * <motion.button whileFocus={{ scale: 1.05 }} />
+ * <motion.button variants={{ active: { outline: '2px solid blue' } }} whileFocus="active" />
  * ```
  */
 export type MotionWhileFocus =
     | (Record<string, unknown> & { transition?: AnimationOptions })
     | DOMKeyframesDefinition
+    | string
+    | string[]
     | undefined
 
 /**
  * Animation properties for drag interactions.
  * When a drag gesture starts, the element animates to this state; when it ends,
  * it animates back to its baseline (from animate/initial), restoring only the changed keys.
+ *
+ * Accepts inline keyframes, a variant key, or an array of variant keys.
  */
 export type MotionWhileDrag =
     | (Record<string, unknown> & { transition?: AnimationOptions })
     | DOMKeyframesDefinition
+    | string
+    | string[]
     | undefined
 
 /**
  * Animation properties for in-view interactions.
  * When the element enters the viewport, it animates to this state; when it leaves,
  * it animates back to its baseline (from animate/initial), restoring only the changed keys.
+ *
+ * Accepts inline keyframes, a variant key, or an array of variant keys.
+ *
  * @example
  * ```svelte
  * <motion.div whileInView={{ opacity: 1, y: 0 }} />
+ * <motion.div variants={{ inView: { opacity: 1 } }} whileInView="inView" />
  * ```
  */
 export type MotionWhileInView =
     | (Record<string, unknown> & { transition?: AnimationOptions })
     | DOMKeyframesDefinition
+    | string
+    | string[]
     | undefined
 
 /**

--- a/src/lib/utils/variants.spec.ts
+++ b/src/lib/utils/variants.spec.ts
@@ -214,6 +214,46 @@ describe('utils/variants - resolveVariantList', () => {
             y: 20
         })
     })
+
+    it('rejects non-plain-object entries (arrays, class instances) from the merge', () => {
+        // A function-form variant could misbehave and return an array
+        // or class instance. Spreading those would corrupt the merge
+        // (array indices as keys, methods leaking in). Skip them.
+        class CustomShape {
+            constructor(public x: number) {}
+        }
+        // Cast to `Variants` — the `Variant` factory signature expects
+        // plain keyframes; we are deliberately misusing it to verify
+        // the runtime guard catches what TypeScript would normally
+        // forbid.
+        const variants = {
+            badArray: () => [1, 2, 3],
+            badInstance: () => new CustomShape(5),
+            good: { opacity: 1 }
+        } as unknown as Variants
+
+        // Arrays alone → undefined (nothing valid merged)
+        expect(resolveVariantList(variants, ['badArray'])).toBeUndefined()
+        // Class instances alone → undefined
+        expect(resolveVariantList(variants, ['badInstance'])).toBeUndefined()
+        // Mixed: the good entry still applies, bad entries skipped
+        expect(resolveVariantList(variants, ['badArray', 'good', 'badInstance'])).toEqual({
+            opacity: 1
+        })
+    })
+
+    it('accepts Object.create(null) entries from the merge (prototype === null)', () => {
+        // Sanity check: a function-form variant building keyframes via
+        // `Object.create(null)` is still a plain map. Don't reject it.
+        const variants = {
+            nullProto: () => {
+                const obj = Object.create(null)
+                obj.scale = 1.5
+                return obj
+            }
+        } as unknown as Variants
+        expect(resolveVariantList(variants, ['nullProto'])).toEqual({ scale: 1.5 })
+    })
 })
 
 describe('utils/variants - resolveWhile', () => {

--- a/src/lib/utils/variants.spec.ts
+++ b/src/lib/utils/variants.spec.ts
@@ -47,6 +47,19 @@ describe('utils/variants - resolveVariant', () => {
         }
         expect(resolveVariant(variants, 'visible', 0)).toEqual({ x: 0 })
     })
+
+    it('does not resolve inherited / prototype keys like "toString" or "constructor"', () => {
+        // Without the `hasOwnProperty` guard, `variants['toString']`
+        // would walk up to `Function.prototype.toString` and leak a
+        // function into the merge path — a real bug for users who name
+        // a variant after a built-in. (#349 CR)
+        const variants: Variants = { real: { opacity: 1 } }
+        expect(resolveVariant(variants, 'toString')).toBeUndefined()
+        expect(resolveVariant(variants, 'constructor')).toBeUndefined()
+        expect(resolveVariant(variants, 'hasOwnProperty')).toBeUndefined()
+        // The real key still resolves.
+        expect(resolveVariant(variants, 'real')).toEqual({ opacity: 1 })
+    })
 })
 
 describe('utils/variants - resolveInitial', () => {
@@ -73,6 +86,17 @@ describe('utils/variants - resolveInitial', () => {
         }
         expect(resolveInitial('hidden', variants, 2)).toEqual({ x: -200 })
     })
+
+    it('resolves an array-form initial via resolveVariantList (later wins)', () => {
+        const variants: Variants = {
+            hidden: { opacity: 0, scale: 0.5 },
+            small: { scale: 0.8 }
+        }
+        expect(resolveInitial(['hidden', 'small'], variants)).toEqual({
+            opacity: 0,
+            scale: 0.8
+        })
+    })
 })
 
 describe('utils/variants - resolveAnimate', () => {
@@ -94,6 +118,17 @@ describe('utils/variants - resolveAnimate', () => {
 
     it('returns undefined when animate is undefined', () => {
         expect(resolveAnimate(undefined, undefined)).toBeUndefined()
+    })
+
+    it('resolves an array-form animate via resolveVariantList (later wins)', () => {
+        const variants: Variants = {
+            visible: { opacity: 1, x: 0 },
+            shifted: { x: 100 }
+        }
+        expect(resolveAnimate(['visible', 'shifted'], variants)).toEqual({
+            opacity: 1,
+            x: 100
+        })
     })
 })
 

--- a/src/lib/utils/variants.spec.ts
+++ b/src/lib/utils/variants.spec.ts
@@ -1,6 +1,13 @@
 import type { Variants } from '$lib/types'
 import { describe, expect, it } from 'vitest'
-import { resolveAnimate, resolveExit, resolveInitial, resolveVariant } from './variants.js'
+import {
+    resolveAnimate,
+    resolveExit,
+    resolveInitial,
+    resolveVariant,
+    resolveVariantList,
+    resolveWhile
+} from './variants.js'
 
 describe('utils/variants - resolveVariant', () => {
     it('returns the static keyframes object for an object-form variant', () => {
@@ -110,5 +117,104 @@ describe('utils/variants - resolveExit', () => {
 
     it('returns undefined when exit is undefined', () => {
         expect(resolveExit(undefined, undefined)).toBeUndefined()
+    })
+
+    it('resolves an array of variant keys by merging keyframes left-to-right', () => {
+        const variants: Variants = {
+            hidden: { opacity: 0, scale: 0.5 },
+            small: { scale: 0.8 }
+        }
+        // `small` is later in the array → its `scale` wins; `opacity`
+        // from `hidden` is preserved.
+        expect(resolveExit(['hidden', 'small'], variants)).toEqual({
+            opacity: 0,
+            scale: 0.8
+        })
+    })
+})
+
+describe('utils/variants - resolveVariantList', () => {
+    it('returns undefined when keys is undefined', () => {
+        expect(resolveVariantList({ a: { x: 1 } }, undefined)).toBeUndefined()
+    })
+
+    it('returns undefined for an empty array', () => {
+        expect(resolveVariantList({ a: { x: 1 } }, [])).toBeUndefined()
+    })
+
+    it('delegates to resolveVariant for a single string', () => {
+        const variants: Variants = { hover: { scale: 1.1 } }
+        expect(resolveVariantList(variants, 'hover')).toEqual({ scale: 1.1 })
+    })
+
+    it('merges multiple variant keys left-to-right, later wins on collisions', () => {
+        const variants: Variants = {
+            hover: { scale: 1.1, color: 'blue' },
+            active: { scale: 1.2 }
+        }
+        expect(resolveVariantList(variants, ['hover', 'active'])).toEqual({
+            scale: 1.2,
+            color: 'blue'
+        })
+    })
+
+    it('skips missing keys without breaking the chain', () => {
+        const variants: Variants = { hover: { scale: 1.1 } }
+        expect(resolveVariantList(variants, ['missing', 'hover'])).toEqual({ scale: 1.1 })
+        expect(resolveVariantList(variants, ['hover', 'missing'])).toEqual({ scale: 1.1 })
+    })
+
+    it('returns undefined when every key in the array misses', () => {
+        const variants: Variants = { hover: { scale: 1.1 } }
+        expect(resolveVariantList(variants, ['none', 'missing'])).toBeUndefined()
+    })
+
+    it('forwards custom to function-form entries per-key', () => {
+        const variants: Variants = {
+            base: (i) => ({ x: (i as number) * 10 }) as never,
+            delta: (i) => ({ y: (i as number) * 5 }) as never
+        }
+        expect(resolveVariantList(variants, ['base', 'delta'], 4)).toEqual({
+            x: 40,
+            y: 20
+        })
+    })
+})
+
+describe('utils/variants - resolveWhile', () => {
+    it('passes through inline keyframes unchanged', () => {
+        expect(resolveWhile({ scale: 1.1 }, undefined)).toEqual({ scale: 1.1 })
+    })
+
+    it('resolves a single variant key', () => {
+        const variants: Variants = { hover: { scale: 1.05 } }
+        expect(resolveWhile('hover', variants)).toEqual({ scale: 1.05 })
+    })
+
+    it('resolves an array of variant keys with later-wins merging', () => {
+        const variants: Variants = {
+            hover: { scale: 1.1 },
+            active: { scale: 1.2, color: 'red' }
+        }
+        expect(resolveWhile(['hover', 'active'], variants)).toEqual({
+            scale: 1.2,
+            color: 'red'
+        })
+    })
+
+    it('returns undefined when value is undefined', () => {
+        expect(resolveWhile(undefined, undefined)).toBeUndefined()
+    })
+
+    it('returns undefined when the variant key misses', () => {
+        const variants: Variants = { hover: { scale: 1.1 } }
+        expect(resolveWhile('missing', variants)).toBeUndefined()
+    })
+
+    it('forwards custom to function-form variants', () => {
+        const variants: Variants = {
+            hover: (i) => ({ scale: 1 + (i as number) * 0.1 }) as never
+        }
+        expect(resolveWhile('hover', variants, 3)).toEqual({ scale: 1.3 })
     })
 })

--- a/src/lib/utils/variants.ts
+++ b/src/lib/utils/variants.ts
@@ -43,6 +43,11 @@ export const resolveVariant = (
     custom?: unknown
 ): DOMKeyframesDefinition | undefined => {
     if (!variants || !key) return undefined
+    // Guard against built-in / inherited keys like 'toString' or
+    // 'constructor' — without this, `whileHover="toString"` would
+    // resolve to `Function.prototype.toString` and leak a function into
+    // the merge path.
+    if (!Object.prototype.hasOwnProperty.call(variants, key)) return undefined
     const entry = variants[key]
     if (typeof entry === 'function') return entry(custom)
     return entry
@@ -86,8 +91,13 @@ export const resolveVariantList = (
     let merged: Record<string, unknown> | undefined
     for (const key of keys) {
         const entry = resolveVariant(variants, key, custom)
-        if (!entry) continue
-        merged = merged ? { ...merged, ...(entry as Record<string, unknown>) } : { ...entry }
+        // Defensive: skip anything that isn't a plain object — a
+        // function-form variant could return a non-object (e.g. a user
+        // accidentally returning a string), and we don't want that to
+        // poison the merged result.
+        if (!entry || typeof entry !== 'object') continue
+        const obj = entry as Record<string, unknown>
+        merged = merged ? { ...merged, ...obj } : { ...obj }
     }
     return merged as DOMKeyframesDefinition | undefined
 }
@@ -128,13 +138,24 @@ export const resolveInitial = (
 /**
  * Resolves the animate prop to keyframes, handling variant keys.
  *
- * When `animate` is a string, looks it up in the variants object (invoking
- * dynamic variants with `custom`). Otherwise returns the keyframes directly.
+ * When `animate` is a string (or array of strings), looks it up in the
+ * variants object (invoking dynamic variants with `custom`). Otherwise
+ * returns the keyframes directly.
  *
- * @param animate - The animate prop value (keyframes, variant key, or undefined).
+ * @param animate - The animate prop value (keyframes, variant key, array
+ *     of variant keys, or undefined).
  * @param variants - The variants object for resolving string keys.
  * @param custom - Forwarded to function-form variants.
  * @returns Keyframes definition or undefined.
+ *
+ * @example
+ * ```ts
+ * const variants = { visible: { opacity: 1 }, shifted: { x: 100 } }
+ * resolveAnimate('visible', variants)              // { opacity: 1 }
+ * resolveAnimate(['visible', 'shifted'], variants) // { opacity: 1, x: 100 }
+ * resolveAnimate({ scale: 1.2 }, variants)         // { scale: 1.2 }  (pass-through)
+ * resolveAnimate(undefined, variants)              // undefined
+ * ```
  */
 export const resolveAnimate = (
     animate: MotionAnimate,
@@ -150,14 +171,25 @@ export const resolveAnimate = (
 /**
  * Resolves the exit prop to keyframes, handling variant keys.
  *
- * When `exit` is a string, looks it up in the variants object (invoking
- * dynamic variants with `custom`). Otherwise returns the keyframes directly.
- * Used by AnimatePresence for exit animations.
+ * When `exit` is a string (or array of strings), looks it up in the
+ * variants object (invoking dynamic variants with `custom`). Otherwise
+ * returns the keyframes directly. Used by AnimatePresence for exit
+ * animations.
  *
- * @param exit - The exit prop value (keyframes, variant key, or undefined).
+ * @param exit - The exit prop value (keyframes, variant key, array of
+ *     variant keys, or undefined).
  * @param variants - The variants object for resolving string keys.
  * @param custom - Forwarded to function-form variants.
  * @returns Keyframes definition or undefined.
+ *
+ * @example
+ * ```ts
+ * const variants = { hidden: { opacity: 0 }, small: { scale: 0.8 } }
+ * resolveExit('hidden', variants)              // { opacity: 0 }
+ * resolveExit(['hidden', 'small'], variants)   // { opacity: 0, scale: 0.8 }
+ * resolveExit({ y: -20 }, variants)            // { y: -20 }
+ * resolveExit(undefined, variants)             // undefined
+ * ```
  */
 export const resolveExit = (
     exit: MotionExit,

--- a/src/lib/utils/variants.ts
+++ b/src/lib/utils/variants.ts
@@ -91,11 +91,15 @@ export const resolveVariantList = (
     let merged: Record<string, unknown> | undefined
     for (const key of keys) {
         const entry = resolveVariant(variants, key, custom)
-        // Defensive: skip anything that isn't a plain object — a
-        // function-form variant could return a non-object (e.g. a user
-        // accidentally returning a string), and we don't want that to
-        // poison the merged result.
-        if (!entry || typeof entry !== 'object') continue
+        // Defensive: only merge plain keyframe objects. A function-form
+        // variant could return something else (array, class instance,
+        // string) under a misuse, and spreading those would corrupt the
+        // merged result. Reject arrays explicitly and require the
+        // prototype to be `Object.prototype` (or `null` for objects
+        // created via `Object.create(null)`).
+        if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+        const proto = Object.getPrototypeOf(entry)
+        if (proto !== Object.prototype && proto !== null) continue
         const obj = entry as Record<string, unknown>
         merged = merged ? { ...merged, ...obj } : { ...obj }
     }

--- a/src/lib/utils/variants.ts
+++ b/src/lib/utils/variants.ts
@@ -1,4 +1,14 @@
-import type { MotionAnimate, MotionExit, MotionInitial, Variants } from '$lib/types'
+import type {
+    MotionAnimate,
+    MotionExit,
+    MotionInitial,
+    MotionWhileDrag,
+    MotionWhileFocus,
+    MotionWhileHover,
+    MotionWhileInView,
+    MotionWhileTap,
+    Variants
+} from '$lib/types'
 import type { DOMKeyframesDefinition } from 'motion'
 
 /**
@@ -39,6 +49,50 @@ export const resolveVariant = (
 }
 
 /**
+ * Resolves a single variant key or an ordered list of keys to merged
+ * keyframes. Matches framer-motion's `VariantLabels = string | string[]`
+ * surface: later keys in the list override earlier ones on key
+ * collisions (`Object.assign` semantics).
+ *
+ * Missing keys are skipped. An empty list, an empty string, or an
+ * undefined argument all resolve to `undefined`.
+ *
+ * @param variants - The variants object containing named animation states.
+ * @param keys - A single variant key or an array of variant keys.
+ * @param custom - Forwarded to function-form variants (per-entry).
+ * @returns Merged keyframes definition, or `undefined` when nothing resolved.
+ *
+ * @example
+ * ```ts
+ * const variants = {
+ *   hover:  { scale: 1.1 },
+ *   active: { scale: 1.2, color: 'red' }
+ * }
+ * resolveVariantList(variants, 'hover')             // { scale: 1.1 }
+ * resolveVariantList(variants, ['hover', 'active']) // { scale: 1.2, color: 'red' }
+ * resolveVariantList(variants, ['hover', 'missing']) // { scale: 1.1 }
+ * resolveVariantList(variants, [])                   // undefined
+ * ```
+ */
+export const resolveVariantList = (
+    variants: Variants | undefined,
+    keys: string | string[] | undefined,
+    custom?: unknown
+): DOMKeyframesDefinition | undefined => {
+    if (keys === undefined) return undefined
+    if (typeof keys === 'string') return resolveVariant(variants, keys, custom)
+    if (keys.length === 0) return undefined
+
+    let merged: Record<string, unknown> | undefined
+    for (const key of keys) {
+        const entry = resolveVariant(variants, key, custom)
+        if (!entry) continue
+        merged = merged ? { ...merged, ...(entry as Record<string, unknown>) } : { ...entry }
+    }
+    return merged as DOMKeyframesDefinition | undefined
+}
+
+/**
  * Resolves the initial prop to keyframes, handling variant keys and `initial={false}`.
  *
  * When `initial` is a string, looks it up in the variants object (invoking
@@ -66,7 +120,8 @@ export const resolveInitial = (
 ): DOMKeyframesDefinition | false | undefined => {
     if (initial === false) return false
     if (initial === undefined) return undefined
-    if (typeof initial === 'string') return resolveVariant(variants, initial, custom)
+    if (typeof initial === 'string' || Array.isArray(initial))
+        return resolveVariantList(variants, initial, custom)
     return initial as DOMKeyframesDefinition
 }
 
@@ -87,7 +142,8 @@ export const resolveAnimate = (
     custom?: unknown
 ): DOMKeyframesDefinition | undefined => {
     if (animate === undefined) return undefined
-    if (typeof animate === 'string') return resolveVariant(variants, animate, custom)
+    if (typeof animate === 'string' || Array.isArray(animate))
+        return resolveVariantList(variants, animate, custom)
     return animate as DOMKeyframesDefinition
 }
 
@@ -109,6 +165,47 @@ export const resolveExit = (
     custom?: unknown
 ): DOMKeyframesDefinition | undefined => {
     if (exit === undefined) return undefined
-    if (typeof exit === 'string') return resolveVariant(variants, exit, custom)
+    if (typeof exit === 'string' || Array.isArray(exit))
+        return resolveVariantList(variants, exit, custom)
     return exit as DOMKeyframesDefinition
+}
+
+/**
+ * Resolves a `whileX` prop (hover, tap, focus, drag, in-view) to
+ * keyframes. Mirrors `resolveAnimate` — pass-through for inline
+ * keyframes, look up variant keys via `resolveVariantList` (single
+ * string or array of strings, merged left-to-right).
+ *
+ * Used by `_MotionContainer.svelte` to feed the gesture attach helpers
+ * a consistent keyframes object regardless of whether the consumer
+ * wrote inline keyframes or a variant reference.
+ *
+ * @param value - The whileX prop value.
+ * @param variants - The variants object for resolving string keys.
+ * @param custom - Forwarded to function-form variants.
+ * @returns Keyframes definition or `undefined` when nothing applies.
+ *
+ * @example
+ * ```ts
+ * const variants = { hover: { scale: 1.1 }, active: { color: 'red' } }
+ * resolveWhile('hover', variants)            // { scale: 1.1 }
+ * resolveWhile(['hover', 'active'], variants) // { scale: 1.1, color: 'red' }
+ * resolveWhile({ scale: 1.2 }, variants)     // { scale: 1.2 }  (pass-through)
+ * resolveWhile(undefined, variants)          // undefined
+ * ```
+ */
+export const resolveWhile = (
+    value:
+        | MotionWhileTap
+        | MotionWhileHover
+        | MotionWhileFocus
+        | MotionWhileDrag
+        | MotionWhileInView,
+    variants: Variants | undefined,
+    custom?: unknown
+): DOMKeyframesDefinition | undefined => {
+    if (value === undefined) return undefined
+    if (typeof value === 'string' || Array.isArray(value))
+        return resolveVariantList(variants, value, custom)
+    return value as DOMKeyframesDefinition
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -72,6 +72,14 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/motion/while-string-variants') + searchParams}
+                    >
+                        whileX — variant string keys
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/motion/keyframes') + searchParams}
                     >
                         Keyframes (shape + scale)

--- a/src/routes/tests/motion/while-string-variants/+page.svelte
+++ b/src/routes/tests/motion/while-string-variants/+page.svelte
@@ -26,6 +26,28 @@
 
 <svelte:head>
     <title>whileX string variants · regression test</title>
+    <style>
+        /* The root layout locks page scroll for most demos. The whileInView
+           card needs real page scroll so the IntersectionObserver fires when
+           the box scrolls into the viewport — un-lock for this route only.
+           Pattern lifted from /tests/motion/while-in-view. */
+        html,
+        body {
+            height: auto !important;
+            overflow: auto !important;
+        }
+        body > .container,
+        body > div > .container,
+        #sandbox,
+        .test-layout {
+            display: block !important;
+            height: auto !important;
+            min-height: auto !important;
+            align-items: stretch !important;
+            justify-content: flex-start !important;
+            overflow: visible !important;
+        }
+    </style>
 </svelte:head>
 
 <div class="page" data-testid="while-string-variants-page">
@@ -91,20 +113,25 @@
                 tab to me
             </motion.button>
         </article>
+    </section>
 
-        <article>
-            <h2>whileInView — single string</h2>
-            <div style="height: 60vh; padding-bottom: 40vh;"></div>
-            <motion.div
-                data-testid="box-while-inview-string"
-                variants={tabVariants}
-                initial={{ opacity: 0, y: 40 }}
-                whileInView="visible"
-                style="{baseBox} background: #a855f7;"
-            >
-                scroll to me
-            </motion.div>
-        </article>
+    <section class="inview-section">
+        <h2>whileInView — single string</h2>
+        <p class="inview-hint">
+            Scroll down — the purple box below uses <code>whileInView="visible"</code> and fades up when
+            it enters the viewport.
+        </p>
+        <div class="inview-spacer"></div>
+        <motion.div
+            data-testid="box-while-inview-string"
+            variants={tabVariants}
+            initial={{ opacity: 0, y: 40 }}
+            whileInView="visible"
+            style="{baseBox} background: #a855f7;"
+        >
+            scroll to me
+        </motion.div>
+        <div class="inview-tail"></div>
     </section>
 </div>
 
@@ -151,5 +178,22 @@
         flex-direction: column;
         align-items: center;
         background: #fafafa;
+    }
+    .inview-section {
+        margin-top: 48px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+    }
+    .inview-hint {
+        max-width: 480px;
+        margin: 0 0 1.5rem;
+    }
+    .inview-spacer {
+        height: 80vh;
+    }
+    .inview-tail {
+        height: 40vh;
     }
 </style>

--- a/src/routes/tests/motion/while-string-variants/+page.svelte
+++ b/src/routes/tests/motion/while-string-variants/+page.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+    import { motion } from '$lib'
+
+    // Regression page for #349 — variant string keys on whileX props.
+    //
+    // Each box exercises a different whileX prop with a variant *string*
+    // (or array of strings) instead of inline keyframes. Hovering /
+    // tapping / focusing / entering-viewport should produce the same
+    // visual result as inline-form props.
+    //
+    // The Playwright e2e drives `box-while-hover-string` (hover scales
+    // to 1.25) and `box-while-hover-array` (hover scales to 1.25 *and*
+    // tints — the array's later entry wins on `backgroundColor`).
+
+    const tabVariants = {
+        hovered: { scale: 1.25 },
+        tinted: { backgroundColor: '#22c55e' },
+        focused: { outline: '4px solid #2563eb', outlineOffset: '4px' },
+        pressed: { scale: 0.8 },
+        visible: { opacity: 1, y: 0 }
+    }
+
+    const baseBox =
+        'width: 96px; height: 96px; border-radius: 12px; display: inline-flex; align-items: center; justify-content: center; color: white; font-weight: 600; font-family: system-ui;'
+</script>
+
+<svelte:head>
+    <title>whileX string variants · regression test</title>
+</svelte:head>
+
+<div class="page" data-testid="while-string-variants-page">
+    <header>
+        <h1>
+            <code>whileX</code> variant string keys (#349)
+        </h1>
+        <p>
+            Each card passes a variant key (or array) to one of <code>whileHover</code> /
+            <code>whileTap</code> / <code>whileFocus</code> / <code>whileInView</code> instead of an inline
+            keyframes object. The effect should be visually indistinguishable from the equivalent inline
+            form.
+        </p>
+    </header>
+
+    <section class="grid">
+        <article>
+            <h2>whileHover — single string</h2>
+            <motion.div
+                data-testid="box-while-hover-string"
+                variants={tabVariants}
+                whileHover="hovered"
+                style="{baseBox} background: #ef4444;"
+            >
+                hover me
+            </motion.div>
+        </article>
+
+        <article>
+            <h2>whileHover — array (later wins)</h2>
+            <motion.div
+                data-testid="box-while-hover-array"
+                variants={tabVariants}
+                whileHover={['hovered', 'tinted']}
+                style="{baseBox} background: #f97316;"
+            >
+                hover me
+            </motion.div>
+        </article>
+
+        <article>
+            <h2>whileTap — single string</h2>
+            <motion.button
+                data-testid="box-while-tap-string"
+                type="button"
+                variants={tabVariants}
+                whileTap="pressed"
+                style="{baseBox} background: #6366f1; border: none; cursor: pointer;"
+            >
+                press me
+            </motion.button>
+        </article>
+
+        <article>
+            <h2>whileFocus — single string</h2>
+            <motion.button
+                data-testid="box-while-focus-string"
+                type="button"
+                variants={tabVariants}
+                whileFocus="focused"
+                style="{baseBox} background: #14b8a6; border: none; cursor: pointer;"
+            >
+                tab to me
+            </motion.button>
+        </article>
+
+        <article>
+            <h2>whileInView — single string</h2>
+            <div style="height: 60vh; padding-bottom: 40vh;"></div>
+            <motion.div
+                data-testid="box-while-inview-string"
+                variants={tabVariants}
+                initial={{ opacity: 0, y: 40 }}
+                whileInView="visible"
+                style="{baseBox} background: #a855f7;"
+            >
+                scroll to me
+            </motion.div>
+        </article>
+    </section>
+</div>
+
+<style>
+    .page {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 24px;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+    }
+    header {
+        margin-bottom: 24px;
+    }
+    h1 {
+        font-size: 1.4rem;
+        margin: 0 0 0.5rem;
+    }
+    h2 {
+        font-size: 0.9rem;
+        margin: 0 0 0.75rem;
+        color: #444;
+    }
+    p {
+        color: #444;
+        line-height: 1.5;
+    }
+    code {
+        font-family: ui-monospace, monospace;
+        font-size: 0.85em;
+        background: #f3f3f3;
+        padding: 0 4px;
+        border-radius: 3px;
+    }
+    .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 24px;
+    }
+    article {
+        border: 1px solid #ddd;
+        border-radius: 12px;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        background: #fafafa;
+    }
+</style>


### PR DESCRIPTION
## Summary

Closes #349. Widens `whileHover` / `whileTap` / `whileFocus` / `whileDrag` / `whileInView` to accept a variant key string or array of keys (matching framer-motion's `VariantLabels = string | string[]`), so copy-pasted framer-motion examples drop in without rewriting gesture props as inline keyframes. Inline form still works — this is purely additive.

While in there, also extended `initial` / `animate` / `exit` to accept array form via the same generalised resolver, since the upstream contract is identical and the existing single-string support refactored cleanly.

## Changes

✨ New features
- `whileX` props accept `string`, `string[]`, or inline keyframes
- Array form merges variants left-to-right, later wins on collisions
- Missing keys silently skipped
- `initial` / `animate` / `exit` gain the same array-form support

🔧 Refactoring
- New `resolveVariantList` helper; `resolveInitial` / `resolveAnimate` / `resolveExit` delegate to it
- New `resolveWhile` helper feeding five `$derived resolvedWhile*` values in `_MotionContainer.svelte`

🧪 Testing
- 14 new unit tests in `variants.spec.ts` (resolver paths)
- 3 new component tests in `_MotionContainer.spec.ts` (whileHover single key / array / missing key)
- Regression route `/tests/motion/while-string-variants/` covering all five whileX, wired into root nav
- Playwright e2e drives whileHover single-key + array form, asserts scale and later-wins `backgroundColor` merge

📚 Documentation
- New `/examples/variants-while-hover` route + `VariantsWhileHoverExample` component
- "Variant keys on gesture props" section added to `/docs/variants`
- README parity row + llms.txt / llms-full.txt updated

## Commits

- [`c830ae8`](https://github.com/humanspeak/svelte-motion/commit/c830ae8bdab63893e6e6e3af265e88585461557f) feat(variants): variant string keys + arrays on whileX props (#349)
