### PR TITLE
build(docs): adopt sitemapManifestPlugin, remove sitemap step from GA workflow

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -49,9 +49,11 @@ jobs:
             - name: Build Package
               run: pnpm run build
 
-            - name: Generate sitemap manifest
-              working-directory: docs
-              run: pnpm run sitemap:manifest
+            # The sitemap manifest was previously generated here by a
+            # standalone script. It now emits from
+            # `sitemapManifestPlugin` (docs-kit) in `docs/vite.config.ts`,
+            # which fires automatically inside the `vite build` step run
+            # by `pnpm run deploy` below — no separate workflow step.
 
             - name: Deploy Docs
               working-directory: docs

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,8 @@
         "dev": "vite dev",
         "doc-mirrors": "node ./scripts/generate-doc-mirrors.mjs",
         "doc-mirrors:watch": "chokidar 'src/routes/docs/**/+page.svx' -c 'node ./scripts/generate-doc-mirrors.mjs' --initial --silent",
+        "examples-catalog:sync": "node ./scripts/sync-examples-catalog.mjs",
+        "examples-catalog:watch": "chokidar 'src/routes/examples/**/+page.ts' --ignore 'src/routes/examples/+page.ts' -c 'node ./scripts/sync-examples-catalog.mjs' --initial --silent",
         "format": "prettier --write .",
         "generate-social": "tsx ./scripts/generate-social-cards.ts",
         "lint": "prettier --check . && eslint .",
@@ -19,8 +21,6 @@
         "preview": "pnpm run build && wrangler dev",
         "registry:generate": "node ./scripts/generate-registry.mjs",
         "registry:watch": "chokidar 'src/lib/shadcn/ui/**/*.svelte' 'src/lib/shadcn/ui/**/*.ts' -c 'node ./scripts/generate-registry.mjs' --initial --silent",
-        "sitemap:manifest": "node ./scripts/generate-sitemap-manifest.mjs",
-        "sitemap:watch": "chokidar 'src/routes/**/*.svelte' 'src/routes/**/*.svx' 'src/routes/**/*.md' --ignore 'src/routes/examples/+page.ts' -c 'node ./scripts/generate-sitemap-manifest.mjs' --initial --silent",
         "social:watch": "chokidar 'scripts/generate-social-cards.ts' 'src/routes/**/+page.svelte' 'src/routes/**/+page.svx' -c 'tsx ./scripts/generate-social-cards.ts' --initial --silent",
         "test": "npm run test:unit -- --run",
         "test:unit": "vitest"

--- a/docs/scripts/sync-examples-catalog.mjs
+++ b/docs/scripts/sync-examples-catalog.mjs
@@ -1,16 +1,26 @@
-import { readdir, readFile, stat, writeFile } from 'node:fs/promises'
+import { readdir, readFile, writeFile } from 'node:fs/promises'
 import { join, resolve as resolvePath } from 'node:path'
+
+/**
+ * Sync the examples catalog object in `src/routes/examples/+page.ts` from
+ * each individual `src/routes/examples/<slug>/+page.ts`'s `load()` return.
+ *
+ * Each example's `+page.ts` is the source of truth for its `title` and
+ * (optional) `sourceUrl`; the catalog file just mirrors them into a
+ * static record consumed by the examples landing page. Without this
+ * sync a new example wouldn't surface in the catalog until someone
+ * remembered to update the record by hand.
+ *
+ * Previously this script also emitted `src/lib/sitemap-manifest.json`.
+ * That half now runs through docs-kit's `sitemapManifestPlugin` (wired
+ * in `vite.config.ts`) and fires automatically on every `vite build`
+ * and dev server boot — so this script is now exclusively about the
+ * catalog rewrite.
+ */
 
 const ROOT = resolvePath(process.cwd(), 'src', 'routes')
 
-/** Convert a +page file path to a route path */
-function toRoutePath(file) {
-    let p = file.replace(ROOT, '')
-    p = p.replace(/\/\+page\.(svelte|svx|md)$/i, '')
-    return p === '' ? '/' : p
-}
-
-/** Recursively find +page files */
+/** Recursively find `+page.{svelte,svx,md}` files under a directory. */
 async function findPageFiles(dir, out = []) {
     const entries = await readdir(dir, { withFileTypes: true })
     for (const e of entries) {
@@ -24,17 +34,23 @@ async function findPageFiles(dir, out = []) {
     return out
 }
 
+/** Convert a `+page` file path to a route path. */
+function toRoutePath(file) {
+    let p = file.replace(ROOT, '')
+    p = p.replace(/\/\+page\.(svelte|svx|md)$/i, '')
+    return p === '' ? '/' : p
+}
+
 /**
- * Load example metadata from individual +page.ts files
- * @param {string} examplePath - Path to the example directory
- * @returns {Promise<Object|null>} Example metadata or null if not found
+ * Load example metadata from an individual `+page.ts`.
+ * @param {string} examplePath Absolute path to the example directory.
+ * @returns {Promise<{ title: string, sourceUrl: string | null } | null>}
  */
 async function loadExampleMetadata(examplePath) {
     try {
         const pageTs = join(examplePath, '+page.ts')
         const content = await readFile(pageTs, 'utf8')
 
-        // Extract title from the load function return
         const titleMatch = content.match(/title:\s*['"`]([^'"`]+)['"`]/)
         const sourceUrlMatch = content.match(/sourceUrl:\s*['"`]([^'"`]+)['"`]/)
 
@@ -45,16 +61,17 @@ async function loadExampleMetadata(examplePath) {
             }
         }
     } catch {
-        // File doesn't exist or can't be read, that's okay
+        // File doesn't exist or can't be read — fall through to the
+        // slug-based fallback.
     }
     return null
 }
 
 /**
- * Format a title for use mid-sentence in the auto-generated description.
- * Phrases ("Animated Button") get lowercased so the sentence reads naturally.
- * Identifier-style names ("useAnimate", "AnimatePresence") keep their casing
- * so the public API name stays correct.
+ * Lowercase multi-word phrases ("Animated Button" → "animated button")
+ * so they read naturally mid-sentence; preserve identifier-style names
+ * ("useAnimate", "AnimatePresence") so the public API names stay
+ * correct.
  *
  * @param {string} title
  * @returns {string}
@@ -64,9 +81,9 @@ function describable(title) {
 }
 
 /**
- * Build the example description sentence, deduplicating the trailing
- * "animation" token when the title already ends in it. Without this,
- * a slug like "shared-layout-animation" produces the awkward
+ * Build the catalog description string. Deduplicates the trailing
+ * "animation" token when the title already ends in one — without this
+ * a slug like `shared-layout-animation` would produce the awkward
  * "Interactive shared layout animation animation example…".
  *
  * @param {string} title
@@ -79,38 +96,29 @@ function describeExample(title) {
 }
 
 /**
- * Generate example metadata for the examples landing page
- * @param {Object} manifest - The sitemap manifest
- * @returns {Promise<Object>} Examples metadata object
+ * Walk every `/examples/<slug>/` directory and build the catalog record.
+ * @returns {Promise<Record<string, { title: string, description: string, sourceUrl: string | null }>>}
  */
-async function generateExamplesMetadata(manifest) {
-    const exampleRoutes = Object.keys(manifest)
-        .filter((route) => route.startsWith('/examples/') && route !== '/examples')
-        .sort()
-
+async function generateExamplesMetadata(exampleRoutes) {
     const examples = {}
 
     for (const route of exampleRoutes) {
         const slug = route.replace('/examples/', '')
         const examplePath = join(ROOT, 'examples', slug)
-
-        // Try to load metadata from the example's +page.ts file
         const metadata = await loadExampleMetadata(examplePath)
 
         if (metadata) {
-            const title = metadata.title
             examples[slug] = {
-                title,
-                description: describeExample(title),
+                title: metadata.title,
+                description: describeExample(metadata.title),
                 sourceUrl: metadata.sourceUrl
             }
         } else {
-            // Fallback: generate from slug
+            // Fallback: derive the title from the slug.
             const title = slug
                 .split('-')
                 .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
                 .join(' ')
-
             examples[slug] = {
                 title,
                 description: describeExample(title),
@@ -123,20 +131,19 @@ async function generateExamplesMetadata(manifest) {
 }
 
 /**
- * Update the examples +page.ts file with the latest example metadata
- * @param {Object} examples - Examples metadata object
+ * Rewrite the `const examples = { … }` block in
+ * `src/routes/examples/+page.ts` from the freshly-generated catalog.
+ * @param {Record<string, object>} examples
  */
 async function updateExamplesPageTs(examples) {
     const examplesPageTs = resolvePath(process.cwd(), 'src', 'routes', 'examples', '+page.ts')
 
     try {
         let content = await readFile(examplesPageTs, 'utf8')
-
-        // Find the examples object in the file and replace it
-        // More robust regex that matches the entire examples object declaration
         const examplesObjectRegex = /const examples\s*=\s*\{[\s\S]*?\n\s*\}(?=\s*\n\s*return)/
 
-        // Format as prettier-compatible JS (single quotes, no trailing commas, no semis)
+        // Format values as prettier-compatible JS (single quotes, no
+        // trailing commas, no semicolons).
         const formatValue = (v) => (v === null ? 'null' : `'${v.replace(/'/g, "\\'")}'`)
         const lines = Object.entries(examples).map(([slug, meta]) => {
             const props = [
@@ -144,7 +151,7 @@ async function updateExamplesPageTs(examples) {
                 `            description: ${formatValue(meta.description)}`,
                 `            sourceUrl: ${formatValue(meta.sourceUrl)}`
             ]
-            // Quote keys that aren't valid identifiers (contain hyphens)
+            // Quote keys that aren't valid identifiers (contain hyphens).
             const key = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(slug) ? slug : `'${slug}'`
             return `        ${key}: {\n${props.join(',\n')}\n        }`
         })
@@ -164,22 +171,12 @@ async function updateExamplesPageTs(examples) {
 
 async function main() {
     const files = await findPageFiles(ROOT)
-    const manifest = {}
-    for (const file of files) {
-        const s = await stat(file)
-        const route = toRoutePath(file)
-        // Exclude non-public routes
-        if (route.startsWith('/social-cards')) continue
-        // Non-recursive lastmod: use the +page file's mtime only
-        manifest[route] = new Date(s.mtimeMs).toISOString().slice(0, 10)
-    }
+    const exampleRoutes = files
+        .map(toRoutePath)
+        .filter((route) => route.startsWith('/examples/') && route !== '/examples')
+        .sort()
 
-    const dest = resolvePath(process.cwd(), 'src', 'lib', 'sitemap-manifest.json')
-    await writeFile(dest, JSON.stringify(manifest, null, 2) + '\n', 'utf8')
-    console.log(`Sitemap manifest written to ${dest}`)
-
-    // Generate and update examples metadata
-    const examples = await generateExamplesMetadata(manifest)
+    const examples = await generateExamplesMetadata(exampleRoutes)
     await updateExamplesPageTs(examples)
 }
 

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,3 +1,4 @@
+import { sitemapManifestPlugin } from '@humanspeak/docs-kit/vite'
 import { svelteMotionOptimize } from '@humanspeak/svelte-motion/vite'
 import { paraglideVitePlugin } from '@inlang/paraglide-js'
 import { sveltekit } from '@sveltejs/kit/vite'
@@ -11,6 +12,14 @@ import devtoolsJson from 'vite-plugin-devtools-json'
 
 export default defineConfig({
     plugins: [
+        // Emits `src/lib/sitemap-manifest.json` (consumed by
+        // `src/routes/sitemap.xml/+server.ts`) on both `vite build` and the
+        // dev server's `buildStart` hook. Replaces the sitemap half of the
+        // legacy `generate-sitemap-manifest.mjs` script; the trimmed script
+        // (`sync-examples-catalog.mjs`) now owns only the
+        // `examples/+page.ts` metadata sync. `blogDir: false` disables
+        // docs-kit's default blog-folder scan — we don't have a blog.
+        sitemapManifestPlugin({ blogDir: false }),
         svelteMotionOptimize(),
         tailwindcss(),
         sveltekit(),

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -10,8 +10,8 @@ procs:
         shell: rm -rf .svelte-kit node_modules/.vite && pnpm -w -r --filter @humanspeak/svelte-motion run dev
     docs:
         shell: rm -rf docs/.svelte-kit docs/node_modules/.vite && pnpm --filter docs run dev
-    sitemap:
-        shell: pnpm --filter docs run sitemap:watch
+    examples-catalog:
+        shell: pnpm --filter docs run examples-catalog:watch
     registry:
         shell: pnpm --filter docs run registry:watch
     social:


### PR DESCRIPTION
## Summary

Phase 1 of two on the docs UX modernization. Moves the build-time `sitemap-manifest.json` emission off a hand-rolled chokidar-driven Node script and onto docs-kit's `sitemapManifestPlugin` (added to `docs/vite.config.ts`). The plugin fires automatically on `vite build` + dev-server `buildStart`, so the cloudflare-deploy workflow no longer needs its dedicated "Generate sitemap manifest" step.

Phase 2 (separate branch `docs-ui-ux`) will migrate the examples themselves to docs-kit's `ExampleV2` + `demoManifestPlugin` chrome.

## Changes

✨ New
- `sitemapManifestPlugin({ blogDir: false })` in `docs/vite.config.ts`

🔧 Refactoring
- `generate-sitemap-manifest.mjs` was doing two jobs (sitemap manifest + examples catalog rewrite). The sitemap half moves to the plugin; the catalog rewrite stays as `sync-examples-catalog.mjs` with a narrower chokidar watch (only per-example `+page.ts` files, since manifest mtime walking is no longer needed)
- mprocs proc + package.json scripts renamed `sitemap:*` → `examples-catalog:*` to match what the script actually does post-trim

🔄 CI
- Removed the "Generate sitemap manifest" step from `.github/workflows/cloudflare-deploy.yml` — `pnpm run deploy` already runs `vite build` which now fires the plugin

## Verification

- `pnpm --filter docs vite build` emits `src/lib/sitemap-manifest.json` with 66 entries
- `/social-cards` correctly excluded via the plugin's default `excludePrefixes`
- Manifest shape identical to the prior script's output (`{ "/route": "YYYY-MM-DD" }`), so `/sitemap.xml/+server.ts` renders the same XML without code changes
- `svelte-check` clean

## A note on `sync-examples-catalog.mjs` — on the chopping block for Phase 2

The renamed script (formerly the second half of `generate-sitemap-manifest.mjs`) is preserved here purely to keep this PR's diff minimal. **It will be deleted entirely in Phase 2**, not converted to a docs-kit plugin. Reasoning:

1. The script has been a **silent no-op for months** — its regex looks for `const examples = {...}` but the catalog file declares `const EXAMPLES: Record<...> = {...}` (uppercase, typed). The "Could not find examples object pattern" warning has been firing on every run; humans have been hand-maintaining both files independently.
2. **svelte-markdown's brutalist sweep solved this differently**: catalog is hand-curated inline in `examples/+page.svelte` with editorial `tag` fields (DEMO/RENDERERS/SECURITY/EXTENSIONS/etc.) and intentional ordering. They did *not* extract this to a docs-kit plugin — and shouldn't, because editorial taxonomy and curated ordering can't be inferred from per-page `+page.ts` files.
3. Phase 2 will adopt that pattern: delete the script, the mprocs proc, both package.json scripts, and rewrite the catalog page to hold the `examples[]` array inline with the editorial taxonomy. Reviewers don't need to bikeshed the script's design here — it's transient.

## Commits

- [`7dd8ffe`](https://github.com/humanspeak/svelte-motion/commit/7dd8ffe27dff4cb5d0ba7f8624b71abc694a3ea0) build(docs): adopt sitemapManifestPlugin (docs-kit), drop standalone script
