### PR TITLE
feat(docs): migrate examples to ExampleV2 chrome (batch 1: standalones)

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -36,6 +36,9 @@ static/twitter-default.png
 # Generated sitemap manifest
 src/lib/sitemap-manifest.json
 
+# Generated demo manifest (docs-kit's demoManifestPlugin output)
+src/lib/demo-manifest.json
+
 # Generated GitHub stats (build artifact)
 src/lib/github-stats.json
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.5.29",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.5.30",
         "@humanspeak/svelte-motion": "workspace:*",
         "@inlang/paraglide-js": "^2.18.1",
         "@lucide/svelte": "^1.16.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.5.27",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.5.29",
         "@humanspeak/svelte-motion": "workspace:*",
         "@inlang/paraglide-js": "^2.18.1",
         "@lucide/svelte": "^1.16.0",

--- a/docs/src/lib/examples/animated-tabs/demos/Default.svelte
+++ b/docs/src/lib/examples/animated-tabs/demos/Default.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+    import * as Tabs from '$lib/shadcn/ui/tabs'
+</script>
+
+<!-- HUMANSPEAK: positioning shell — centers the tabs inside `.dk-ex-body`
+     and pushes the footer strip to the panel bottom. Stripped from the
+     published manifest by `demoManifestPlugin`. -->
+<div class="humanspeak-demo-shell">
+    <div class="w-full max-w-md">
+        <Tabs.Root value="account">
+            <Tabs.List>
+                <Tabs.Trigger value="account">Account</Tabs.Trigger>
+                <Tabs.Trigger value="password">Password</Tabs.Trigger>
+                <Tabs.Trigger value="settings">Settings</Tabs.Trigger>
+            </Tabs.List>
+            <Tabs.Content
+                value="account"
+                class="rounded-lg border bg-card p-6 text-card-foreground shadow-sm"
+            >
+                <h3 class="text-lg font-semibold">Account</h3>
+                <p class="mt-2 text-sm text-muted-foreground">
+                    Make changes to your account here. Click save when you're done.
+                </p>
+                <div class="mt-4 space-y-2">
+                    <label class="text-sm font-medium" for="name">Name</label>
+                    <input
+                        id="name"
+                        class="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none"
+                        placeholder="Enter your name"
+                    />
+                </div>
+            </Tabs.Content>
+            <Tabs.Content
+                value="password"
+                class="rounded-lg border bg-card p-6 text-card-foreground shadow-sm"
+            >
+                <h3 class="text-lg font-semibold">Password</h3>
+                <p class="mt-2 text-sm text-muted-foreground">
+                    Change your password here. After saving, you'll be logged out.
+                </p>
+                <div class="mt-4 space-y-2">
+                    <label class="text-sm font-medium" for="current">Current password</label>
+                    <input
+                        id="current"
+                        type="password"
+                        class="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none"
+                    />
+                </div>
+            </Tabs.Content>
+            <Tabs.Content
+                value="settings"
+                class="rounded-lg border bg-card p-6 text-card-foreground shadow-sm"
+            >
+                <h3 class="text-lg font-semibold">Settings</h3>
+                <p class="mt-2 text-sm text-muted-foreground">
+                    Configure your preferences and notification settings.
+                </p>
+                <div class="mt-4 flex items-center gap-2">
+                    <input id="notifications" type="checkbox" class="h-4 w-4 accent-primary" />
+                    <label class="text-sm font-medium" for="notifications">
+                        Enable notifications
+                    </label>
+                </div>
+            </Tabs.Content>
+        </Tabs.Root>
+    </div>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 360px;
+    }
+</style>

--- a/docs/src/lib/examples/characters-remaining/demos/Default.svelte
+++ b/docs/src/lib/examples/characters-remaining/demos/Default.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+    import { motion, animate, transform } from '@humanspeak/svelte-motion'
+
+    // Characters-remaining counter with a spring-bounce when getting
+    // close to the limit. `transform` builds a value-mapping function
+    // (a → b → c), and `animate(...)` runs an imperative spring keyed
+    // by the remaining-character count.
+    // Ported from: https://examples.motion.dev/react/characters-remaining
+
+    let value = $state('')
+    const maxLength = 12
+    const charactersRemaining = $derived(maxLength - value.length)
+    let counterEl: HTMLElement | null = $state(null)
+
+    // Map remaining count to a colour gradient: at 6+ characters left
+    // the counter sits muted grey; from 5 down to 2 it warms toward
+    // pink; at 0 it's full pink.
+    const mapRemainingToColor = transform([2, 6], ['#ff008c', '#ccc'])
+
+    $effect(() => {
+        if (charactersRemaining > 6 || !counterEl) return
+
+        // The spring's velocity also scales with remaining count —
+        // 5 left = subtle nudge; 0 left = aggressive bounce.
+        const mapRemainingToSpringVelocity = transform([0, 5], [50, 0])
+
+        animate(
+            counterEl,
+            { scale: 1 },
+            {
+                type: 'spring',
+                velocity: mapRemainingToSpringVelocity(charactersRemaining),
+                stiffness: 700,
+                damping: 80
+            }
+        )
+    })
+</script>
+
+<!-- HUMANSPEAK: docs-kit positioning shell — stripped from the published code. -->
+<div class="humanspeak-demo-shell">
+    <div class="outer">
+        <div class="input-container">
+            <input bind:value />
+            <div class="counter">
+                <motion.span
+                    bind:ref={counterEl}
+                    style="color: {mapRemainingToColor(
+                        charactersRemaining
+                    )}; will-change: transform; display: block;"
+                >
+                    {charactersRemaining}
+                </motion.span>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 280px;
+    }
+
+    .outer {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        background: transparent;
+        border-radius: 12px;
+        padding: 40px;
+    }
+
+    :global(.dark) .outer {
+        background: #0b1011;
+    }
+
+    .input-container {
+        position: relative;
+        font-size: 32px;
+        line-height: 1;
+    }
+
+    .input-container input {
+        position: relative;
+        font-size: 32px;
+        line-height: 1;
+        background-color: #ffffff;
+        color: #1a1a1a;
+        border: 2px solid #d1d5db;
+        border-radius: 10px;
+        padding: 20px;
+        padding-right: 70px;
+        width: 300px;
+        outline: none;
+    }
+
+    :global(.dark) .input-container input {
+        background-color: #0b1011;
+        color: #f5f5f5;
+        border-color: #1d2628;
+    }
+
+    .input-container input:focus {
+        border-color: #3b82f6;
+    }
+
+    .counter {
+        color: #6b7280;
+        background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #ffffff 20%);
+        position: absolute;
+        top: 50%;
+        right: 2px;
+        transform: translateY(-50%);
+        padding: 10px;
+        padding-right: 20px;
+        padding-left: 50px;
+    }
+
+    :global(.dark) .counter {
+        color: #ccc;
+        background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #0b1011 20%);
+    }
+</style>

--- a/docs/src/lib/examples/color-interpolation/demos/Default.svelte
+++ b/docs/src/lib/examples/color-interpolation/demos/Default.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+    import { animate } from 'motion'
+
+    // Side-by-side comparison of how the browser's Web Animations API
+    // and motion's `animate()` interpolate between two colors. WAAPI
+    // interpolates in HSL (the path sweeps through hue), motion
+    // interpolates in RGB (a straight line through colour space).
+
+    let waapiElement: HTMLDivElement | undefined = $state(undefined)
+    let motionElement: HTMLDivElement | undefined = $state(undefined)
+
+    $effect(() => {
+        if (!waapiElement || !motionElement) return
+
+        // Web Animations API — HSL interpolation
+        const waapiAnimation = waapiElement.animate(
+            [{ backgroundColor: '#ff0088' }, { backgroundColor: '#0d63f8' }],
+            {
+                duration: 2000,
+                iterations: Infinity,
+                direction: 'alternate',
+                easing: 'linear'
+            }
+        )
+
+        // motion — RGB interpolation
+        const motionAnimation = animate(
+            motionElement,
+            { backgroundColor: ['#ff0088', '#0d63f8'] },
+            {
+                duration: 2,
+                repeat: Infinity,
+                repeatType: 'reverse',
+                ease: 'linear'
+            }
+        )
+
+        return () => {
+            waapiAnimation.cancel()
+            motionAnimation.cancel()
+        }
+    })
+</script>
+
+<!-- HUMANSPEAK: docs-kit positioning shell — stripped from the published code. -->
+<div class="humanspeak-demo-shell">
+    <div class="container">
+        <div class="swatch-container">
+            <div class="swatch waapi" bind:this={waapiElement}></div>
+            <div class="label">Browser (HSL)</div>
+        </div>
+        <div class="swatch-container">
+            <div class="swatch motion" bind:this={motionElement}></div>
+            <div class="label">Motion (RGB)</div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 280px;
+    }
+
+    .container {
+        display: flex;
+        gap: 30px;
+        align-items: center;
+        justify-content: center;
+        padding: 40px 20px;
+    }
+
+    .swatch-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+    }
+
+    .swatch {
+        width: 100px;
+        height: 100px;
+        border-radius: 8px;
+        background-color: #ff0088;
+        box-shadow:
+            0 4px 6px -1px rgb(0 0 0 / 0.1),
+            0 2px 4px -2px rgb(0 0 0 / 0.1);
+    }
+
+    .label {
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--text-secondary, #6b7280);
+    }
+</style>

--- a/docs/src/lib/examples/conic-gradient/demos/Default.svelte
+++ b/docs/src/lib/examples/conic-gradient/demos/Default.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+    import { writable } from 'svelte/store'
+    import { motion, styleString, useTransform } from '@humanspeak/svelte-motion'
+
+    // Pointer-tracking conic gradient. `useTransform` derives the
+    // background string from two motion values; `styleString` glues
+    // it onto the inline `style` attribute. Move the cursor across the
+    // box and the gradient pivot follows.
+    // Ported from the motion.dev conic-gradient example.
+
+    let el: HTMLElement | undefined = $state(undefined)
+    let width = $state(400)
+    let height = $state(400)
+
+    const gradientX = writable(0.5)
+    const gradientY = writable(0.5)
+
+    const background = useTransform(
+        () =>
+            `conic-gradient(at ${$gradientX * 100}% ${$gradientY * 100}%, #0cdcf7, #ff0088, #fff312, #0cdcf7)`,
+        [gradientX, gradientY]
+    )
+
+    function handlePointerMove(e: PointerEvent) {
+        if (!el) return
+        const rect = el.getBoundingClientRect()
+        gradientX.set((e.clientX - rect.left) / rect.width)
+        gradientY.set((e.clientY - rect.top) / rect.height)
+    }
+
+    function handlePointerEnter() {
+        if (!el) return
+        const rect = el.getBoundingClientRect()
+        width = rect.width
+        height = rect.height
+    }
+</script>
+
+<!-- HUMANSPEAK: docs-kit positioning shell — stripped from the published code. -->
+<div class="humanspeak-demo-shell">
+    <div
+        class="gradient-wrapper"
+        bind:this={el}
+        onpointermove={handlePointerMove}
+        onpointerenter={handlePointerEnter}
+        role="presentation"
+    >
+        <motion.div
+            class="gradient-box"
+            style={styleString(() => ({ background: $background, width, height }))}
+        />
+    </div>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 480px;
+    }
+
+    .gradient-wrapper {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 400px;
+        height: 400px;
+    }
+
+    .gradient-wrapper :global(.gradient-box) {
+        border-radius: 30px;
+    }
+</style>

--- a/docs/src/lib/examples/fancy-like-button/demos/Default.svelte
+++ b/docs/src/lib/examples/fancy-like-button/demos/Default.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+    import { motion } from '@humanspeak/svelte-motion'
+
+    // Ported from https://github.com/DRlFTER/fancyLikeButton
+
+    type Heart = {
+        id: number
+        xOffset: number
+        scale: number
+    }
+
+    type Circle = {
+        id: number
+        xOffset: number
+        delay: number
+        size: number
+    }
+
+    let isLiked = $state(false)
+    let spawnInterval: ReturnType<typeof setInterval> | null = null
+    let hearts = $state<Heart[]>([])
+    let circles = $state<Circle[]>([])
+
+    function randomX(): number {
+        return Math.floor(Math.random() * 150) - 75
+    }
+
+    function spawnBurst(): void {
+        const x = randomX()
+        const now = Date.now()
+
+        const newHeart: Heart = {
+            id: now,
+            xOffset: x,
+            scale: 0.9 + Math.random() * 0.4
+        }
+
+        const newCircles: Circle[] = Array.from({ length: 15 }, (_, i) => ({
+            id: now + i + 1,
+            delay: i * 0.015,
+            size: 16 - i,
+            xOffset: x
+        }))
+
+        hearts = [...hearts, newHeart]
+        circles = [...circles, ...newCircles]
+
+        // Cleanup after animations complete
+        setTimeout(() => {
+            hearts = hearts.filter((h) => h.id !== newHeart.id)
+            const ids = new Set(newCircles.map((c) => c.id))
+            circles = circles.filter((c) => !ids.has(c.id))
+        }, 2200)
+    }
+
+    function startSpawning(): void {
+        if (!isLiked) return
+        if (spawnInterval) return
+        spawnBurst()
+        spawnInterval = setInterval(spawnBurst, 120)
+    }
+
+    function stopSpawning(): void {
+        if (spawnInterval) {
+            clearInterval(spawnInterval)
+            spawnInterval = null
+        }
+    }
+
+    function onPointerDown(): void {
+        if (!isLiked) {
+            isLiked = true
+            startSpawning()
+        } else {
+            isLiked = false
+            stopSpawning()
+        }
+    }
+
+    function onPointerUp(): void {
+        stopSpawning()
+    }
+
+    function onKeyDown(e: KeyboardEvent): void {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            if (!isLiked) {
+                isLiked = true
+                startSpawning()
+            } else {
+                isLiked = false
+                stopSpawning()
+            }
+        }
+    }
+
+    const buttonBg = $derived(isLiked ? 'bg-red-500/50' : 'bg-[#2C3A47]')
+
+    function likeInteraction(node: HTMLElement) {
+        const handlePointerDown = (e: PointerEvent) => {
+            node.setPointerCapture(e.pointerId)
+            onPointerDown()
+        }
+        const handlePointerUp = () => {
+            onPointerUp()
+        }
+        const handleKeyDown = (e: KeyboardEvent) => {
+            onKeyDown(e)
+        }
+        node.addEventListener('pointerdown', handlePointerDown)
+        node.addEventListener('pointerup', handlePointerUp)
+        node.addEventListener('pointercancel', handlePointerUp)
+        node.addEventListener('lostpointercapture', handlePointerUp)
+        node.addEventListener('keydown', handleKeyDown)
+        return {
+            destroy() {
+                node.removeEventListener('pointerdown', handlePointerDown)
+                node.removeEventListener('pointerup', handlePointerUp)
+                node.removeEventListener('pointercancel', handlePointerUp)
+                node.removeEventListener('lostpointercapture', handlePointerUp)
+                node.removeEventListener('keydown', handleKeyDown)
+            }
+        }
+    }
+</script>
+
+<!-- HUMANSPEAK: docs-kit positioning shell — stripped from the published code. -->
+<div class="humanspeak-demo-shell">
+    <div class="relative flex" use:likeInteraction>
+        <motion.button
+            class={`size-6 ${buttonBg} z-30 m-1 flex items-center justify-center rounded-full select-none`}
+            initial={{ scale: 1.05 }}
+            whileTap={{ scale: 0.92 }}
+            transition={{ type: 'spring', stiffness: 400, duration: 0.3 }}
+            aria-pressed={isLiked}
+            role="button"
+            tabindex="0"
+        >
+            <svg
+                version="1.1"
+                id="Layer_1"
+                xmlns="http://www.w3.org/2000/svg"
+                x="0px"
+                y="-10px"
+                viewBox="0 0 122.88 107.41"
+                style="enableBackground: new 0 0 122.88 107.41"
+                class="size-4 pt-0.5"
+            >
+                <g>
+                    <path
+                        class="st0"
+                        d="M60.83,17.19C68.84,8.84,74.45,1.62,86.79,0.21c23.17-2.66,44.48,21.06,32.78,44.41 c-3.33,6.65-10.11,14.56-17.61,22.32c-8.23,8.52-17.34,16.87-23.72,23.2l-17.4,17.26L46.46,93.56C29.16,76.9,0.95,55.93,0.02,29.95 C-0.63,11.75,13.73,0.09,30.25,0.3C45.01,0.5,51.22,7.84,60.83,17.19L60.83,17.19L60.83,17.19z"
+                        fill={isLiked ? '#fb2c36' : '#A5AAB1'}
+                    />
+                </g>
+            </svg>
+        </motion.button>
+        <!-- Spawn origin centered on the button -->
+        <div
+            class="pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+        >
+            {#each hearts as heart (heart.id)}
+                <motion.div
+                    class="pointer-events-none absolute z-20 flex size-5 items-center justify-center text-red-500/50"
+                    style="translate: -50% -50%"
+                    initial={{ opacity: 1, x: 0, y: 0, scale: heart.scale }}
+                    animate={{ x: heart.xOffset, y: -(heart.xOffset + 100), opacity: 0 }}
+                    transition={{
+                        x: { duration: 0.2, ease: 'easeOut' },
+                        y: { duration: 0.6, ease: 'easeInOut' },
+                        opacity: { delay: 0.85, duration: 0.6 }
+                    }}
+                >
+                    ❤️
+                </motion.div>
+            {/each}
+
+            {#each circles as circle (circle.id)}
+                <motion.div
+                    class="pointer-events-none absolute z-10 flex size-6 items-center justify-center rounded-full bg-red-500/30"
+                    style="translate: -50% -50%"
+                    initial={{ opacity: 1, x: 0, y: 0, scale: circle.size / 15 }}
+                    animate={{ x: circle.xOffset, y: -(circle.xOffset + 100), opacity: 0 }}
+                    transition={{
+                        x: {
+                            duration: 0.2 + circle.delay,
+                            delay: circle.delay,
+                            ease: 'easeOut'
+                        },
+                        y: {
+                            duration: 0.6 + circle.delay,
+                            delay: circle.delay,
+                            ease: 'easeInOut'
+                        },
+                        opacity: { delay: 0.4 + circle.delay, duration: 0.6 }
+                    }}
+                />
+            {/each}
+        </div>
+    </div>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 360px;
+    }
+</style>

--- a/docs/src/lib/examples/keyframes/demos/Default.svelte
+++ b/docs/src/lib/examples/keyframes/demos/Default.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+    import { motion, styleString } from '@humanspeak/svelte-motion'
+
+    // Multi-property keyframe animation: scale + rotate + borderRadius.
+    // Each property is given its own value sequence; `times` aligns
+    // every keyframe to a normalised t in [0, 1].
+    // Ported from the motion.dev keyframes example.
+</script>
+
+<!-- HUMANSPEAK: docs-kit positioning shell — stripped from the published code. -->
+<div class="humanspeak-demo-shell">
+    <div class="keyframes-wrapper">
+        <motion.div
+            class="keyframes-box"
+            style={styleString(() => ({ width: 100, height: 100 }))}
+            animate={{
+                scale: [1, 2, 2, 1, 1],
+                rotate: [0, 0, 180, 180, 0],
+                borderRadius: ['0%', '0%', '50%', '50%', '0%']
+            }}
+            transition={{
+                duration: 2,
+                ease: 'easeInOut',
+                times: [0, 0.2, 0.5, 0.8, 1],
+                repeat: Infinity,
+                repeatDelay: 1
+            }}
+        />
+    </div>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 480px;
+    }
+
+    .keyframes-wrapper {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 400px;
+        height: 400px;
+    }
+
+    .keyframes-wrapper :global(.keyframes-box) {
+        background: #ff0088;
+    }
+</style>

--- a/docs/src/lib/examples/layout-group/demos/Default.svelte
+++ b/docs/src/lib/examples/layout-group/demos/Default.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+    import { AnimatePresence, LayoutGroup, motion, styleString } from '@humanspeak/svelte-motion'
+
+    // Two sibling tab strips share `layoutId="underline"`. Each is
+    // wrapped in its own `<LayoutGroup id>` so the underline animation
+    // stays scoped — clicking on the right strip doesn't pull the
+    // underline from the left strip across the page. Remove the
+    // LayoutGroups and the underline will jump between strips on click.
+
+    let selectedA = $state(0)
+    let selectedB = $state(0)
+
+    const tabs = [0, 1, 2] as const
+
+    const underlineStyle = styleString(() => ({
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        height: '3px',
+        background: 'var(--color-brand-500, royalblue)',
+        borderRadius: 2
+    }))
+</script>
+
+<!-- HUMANSPEAK: docs-kit positioning shell — stripped from the published code. -->
+<div class="humanspeak-demo-shell">
+    <div
+        style={styleString(() => ({
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gap: '2.5rem',
+            padding: '1.5rem',
+            background: 'var(--color-background-secondary)',
+            borderRadius: 8,
+            width: '100%',
+            maxWidth: '720px'
+        }))}
+    >
+        <article>
+            <header style="margin-bottom: 0.5rem;">
+                <strong style="font-size: 0.85rem;">Group A</strong>
+            </header>
+            <LayoutGroup id="strip-a">
+                <div
+                    style={styleString(() => ({
+                        display: 'flex',
+                        gap: 4,
+                        justifyContent: 'center',
+                        border: '1px dashed var(--color-border, #ccc)',
+                        padding: '1rem',
+                        borderRadius: 8
+                    }))}
+                >
+                    {#each tabs as id (id)}
+                        <button
+                            type="button"
+                            onclick={() => (selectedA = id)}
+                            style={styleString(() => ({
+                                position: 'relative',
+                                padding: '0.5rem 1.25rem',
+                                border: 'none',
+                                background: 'transparent',
+                                fontWeight: 500,
+                                cursor: 'pointer'
+                            }))}
+                        >
+                            Tab {id}
+                            <AnimatePresence>
+                                {#if selectedA === id}
+                                    <motion.div
+                                        key="underline"
+                                        layoutId="underline"
+                                        style={underlineStyle}
+                                        transition={{ duration: 0.4, ease: 'easeInOut' }}
+                                    ></motion.div>
+                                {/if}
+                            </AnimatePresence>
+                        </button>
+                    {/each}
+                </div>
+            </LayoutGroup>
+        </article>
+
+        <article>
+            <header style="margin-bottom: 0.5rem;">
+                <strong style="font-size: 0.85rem;">Group B</strong>
+            </header>
+            <LayoutGroup id="strip-b">
+                <div
+                    style={styleString(() => ({
+                        display: 'flex',
+                        gap: 4,
+                        justifyContent: 'center',
+                        border: '1px dashed var(--color-border, #ccc)',
+                        padding: '1rem',
+                        borderRadius: 8
+                    }))}
+                >
+                    {#each tabs as id (id)}
+                        <button
+                            type="button"
+                            onclick={() => (selectedB = id)}
+                            style={styleString(() => ({
+                                position: 'relative',
+                                padding: '0.5rem 1.25rem',
+                                border: 'none',
+                                background: 'transparent',
+                                fontWeight: 500,
+                                cursor: 'pointer'
+                            }))}
+                        >
+                            Tab {id}
+                            <AnimatePresence>
+                                {#if selectedB === id}
+                                    <motion.div
+                                        key="underline"
+                                        layoutId="underline"
+                                        style={underlineStyle}
+                                        transition={{ duration: 0.4, ease: 'easeInOut' }}
+                                    ></motion.div>
+                                {/if}
+                            </AnimatePresence>
+                        </button>
+                    {/each}
+                </div>
+            </LayoutGroup>
+        </article>
+    </div>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 280px;
+    }
+</style>

--- a/docs/src/lib/examples/layout-scroll/demos/Default.svelte
+++ b/docs/src/lib/examples/layout-scroll/demos/Default.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+    import { motion, styleString } from '@humanspeak/svelte-motion'
+
+    // Two side-by-side scroll containers. Identical FLIP animations
+    // inside. Only the right one has `layoutScroll`. Click "expand",
+    // then drag the scrollbar in either panel mid-animation:
+    //   - Left:  the red box drifts (FLIP measures viewport-relative
+    //            rects, so the scroll offset leaks into the delta).
+    //   - Right: the teal box stays anchored (layoutScroll re-bases
+    //            measurements in the scroll container's coordinate
+    //            space).
+
+    let expanded = $state(false)
+    const sizeRest = '120px'
+    const sizeExpanded = '220px'
+
+    // Slow tween so a viewer has time to grab the scrollbar mid-animation
+    // and actually feel the difference between the two panels.
+    const slowTransition = { duration: 1.8, ease: 'easeInOut' as const }
+
+    function toggle() {
+        expanded = !expanded
+    }
+</script>
+
+<!-- HUMANSPEAK: docs-kit positioning shell — stripped from the published code. -->
+<div class="humanspeak-demo-shell">
+    <div
+        style={styleString(() => ({
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '1rem',
+            padding: '1.5rem',
+            background: 'var(--color-background-secondary)',
+            borderRadius: 8,
+            width: '100%',
+            maxWidth: '720px'
+        }))}
+    >
+        <motion.button
+            whileTap={{ scale: 0.96 }}
+            whileHover={{ scale: 1.03, backgroundColor: 'var(--color-brand-600)' }}
+            onclick={toggle}
+            style={styleString(() => ({
+                alignSelf: 'flex-start',
+                padding: '0.55rem 1.1rem',
+                background: 'var(--color-brand-500)',
+                color: '#ffffff',
+                border: 'none',
+                borderRadius: 8,
+                fontSize: '0.9rem',
+                fontWeight: 600,
+                cursor: 'pointer',
+                letterSpacing: '0.02em',
+                boxShadow:
+                    '0 4px 14px -4px color-mix(in oklab, var(--color-brand-500) 70%, transparent)'
+            }))}
+        >
+            {expanded ? 'shrink box' : 'expand box →'}
+        </motion.button>
+
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+            <article>
+                <header
+                    style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem;"
+                >
+                    <strong style="font-size: 0.85rem;">without <code>layoutScroll</code></strong>
+                    <span
+                        style="font-size: 0.72rem; padding: 1px 6px; border-radius: 4px; color: #b91c1c; background: #fee2e2;"
+                    >
+                        drifts on scroll
+                    </span>
+                </header>
+                <div
+                    style={styleString(() => ({
+                        overflow: 'auto',
+                        height: '240px',
+                        border: '1px solid var(--color-border, #bbb)',
+                        borderRadius: 8,
+                        background: 'var(--color-background, #fff)'
+                    }))}
+                >
+                    <div style="height: 60px;"></div>
+                    <motion.div
+                        layout
+                        transition={slowTransition}
+                        style={styleString(() => ({
+                            width: expanded ? sizeExpanded : sizeRest,
+                            height: expanded ? sizeExpanded : sizeRest,
+                            borderRadius: 12,
+                            background: 'linear-gradient(135deg,#ef4444 0%,#f97316 100%)',
+                            margin: '0 auto'
+                        }))}
+                    ></motion.div>
+                    <div style="height: 360px;"></div>
+                </div>
+            </article>
+
+            <article>
+                <header
+                    style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem;"
+                >
+                    <strong style="font-size: 0.85rem;">with <code>layoutScroll</code></strong>
+                    <span
+                        style="font-size: 0.72rem; padding: 1px 6px; border-radius: 4px; color: #047857; background: #d1fae5;"
+                    >
+                        stays anchored
+                    </span>
+                </header>
+                <motion.div
+                    layoutScroll
+                    style={styleString(() => ({
+                        overflow: 'auto',
+                        height: '240px',
+                        border: '1px solid var(--color-border, #bbb)',
+                        borderRadius: 8,
+                        background: 'var(--color-background, #fff)'
+                    }))}
+                >
+                    <div style="height: 60px;"></div>
+                    <motion.div
+                        layout
+                        transition={slowTransition}
+                        style={styleString(() => ({
+                            width: expanded ? sizeExpanded : sizeRest,
+                            height: expanded ? sizeExpanded : sizeRest,
+                            borderRadius: 12,
+                            background: 'linear-gradient(135deg,#22c55e 0%,#06b6d4 100%)',
+                            margin: '0 auto'
+                        }))}
+                    ></motion.div>
+                    <div style="height: 360px;"></div>
+                </motion.div>
+            </article>
+        </div>
+    </div>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 460px;
+    }
+</style>

--- a/docs/src/lib/examples/multi-state-badge/demos/Default.svelte
+++ b/docs/src/lib/examples/multi-state-badge/demos/Default.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+    import { styleString } from '@humanspeak/svelte-motion'
+    import Badge from '../Badge.svelte'
+    import { getNextState, styles, type BadgeState } from '../constants'
+
+    // Badge that cycles idle → processing → success → error → idle.
+    // Each state swaps an icon and a label inside `AnimatePresence` —
+    // exits and enters share a layout so the chrome stays put while
+    // the contents fly through with blur + scale.
+    // Ported from: https://examples.motion.dev/react/multi-state-badge
+
+    let badgeState = $state<BadgeState>('idle')
+</script>
+
+<!-- HUMANSPEAK: docs-kit positioning shell — stripped from the published code. -->
+<div class="humanspeak-demo-shell">
+    <div style={styleString(() => styles.container)}>
+        <button
+            onclick={() => {
+                badgeState = getNextState(badgeState)
+            }}
+            style="background: none; border: none; cursor: pointer; padding: 0;"
+        >
+            <Badge state={badgeState} />
+        </button>
+    </div>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 280px;
+    }
+</style>

--- a/docs/src/lib/examples/path-morphing/demos/Default.svelte
+++ b/docs/src/lib/examples/path-morphing/demos/Default.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+    import { animate, useMotionValue, useTransform } from '@humanspeak/svelte-motion'
+    import { interpolate } from 'flubber'
+    import { onDestroy } from 'svelte'
+
+    // Morph through a sequence of SVG paths (lightning → hand → plane
+    // → heart → note → star → lightning). flubber computes the
+    // tween between each adjacent pair once; `useTransform` reads a
+    // single normalised progress motion value and snaps to whichever
+    // interpolator is active.
+
+    const lightning = 'M7 2v11h3v9l7-12h-4l4-8z'
+    const hand =
+        'M23 5.5V20c0 2.2-1.8 4-4 4h-7.3c-1.08 0-2.1-.43-2.85-1.19L1 14.83s1.26-1.23 1.3-1.25c.22-.19.49-.29.79-.29.22 0 .42.06.6.16.04.01 4.31 2.46 4.31 2.46V4c0-.83.67-1.5 1.5-1.5S11 3.17 11 4v7h1V1.5c0-.83.67-1.5 1.5-1.5S15 .67 15 1.5V11h1V2.5c0-.83.67-1.5 1.5-1.5s1.5.67 1.5 1.5V11h1V5.5c0-.83.67-1.5 1.5-1.5s1.5.67 1.5 1.5z'
+    const plane =
+        'M21 16v-2l-8-5V3.5c0-.83-.67-1.5-1.5-1.5S10 2.67 10 3.5V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5l8 2.5z'
+    const heart =
+        'M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z'
+    const note =
+        'M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z'
+    const star =
+        'M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z'
+
+    // Lightning duplicated at end for seamless loop
+    const paths = [lightning, hand, plane, heart, note, star, lightning]
+    const colors = ['#fff312', '#ff0088', '#dd00ee', '#9911ff', '#0d63f8', '#0cdcf7', '#4ff0b7']
+
+    // Pre-compute flubber interpolators once (expensive operation)
+    const pathInterpolators = paths.map((p, i) => {
+        if (i === paths.length - 1) return null // last→first not needed (we snap)
+        return interpolate(p, paths[i + 1], { maxSegmentLength: 0.1 })
+    })
+
+    const progress = useMotionValue(0)
+
+    const fill = useTransform(
+        progress,
+        paths.map((_, i) => i),
+        colors
+    )
+
+    // Use function form — calls cheap pre-computed interpolator per frame
+    const path = useTransform(() => {
+        const v = progress.get()
+        const i = Math.min(Math.floor(v), paths.length - 2)
+        const t = v - i
+        if (t < 0.001) return paths[Math.max(0, i)]
+        const interp = pathInterpolators[i]
+        if (!interp) return paths[i]
+        return interp(t)
+    }, [progress])
+
+    let pathIndex = $state(0)
+    let animation: ReturnType<typeof animate> | undefined
+
+    $effect(() => {
+        // Read pathIndex to subscribe
+        const target = pathIndex
+
+        animation?.stop()
+
+        animation = animate(progress.get(), target, {
+            duration: 1.0,
+            ease: 'easeInOut',
+            onUpdate: (v: number) => progress.set(v),
+            onComplete: () => {
+                if (target === paths.length - 1) {
+                    // Snap back to 0 (same shape — lightning) then animate to 1
+                    progress.set(0)
+                    pathIndex = 1
+                } else {
+                    pathIndex = target + 1
+                }
+            }
+        })
+    })
+
+    onDestroy(() => {
+        animation?.stop()
+    })
+</script>
+
+<!-- HUMANSPEAK: docs-kit positioning shell — stripped from the published code. -->
+<div class="humanspeak-demo-shell">
+    <svg width="400" height="400">
+        <g transform="translate(10 10) scale(17 17)">
+            <path d={$path} fill={$fill} />
+        </g>
+    </svg>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 460px;
+    }
+</style>

--- a/docs/src/lib/examples/reordering/demos/Default.svelte
+++ b/docs/src/lib/examples/reordering/demos/Default.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+    import { motion, styleString } from '@humanspeak/svelte-motion'
+    import { onMount } from 'svelte'
+
+    // Four coloured tiles shuffle their order every second. Each tile
+    // is `layout` — FLIP measures the rect before + after the shuffle,
+    // so motion plays the spring-tween between positions.
+
+    const initialOrder = ['#ff0088', '#dd00ee', '#9911ff', '#0d63f8']
+
+    let order = $state([...initialOrder])
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+    onMount(() => {
+        const scheduleNextShuffle = () => {
+            timeoutId = setTimeout(() => {
+                order = shuffle(order)
+                scheduleNextShuffle()
+            }, 1000)
+        }
+
+        scheduleNextShuffle()
+
+        return () => {
+            if (timeoutId !== undefined) {
+                clearTimeout(timeoutId)
+            }
+        }
+    })
+
+    function shuffle(array: string[]) {
+        return [...array].sort(() => Math.random() - 0.5)
+    }
+
+    const spring = {
+        type: 'spring' as const,
+        damping: 20,
+        stiffness: 300
+    }
+
+    const container = {
+        listStyle: 'none',
+        padding: 0,
+        margin: 0,
+        position: 'relative',
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 10,
+        width: 300,
+        flexDirection: 'row',
+        justifyContent: 'center',
+        alignItems: 'center'
+    }
+
+    const item = {
+        width: 100,
+        height: 100,
+        borderRadius: '10px'
+    }
+</script>
+
+<!-- HUMANSPEAK: docs-kit positioning shell — stripped from the published code. -->
+<div class="humanspeak-demo-shell">
+    <motion.ul style={styleString(() => container)}>
+        {#each order as backgroundColor (backgroundColor)}
+            <motion.li
+                layout
+                transition={spring}
+                style={styleString(() => ({
+                    ...item,
+                    backgroundColor
+                }))}
+            />
+        {/each}
+    </motion.ul>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 320px;
+    }
+</style>

--- a/docs/src/lib/examples/tab-select/demos/Default.svelte
+++ b/docs/src/lib/examples/tab-select/demos/Default.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+    import { AnimatePresence, motion } from '@humanspeak/svelte-motion'
+
+    // Classic tab pattern: only the active tab renders the indicator,
+    // but the indicator shares a `layoutId` across all tabs so motion
+    // animates it between positions on click. `AnimatePresence`
+    // handles the mount/unmount handoff.
+
+    const tabs = ['Home', 'React', 'Vue', 'Svelte']
+
+    let selectedTab = $state(0)
+</script>
+
+<!-- HUMANSPEAK: docs-kit positioning shell — stripped from the published code. -->
+<div class="humanspeak-demo-shell">
+    <nav class="container">
+        <ul role="tablist">
+            {#each tabs as name, index (name)}
+                {@const isSelected = selectedTab === index}
+                <li class={isSelected ? 'selected' : ''}>
+                    <AnimatePresence>
+                        {#if isSelected}
+                            <motion.div
+                                key="selected-indicator"
+                                layoutId="selected-indicator"
+                                class="selected-indicator"
+                                transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+                            />
+                        {/if}
+                    </AnimatePresence>
+                    <motion.button
+                        role="tab"
+                        aria-selected={isSelected}
+                        onclick={() => (selectedTab = index)}
+                        whileTap={{ scale: 0.9 }}
+                        whileFocus={{
+                            backgroundColor: 'var(--accent-transparent)'
+                        }}
+                    >
+                        {name}
+                    </motion.button>
+                </li>
+            {/each}
+        </ul>
+    </nav>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 220px;
+    }
+
+    .container {
+        width: fit-content;
+        background-color: var(--color-card);
+        border-radius: 10px;
+        border: 1px solid var(--color-border);
+        padding: 5px;
+    }
+
+    .container ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        gap: 5px;
+        flex-direction: row;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .container li {
+        color: var(--color-foreground);
+        position: relative;
+    }
+
+    :global(.selected-indicator) {
+        background-color: #ff0088;
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        right: 0;
+        z-index: 1;
+        border-radius: 5px;
+    }
+
+    .container :global(button) {
+        all: unset;
+        z-index: 2;
+        position: relative;
+        cursor: pointer;
+        padding: 10px 14px;
+        border-radius: 5px;
+        color: var(--color-foreground);
+        font-size: 14px;
+        --accent-transparent: rgba(255, 0, 136, 0.15);
+    }
+</style>

--- a/docs/src/lib/examples/toggle-switch/demos/Default.svelte
+++ b/docs/src/lib/examples/toggle-switch/demos/Default.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+    import { motion, type MotionTransition } from '@humanspeak/svelte-motion'
+
+    let isOn = $state(true)
+
+    // From https://easings.net/#easeOutBounce
+    const bounceEase = (x: number): number => {
+        const n1 = 7.5625
+        const d1 = 2.75
+
+        if (x < 1 / d1) {
+            return n1 * x * x
+        } else if (x < 2 / d1) {
+            return n1 * (x -= 1.5 / d1) * x + 0.75
+        } else if (x < 2.5 / d1) {
+            return n1 * (x -= 2.25 / d1) * x + 0.9375
+        } else {
+            return n1 * (x -= 2.625 / d1) * x + 0.984375
+        }
+    }
+
+    const bounce: MotionTransition = {
+        duration: 1.2,
+        ease: bounceEase
+    }
+
+    const spring: MotionTransition = {
+        type: 'spring',
+        stiffness: 700,
+        damping: 30
+    }
+
+    // Spring on the way up (snappy), bounce on the way down (playful).
+    const currentTransition = $derived(isOn ? spring : bounce)
+</script>
+
+<!-- HUMANSPEAK: docs-kit positioning shell — stripped from the published code. -->
+<div class="humanspeak-demo-shell">
+    <button
+        class="switch"
+        class:is-on={isOn}
+        onclick={() => (isOn = !isOn)}
+        type="button"
+        aria-label={isOn ? 'Turn off' : 'Turn on'}
+    >
+        <motion.div class="ball" layout transition={currentTransition} />
+    </button>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 320px;
+    }
+
+    .switch {
+        width: 80px;
+        height: 200px;
+        background-color: rgba(255, 255, 255, 0.2);
+        display: flex;
+        align-items: flex-end;
+        border-radius: 50px;
+        padding: 10px;
+        cursor: pointer;
+        border: none;
+        transition: background-color 0.3s;
+    }
+
+    .switch:hover {
+        background-color: rgba(255, 255, 255, 0.25);
+    }
+
+    .switch.is-on {
+        align-items: flex-start;
+    }
+
+    :global(.ball) {
+        width: 60px;
+        height: 60px;
+        background-color: #f5f5f5;
+        border-radius: 30px;
+        will-change: transform;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    }
+</style>

--- a/docs/src/lib/examples/variants-dynamic/demos/Default.svelte
+++ b/docs/src/lib/examples/variants-dynamic/demos/Default.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+    import { motion, styleString, type Variants } from '@humanspeak/svelte-motion'
+
+    // Seven cards cycle through three named states (`fanned`,
+    // `exploded`, `stacked`). Each state is a *function* variant —
+    // `(i) => keyframes` — and the `custom={i}` prop forwards each
+    // card's index into the function. That's the dynamic-variant
+    // shape: one variants map, per-instance values without
+    // duplicating keyframes.
+
+    const STATES = ['fanned', 'exploded', 'stacked'] as const
+    type State = (typeof STATES)[number]
+
+    const NEXT_LABEL: Record<State, string> = {
+        fanned: 'Explode →',
+        exploded: 'Stack →',
+        stacked: 'Fan out →'
+    }
+
+    let state = $state<State>('fanned')
+
+    const CARDS = 7
+    const cards = Array.from({ length: CARDS }, (_, i) => i)
+    const center = (CARDS - 1) / 2
+
+    const cardVariants: Variants = {
+        fanned: (i) => {
+            const offset = (i as number) - center
+            return {
+                x: offset * 22,
+                y: Math.abs(offset) * 12,
+                rotate: offset * 9,
+                scale: 1,
+                opacity: 1,
+                transition: { type: 'spring', stiffness: 220, damping: 22 }
+            }
+        },
+        exploded: (i) => {
+            const offset = (i as number) - center
+            return {
+                x: offset * 95,
+                y: -Math.abs(offset) * 8 - 20,
+                rotate: offset * 14,
+                scale: 1.05,
+                opacity: 1,
+                transition: { type: 'spring', stiffness: 200, damping: 18 }
+            }
+        },
+        stacked: (i) => ({
+            x: (i as number) * 1,
+            y: -(i as number) * 1,
+            rotate: 0,
+            scale: 1,
+            opacity: 1,
+            transition: {
+                type: 'spring',
+                stiffness: 320,
+                damping: 30,
+                delay: (i as number) * 0.03
+            }
+        })
+    }
+
+    const hues = ['#f97316', '#ec4899', '#8b5cf6', '#06b6d4', '#22c55e', '#eab308', '#ef4444']
+
+    function cycle() {
+        state = STATES[(STATES.indexOf(state) + 1) % STATES.length]
+    }
+</script>
+
+<!-- HUMANSPEAK: docs-kit positioning shell — stripped from the published code. -->
+<div class="humanspeak-demo-shell">
+    <div
+        style={styleString(() => ({
+            position: 'relative',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: '440px',
+            padding: '2rem'
+        }))}
+    >
+        <div
+            style={styleString(() => ({
+                position: 'relative',
+                width: '100%',
+                height: '280px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center'
+            }))}
+        >
+            {#each cards as i (i)}
+                <motion.div
+                    custom={i}
+                    variants={cardVariants}
+                    initial="stacked"
+                    animate={state}
+                    whileHover={{
+                        scale: 1.15,
+                        zIndex: 10,
+                        transition: { type: 'spring', stiffness: 320, damping: 20 }
+                    }}
+                    style={styleString(() => ({
+                        position: 'absolute',
+                        width: '110px',
+                        height: '160px',
+                        borderRadius: 12,
+                        background: `linear-gradient(155deg, ${hues[i]} 0%, ${hues[(i + 3) % hues.length]} 100%)`,
+                        boxShadow:
+                            '0 14px 38px -12px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.12) inset, 0 1px 0 rgba(255,255,255,0.25) inset',
+                        border: '2px solid rgba(255,255,255,0.6)',
+                        display: 'flex',
+                        alignItems: 'flex-end',
+                        justifyContent: 'center',
+                        padding: '0.75rem',
+                        color: 'white',
+                        fontFamily: 'JetBrains Mono Variable, ui-monospace, monospace',
+                        fontWeight: 700,
+                        fontSize: '0.9rem',
+                        textShadow: '0 1px 2px rgba(0,0,0,0.3)',
+                        cursor: 'pointer',
+                        zIndex: i + 1
+                    }))}
+                >
+                    №{i + 1}
+                </motion.div>
+            {/each}
+        </div>
+
+        <motion.button
+            whileTap={{ scale: 0.95 }}
+            whileHover={{ scale: 1.04, backgroundColor: 'var(--color-brand-600)' }}
+            onclick={cycle}
+            style={styleString(() => ({
+                marginTop: '1.5rem',
+                padding: '0.65rem 1.5rem',
+                background: 'var(--color-brand-500)',
+                color: '#ffffff',
+                border: 'none',
+                borderRadius: 10,
+                fontSize: '0.95rem',
+                fontWeight: 600,
+                cursor: 'pointer',
+                letterSpacing: '0.02em',
+                boxShadow:
+                    '0 4px 14px -4px color-mix(in oklab, var(--color-brand-500) 70%, transparent)'
+            }))}
+        >
+            {NEXT_LABEL[state]}
+        </motion.button>
+
+        <p
+            style={styleString(() => ({
+                marginTop: '0.85rem',
+                fontSize: '0.78rem',
+                color: 'var(--color-text-muted)',
+                fontFamily: 'JetBrains Mono Variable, ui-monospace, monospace',
+                letterSpacing: '0.02em'
+            }))}
+        >
+            // state: <b style="color: var(--color-brand-500)">{state}</b> — every card resolves
+            <code style="color: var(--color-text-primary)">variants[{state}](i)</code>
+        </p>
+    </div>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 540px;
+    }
+</style>

--- a/docs/src/lib/examples/variants-while-hover/demos/InlineForm.svelte
+++ b/docs/src/lib/examples/variants-while-hover/demos/InlineForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+    import { motion, styleString } from '@humanspeak/svelte-motion'
+</script>
+
+<!-- HUMANSPEAK: positioning shell — docs-kit's `.dk-ex-body` flex column
+     gives its direct child `flex: 1 1 auto`, so this wrapper grows to
+     fill the example panel and pushes the footer strip to the bottom of
+     the sheet. The motion card then centers within. Stripped from the
+     published manifest by `demoManifestPlugin`'s `stripComments` +
+     `stripWrappers` so readers see only the lesson code below. -->
+<div class="humanspeak-demo-shell">
+    <motion.div
+        whileHover={{ scale: 1.06, boxShadow: '0 12px 24px -8px rgba(0,0,0,0.25)' }}
+        whileTap={{ scale: 0.96 }}
+        style={styleString(() => ({
+            width: '200px',
+            height: '120px',
+            borderRadius: 16,
+            padding: '1rem',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+            background: 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)',
+            color: '#fff',
+            fontWeight: 600,
+            fontSize: '0.95rem',
+            cursor: 'pointer'
+        }))}
+    >
+        <span>hover or tap me</span>
+        <small style="opacity: 0.75; font-weight: 400;">whileHover={`{{...}}`}</small>
+    </motion.div>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 240px;
+    }
+</style>

--- a/docs/src/lib/examples/variants-while-hover/demos/VariantKey.svelte
+++ b/docs/src/lib/examples/variants-while-hover/demos/VariantKey.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+    import { motion, styleString, type Variants } from '@humanspeak/svelte-motion'
+
+    // The named states live once on the `variants` map and any number of
+    // gesture props can pull from them by key. Same animation reused across
+    // `whileHover`, `whileTap` (and `whileFocus` / `whileDrag` / `whileInView`).
+    const cardVariants: Variants = {
+        hovered: { scale: 1.06, boxShadow: '0 12px 24px -8px rgba(0,0,0,0.25)' },
+        pressed: { scale: 0.96 }
+    }
+</script>
+
+<!-- HUMANSPEAK: positioning shell — see InlineForm.svelte's note for the
+     full why; stripped from the published manifest. -->
+<div class="humanspeak-demo-shell">
+    <motion.div
+        variants={cardVariants}
+        whileHover="hovered"
+        whileTap="pressed"
+        style={styleString(() => ({
+            width: '200px',
+            height: '120px',
+            borderRadius: 16,
+            padding: '1rem',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+            background: 'linear-gradient(135deg, #22c55e 0%, #06b6d4 100%)',
+            color: '#fff',
+            fontWeight: 600,
+            fontSize: '0.95rem',
+            cursor: 'pointer'
+        }))}
+    >
+        <span>hover or tap me</span>
+        <small style="opacity: 0.75; font-weight: 400;">whileHover="hovered"</small>
+    </motion.div>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 240px;
+    }
+</style>

--- a/docs/src/lib/examples/while-focus/demos/Default.svelte
+++ b/docs/src/lib/examples/while-focus/demos/Default.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+    import { motion } from '@humanspeak/svelte-motion'
+
+    // `whileFocus` reacts to keyboard focus + click focus on natively
+    // focusable elements. The animation lasts as long as the element
+    // holds focus and reverses on blur — perfect for keyboard-driven
+    // affordances.
+</script>
+
+<!-- HUMANSPEAK: docs-kit positioning shell — stripped from the published code. -->
+<div class="humanspeak-demo-shell">
+    <div class="container">
+        <p class="instructions">Tab through or click the elements below to see focus animations:</p>
+
+        <motion.button
+            class="focus-button"
+            whileFocus={{ scale: 1.1, boxShadow: '0 0 0 3px rgba(13, 99, 248, 0.5)' }}
+            onFocusStart={() => console.log('Button focused')}
+            onFocusEnd={() => console.log('Button blurred')}
+        >
+            Focus Me
+        </motion.button>
+
+        <motion.input
+            type="text"
+            placeholder="Type here..."
+            class="focus-input"
+            whileFocus={{
+                scale: 1.05,
+                borderColor: '#0d63f8',
+                boxShadow: '0 0 0 3px rgba(13, 99, 248, 0.2)'
+            }}
+        />
+
+        <motion.div
+            tabindex="0"
+            class="focus-card"
+            whileFocus={{
+                scale: 1.08,
+                backgroundColor: '#0d63f8',
+                color: '#ffffff',
+                transition: { duration: 0.2 }
+            }}
+        >
+            Focusable Card
+        </motion.div>
+    </div>
+</div>
+
+<style>
+    .humanspeak-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 420px;
+    }
+
+    .container {
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        align-items: center;
+        padding: 40px 20px;
+    }
+
+    .instructions {
+        font-size: 14px;
+        color: var(--text-secondary, #6b7280);
+        text-align: center;
+        margin-bottom: 10px;
+    }
+
+    :global(.focus-button) {
+        width: 140px;
+        height: 50px;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        border: none;
+        border-radius: 8px;
+        font-size: 16px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: opacity 0.2s;
+    }
+
+    :global(.focus-button:hover) {
+        opacity: 0.9;
+    }
+
+    :global(.focus-input) {
+        width: 240px;
+        padding: 12px 16px;
+        border: 2px solid #d1d5db;
+        border-radius: 8px;
+        font-size: 14px;
+        background: white;
+        transition: background-color 0.2s;
+    }
+
+    :global(.focus-input:hover) {
+        background-color: #f9fafb;
+    }
+
+    :global(.focus-card) {
+        width: 180px;
+        height: 80px;
+        background-color: #22c55e;
+        border-radius: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+        color: white;
+        cursor: pointer;
+        user-select: none;
+        box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+    }
+
+    :global(.focus-card:hover) {
+        box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1);
+    }
+</style>

--- a/docs/src/routes/examples/+layout.svelte
+++ b/docs/src/routes/examples/+layout.svelte
@@ -1,32 +1,65 @@
 <script lang="ts">
-    import { HeaderV2, FooterV2 } from '@humanspeak/docs-kit'
+    import { enhanceCodeBlocks, ExampleLayoutV2 } from '@humanspeak/docs-kit'
     import { MotionConfig } from '@humanspeak/svelte-motion'
-    import { docsConfig } from '$lib/docs-config'
     import favicon from '$lib/assets/logo.svg'
+    import { docsConfig } from '$lib/docs-config'
     import rootPkg from '../../../../package.json'
     import '@fontsource-variable/inter/index.css'
     import '@fontsource-variable/jetbrains-mono/index.css'
 
-    const PKG_VERSION = rootPkg.version
-
     const { children } = $props()
+    const PKG_VERSION = rootPkg.version
 </script>
 
-<div class="flex min-h-screen flex-col justify-between bg-background">
-    <HeaderV2
-        config={docsConfig}
-        {favicon}
-        version={PKG_VERSION}
-        nav={[
-            { label: 'docs', href: '/docs' },
-            { label: 'examples', href: '/examples' },
-            { label: 'compare', href: '/compare' }
-        ]}
-    />
-    <main class="flex flex-1 flex-col">
+<!--
+    Brutalist examples shell. `ExampleLayoutV2` is the docs-kit-provided
+    `.brut-wrap` surface that supplies the `--brut-bg` / `--brut-rule` /
+    `--brut-accent` CSS tokens every `ExampleV2` sheet needs to render its
+    hairline-bordered chrome. Without this wrapper the panel chrome
+    disappears and demos float on the raw page background.
+
+    `enhanceCodeBlocks` decorates inline `<code>` chips with the brutalist
+    "filled with thin rule" treatment so references like
+    `<code>whileHover</code>` inside notes columns visually pop.
+
+    `MotionConfig` provides the same 0.6s default transition the previous
+    layout shipped — preserved so existing per-example transition
+    overrides keep behaving the same way.
+-->
+<ExampleLayoutV2
+    config={docsConfig}
+    {favicon}
+    version={PKG_VERSION}
+    nav={[
+        { label: 'docs', href: '/docs' },
+        { label: 'examples', href: '/examples' },
+        { label: 'compare', href: '/compare' }
+    ]}
+>
+    <div class="flex flex-1 flex-col" use:enhanceCodeBlocks>
         <MotionConfig transition={{ duration: 0.6 }}>
             {@render children?.()}
         </MotionConfig>
-    </main>
-    <FooterV2 version={PKG_VERSION} />
-</div>
+    </div>
+</ExampleLayoutV2>
+
+<style>
+    /*
+     * docs-kit's `.dk-ex-body` defaults to `flex-grow: 0`, which leaves
+     * the footer strip floating mid-panel whenever the lede column is
+     * taller than the demo body (notes column + description vs a small
+     * interactive demo card). svelte-markdown's demos are content-heavy
+     * enough — full markdown renders — that the body fills naturally
+     * and the issue doesn't surface. Our motion demos are intrinsically
+     * sized cards, so we force the body to claim the remaining panel
+     * height; the footer then anchors to the panel bottom and the
+     * demo's `min-height` shell centers the card.
+     *
+     * TODO(docs-kit): file an upstream issue — `.dk-ex-body` should
+     * probably be `flex: 1` by default since the panel chrome relies on
+     * the footer being anchored to the bottom.
+     */
+    :global(.dk-ex-body) {
+        flex: 1 1 auto;
+    }
+</style>

--- a/docs/src/routes/examples/animated-tabs/+page.svelte
+++ b/docs/src/routes/examples/animated-tabs/+page.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { Boxes, MoveHorizontal, Sparkles } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import AnimatedTabsExample from '$lib/examples/AnimatedTabsExample.svelte'
+    import AnimatedTabsDefault from '$lib/examples/animated-tabs/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
 
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
@@ -22,8 +25,105 @@
         seo.ogFeatures = ['layoutId', 'Sliding Indicator', 'Spring Physics', 'bits-ui']
         seo.ogSlug = 'examples-animated-tabs'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'LAYOUTID',
+            title: { prefix: 'animated ', accent: 'tabs', end: '.' },
+            description:
+                'A shared `layoutId` on the active indicator slides it between tab triggers with spring physics. State management stays on bits-ui; animation stays on svelte-motion.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'tabs-sliding-indicator' }],
+            sourceUrl: `${SOURCE_URL}animated-tabs/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="Animated Tabs" file="AnimatedTabsExample.svelte">
-    <AnimatedTabsExample />
-</Example>
+{#snippet defaultSection()}
+    <AnimatedTabsDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <MoveHorizontal />
+            <span>
+                The active-tab indicator carries a shared <code>layoutId</code> across all triggers —
+                when the active tab changes, motion animates the indicator from the old position to the
+                new one.
+            </span>
+        </li>
+        <li>
+            <Sparkles />
+            <span>
+                Tab content fades through <code>AnimatePresence</code> so switching panels reads as a
+                state change, not a hard cut.
+            </span>
+        </li>
+        <li>
+            <Boxes />
+            <span>
+                Composed on top of bits-ui's <code>Tabs.Root</code> — bits-ui owns the state machine
+                + keyboard accessibility, svelte-motion owns the animation. Add
+                <code>animated={false}</code> on the root to fall back to vanilla shadcn behaviour.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'animated-tabs-default',
+                label: 'Default.svelte',
+                ...manifest['animated-tabs/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/characters-remaining/+page.svelte
+++ b/docs/src/routes/examples/characters-remaining/+page.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { Activity, Palette, Type } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import CharactersRemainingExample from '$lib/examples/CharactersRemainingExample.svelte'
+    import CharactersRemainingDefault from '$lib/examples/characters-remaining/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
 
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
@@ -22,8 +25,107 @@
         seo.ogFeatures = ['Spring Bounce', 'Color Mapping', 'Reactive Updates', 'Visual Feedback']
         seo.ogSlug = 'examples-characters-remaining'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'TRANSFORM',
+            title: { prefix: 'characters ', accent: 'remaining', end: '.' },
+            description:
+                'Type into the input. As you approach the 12-character limit the counter darkens through pink and the digit bounces — a `transform` value-mapper drives the colour, an imperative `animate()` spring keyed by the count drives the bounce.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'mapped-feedback' }],
+            sourceUrl: `${SOURCE_URL}characters-remaining/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="Characters Remaining" file="CharactersRemainingExample.svelte">
-    <CharactersRemainingExample />
-</Example>
+{#snippet defaultSection()}
+    <CharactersRemainingDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Type />
+            <span>
+                <code>transform([from, to], [a, b])</code> builds a function that maps a numeric input
+                to an interpolated output. The colour mapper here goes from pink at 2 left to muted grey
+                at 6+ left — a smooth read of urgency without conditional CSS.
+            </span>
+        </li>
+        <li>
+            <Activity />
+            <span>
+                The spring fires from a <code>$effect</code> keyed by
+                <code>charactersRemaining</code>. <code>velocity</code> scales with the count, so the
+                bounce gets more energetic as the limit approaches and goes still when there's room to
+                spare.
+            </span>
+        </li>
+        <li>
+            <Palette />
+            <span>
+                The counter's <code>color</code> is a regular reactive style; only the
+                <code>scale</code> bounce is imperative because we want the spring to fire on value change,
+                not just animate to a target.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'characters-remaining-default',
+                label: 'Default.svelte',
+                ...manifest['characters-remaining/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/color-interpolation/+page.svelte
+++ b/docs/src/routes/examples/color-interpolation/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { Palette, Route, Sparkles } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import ColorInterpolationExample from '$lib/examples/ColorInterpolationExample.svelte'
+    import ColorInterpolationDefault from '$lib/examples/color-interpolation/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
+
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -25,8 +29,105 @@
         ]
         seo.ogSlug = 'examples-color-interpolation'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'COLOR',
+            title: { prefix: 'rgb vs ', accent: 'hsl', end: '.' },
+            description:
+                'The browser`s Web Animations API and motion`s `animate()` interpolate colours differently. Watch them side by side: the left swatch sweeps through hue (HSL), the right takes a straight line in RGB space.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'interpolation comparison' }],
+            sourceUrl: `${SOURCE_URL}color-interpolation/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="Color Interpolation" file="ColorInterpolationExample.svelte">
-    <ColorInterpolationExample />
-</Example>
+{#snippet defaultSection()}
+    <ColorInterpolationDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Route />
+            <span>
+                Same start (<code>#ff0088</code>) and end (<code>#0d63f8</code>) colour for both
+                swatches — only the interpolation path differs.
+            </span>
+        </li>
+        <li>
+            <Palette />
+            <span>
+                The left swatch (WAAPI) sweeps through HSL space, so the midpoint takes a detour
+                through orange / green / cyan before reaching blue. The right swatch (motion) walks
+                straight through RGB space — magenta dims, blue brightens, no hue detour.
+            </span>
+        </li>
+        <li>
+            <Sparkles />
+            <span>
+                Pure motion call: <code>animate(element, &#123;backgroundColor: […]&#125;, …)</code>
+                binds an imperative animation lifecycle to the element. The returned controls let you
+                <code>cancel()</code> on cleanup so the animation doesn't outlive the component.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'color-interpolation-default',
+                label: 'Default.svelte',
+                ...manifest['color-interpolation/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/conic-gradient/+page.svelte
+++ b/docs/src/routes/examples/conic-gradient/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { MousePointer2, Palette, Wand2 } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import ConicGradientExample from '$lib/examples/ConicGradientExample.svelte'
+    import ConicGradientDefault from '$lib/examples/conic-gradient/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
+
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -20,8 +24,107 @@
         seo.ogFeatures = ['Pointer Tracking', 'useTransform', 'Writable Stores', 'CSS Gradients']
         seo.ogSlug = 'examples-conic-gradient'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'USETRANSFORM',
+            title: { prefix: 'pointer-tracking ', accent: 'gradient', end: '.' },
+            description:
+                'Move the cursor across the swatch. Two writable stores track the pointer position; `useTransform` derives the `conic-gradient(...)` background string from them; `styleString` paints it onto the inline style.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'derived-style' }],
+            sourceUrl: `${SOURCE_URL}conic-gradient/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="Conic Gradient" file="ConicGradientExample.svelte">
-    <ConicGradientExample />
-</Example>
+{#snippet defaultSection()}
+    <ConicGradientDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <MousePointer2 />
+            <span>
+                Two writable stores (<code>gradientX</code>, <code>gradientY</code>) hold the
+                pointer's normalised position. <code>onpointermove</code> writes to them; the derived
+                background re-evaluates synchronously.
+            </span>
+        </li>
+        <li>
+            <Wand2 />
+            <span>
+                <code>useTransform(fn, deps)</code> returns a derived motion value that recomputes
+                whenever any dep store changes. The fn produces the full
+                <code>conic-gradient(...)</code> string by interpolating store values into a template
+                literal.
+            </span>
+        </li>
+        <li>
+            <Palette />
+            <span>
+                <code>styleString</code> serialises the derived value object onto the inline
+                <code>style</code> attribute. Re-evaluates every time
+                <code>$background</code> emits, keeping the gradient in lockstep with the pointer.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'conic-gradient-default',
+                label: 'Default.svelte',
+                ...manifest['conic-gradient/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/fancy-like-button/+page.svelte
+++ b/docs/src/routes/examples/fancy-like-button/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { Hand, Heart, SlidersHorizontal } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import FancyLikeButtonExample from '$lib/examples/FancyLikeButtonExample.svelte'
+    import FancyLikeButtonDefault from '$lib/examples/fancy-like-button/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
+
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -21,8 +25,110 @@
         seo.ogFeatures = ['Particle Burst', 'Press & Hold', 'Heart Animation', 'Spring Physics']
         seo.ogSlug = 'examples-fancy-like-button'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'GESTURE',
+            title: { prefix: 'fancy ', accent: 'like button', end: '.' },
+            description:
+                'Press and hold the heart to spawn a stream of bursting hearts and circles. Each particle animates `x` / `y` / `opacity` with its own timing — many small motion components composed for one rich gesture.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'press-hold-burst' }],
+            sourceUrl: `${SOURCE_URL}fancy-like-button/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="Fancy Like Button" file="FancyLikeButtonExample.svelte">
-    <FancyLikeButtonExample />
-</Example>
+{#snippet defaultSection()}
+    <FancyLikeButtonDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Hand />
+            <span>
+                Pointer + keyboard handling lives in a single Svelte action (<code
+                    >likeInteraction</code
+                >) so the gesture surface stays accessible —
+                <code>pointerdown</code> starts spawning, <code>pointerup</code> /
+                <code>pointercancel</code> stop it, and Enter / Space mirror the same toggle for keyboard
+                users.
+            </span>
+        </li>
+        <li>
+            <Heart />
+            <span>
+                Each burst pushes a heart and 15 circle entries into reactive
+                <code>$state</code> arrays. Every motion entry animates from the button's centre to
+                a random offset, then drops out of the array via a <code>setTimeout</code>
+                cleanup once its animation has settled.
+            </span>
+        </li>
+        <li>
+            <SlidersHorizontal />
+            <span>
+                The <code>transition</code> prop accepts per-key objects — independent timings for
+                <code>x</code>, <code>y</code>, and <code>opacity</code> let the particles drift sideways
+                quickly, rise more slowly, and fade out last for the layered feel.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'fancy-like-button-default',
+                label: 'Default.svelte',
+                ...manifest['fancy-like-button/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/keyframes/+page.svelte
+++ b/docs/src/routes/examples/keyframes/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { Clock, Layers, Repeat } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import KeyframesExample from '$lib/examples/KeyframesExample.svelte'
+    import KeyframesDefault from '$lib/examples/keyframes/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
+
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -18,8 +22,107 @@
         seo.ogFeatures = ['Multi-Property', 'Scale & Rotate', 'Border Radius', 'Sequence Animation']
         seo.ogSlug = 'examples-keyframes'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'ANIMATE',
+            title: { prefix: 'multi-property ', accent: 'keyframes', end: '.' },
+            description:
+                'Three properties (`scale`, `rotate`, `borderRadius`) animate in lockstep as arrays of keyframes. `times` aligns each value to a normalised t — the square grows, then turns into a spinning circle, then settles back.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'keyframe-array' }],
+            sourceUrl: `${SOURCE_URL}keyframes/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="Keyframes" file="KeyframesExample.svelte">
-    <KeyframesExample />
-</Example>
+{#snippet defaultSection()}
+    <KeyframesDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Layers />
+            <span>
+                Pass an <strong>array</strong> as any animate value to walk through keyframes —
+                <code>scale: [1, 2, 2, 1, 1]</code> traces five samples. Multiple properties with arrays
+                of the same length keep step automatically.
+            </span>
+        </li>
+        <li>
+            <Clock />
+            <span>
+                <code>times: [0, 0.2, 0.5, 0.8, 1]</code> maps each keyframe to a normalised t in
+                <code>[0, 1]</code>
+                — independent of duration. Cluster keyframes near
+                <code>0.5</code> for a held middle state, spread them for steady motion.
+            </span>
+        </li>
+        <li>
+            <Repeat />
+            <span>
+                <code>repeat: Infinity</code> + <code>repeatDelay: 1</code> loops the sequence with a
+                one-second breath between cycles. Useful for ambient idle animations that don't compete
+                for attention.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'keyframes-default',
+                label: 'Default.svelte',
+                ...manifest['keyframes/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/layout-group/+page.svelte
+++ b/docs/src/routes/examples/layout-group/+page.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { Layers, Lock, Shuffle } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import LayoutGroupExample from '$lib/examples/LayoutGroupExample.svelte'
+    import LayoutGroupDefault from '$lib/examples/layout-group/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
 
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
@@ -21,8 +24,107 @@
         seo.ogFeatures = ['Shared layout', 'LayoutGroup', 'layoutId scoping', 'Tab strips']
         seo.ogSlug = 'examples-layout-group'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'LAYOUTGROUP',
+            title: { prefix: 'scoped ', accent: 'layoutId', end: '.' },
+            description:
+                'Two sibling tab strips share `layoutId="underline"`. Each strip lives in its own `<LayoutGroup id>` so the underline animation stays scoped — clicking a tab in one strip never pulls the underline from the other.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'scoped shared-layout' }],
+            sourceUrl: `${SOURCE_URL}layout-group/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="LayoutGroup — scope shared-layout animations" file="LayoutGroupExample.svelte">
-    <LayoutGroupExample />
-</Example>
+{#snippet defaultSection()}
+    <LayoutGroupDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Layers />
+            <span>
+                Same <code>layoutId="underline"</code> appears in <strong>both</strong> tab strips.
+                Without scoping, the underline would jump between strips because
+                <code>motion</code> looks up <code>layoutId</code> on a single global registry.
+            </span>
+        </li>
+        <li>
+            <Lock />
+            <span>
+                Wrapping each strip in <code>&lt;LayoutGroup id="strip-a"&gt;</code> /
+                <code>id="strip-b"</code> prefixes the registry key —
+                <code>strip-a::underline</code> vs <code>strip-b::underline</code> — so the two animations
+                never see each other.
+            </span>
+        </li>
+        <li>
+            <Shuffle />
+            <span>
+                Click tabs across both strips: the underline always slides within its own strip. Try
+                removing the <code>&lt;LayoutGroup&gt;</code> wrappers locally and the underline will
+                jump across the page on every click.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'layout-group-default',
+                label: 'Default.svelte',
+                ...manifest['layout-group/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/layout-scroll/+page.svelte
+++ b/docs/src/routes/examples/layout-scroll/+page.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { Anchor, Hand, MousePointer2 } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import LayoutScrollExample from '$lib/examples/LayoutScrollExample.svelte'
+    import LayoutScrollDefault from '$lib/examples/layout-scroll/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
 
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
@@ -21,8 +24,105 @@
         seo.ogFeatures = ['FLIP layout', 'layoutScroll', 'Scroll containers', 'Anchored animations']
         seo.ogSlug = 'examples-layout-scroll'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'LAYOUTSCROLL',
+            title: { prefix: 'anchored ', accent: 'inside scroll', end: '.' },
+            description:
+                'FLIP measures viewport-relative rects by default — scroll a parent container mid-animation and the offset leaks in as drift. Marking the scroll container with `layoutScroll` keeps measurements anchored.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'side-by-side comparison' }],
+            sourceUrl: `${SOURCE_URL}layout-scroll/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="layoutScroll — FLIP inside scroll containers" file="LayoutScrollExample.svelte">
-    <LayoutScrollExample />
-</Example>
+{#snippet defaultSection()}
+    <LayoutScrollDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Hand />
+            <span>
+                Click <strong>expand box</strong> — the FLIP runs over 1.8 s, plenty of time to
+                experiment. <em>While the boxes are still animating</em>, drag the scrollbar of
+                either panel down by ~80 px.
+            </span>
+        </li>
+        <li>
+            <MousePointer2 />
+            <span>
+                Left panel — the red box drifts as the FLIP transform fights the scroll offset. Same
+                FLIP, no <code>layoutScroll</code>.
+            </span>
+        </li>
+        <li>
+            <Anchor />
+            <span>
+                Right panel — the teal box stays anchored in scroll-content space.
+                <code>layoutScroll</code> tells FLIP to re-base measurements in the container's coordinate
+                system, so a mid-animation scroll cancels out instead of leaking into the delta.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'layout-scroll-default',
+                label: 'Default.svelte',
+                ...manifest['layout-scroll/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/multi-state-badge/+page.svelte
+++ b/docs/src/routes/examples/multi-state-badge/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { Activity, Repeat, Sparkles } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import MultiStateBadgeExample from '$lib/examples/MultiStateBadgeExample.svelte'
+    import MultiStateBadgeDefault from '$lib/examples/multi-state-badge/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
+
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -26,8 +30,107 @@
         ]
         seo.ogSlug = 'examples-multi-state-badge'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'ANIMATE-PRESENCE',
+            title: { prefix: 'multi-state ', accent: 'badge', end: '.' },
+            description:
+                'A badge that cycles `idle → processing → success → error → idle`. Click to advance. Each state swap exits and enters its icon + label inside `AnimatePresence`, with blur + scale carrying the transitions.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'state-cycle' }],
+            sourceUrl: `${SOURCE_URL}multi-state-badge/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="Multi-State Badge" file="MultiStateBadgeExample.svelte">
-    <MultiStateBadgeExample />
-</Example>
+{#snippet defaultSection()}
+    <MultiStateBadgeDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Repeat />
+            <span>
+                The badge holds an enum state (<code>idle</code>, <code>processing</code>,
+                <code>success</code>, <code>error</code>) — clicking advances to the next via
+                <code>getNextState()</code>. State change drives every animation downstream.
+            </span>
+        </li>
+        <li>
+            <Sparkles />
+            <span>
+                Icon + label both live inside <code>AnimatePresence</code> keyed by state. Exit blurs
+                and shrinks the outgoing content; enter blurs and grows the incoming content. Layout stays
+                put because the badge chrome wraps the presence.
+            </span>
+        </li>
+        <li>
+            <Activity />
+            <span>
+                The composition lives in
+                <code>$lib/examples/multi-state-badge/Badge.svelte</code> alongside icon helpers. The
+                demo file is a thin wrapper that owns the state cycle — the animation lives in the badge
+                components.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'multi-state-badge-default',
+                label: 'Default.svelte',
+                ...manifest['multi-state-badge/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/path-morphing/+page.svelte
+++ b/docs/src/routes/examples/path-morphing/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { Gauge, Shapes, Zap } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import PathMorphingExample from '$lib/examples/PathMorphingExample.svelte'
+    import PathMorphingDefault from '$lib/examples/path-morphing/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
+
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -21,8 +25,107 @@
         seo.ogFeatures = ['SVG Morphing', 'Shape Interpolation', 'useMotionValue', 'useTransform']
         seo.ogSlug = 'examples-path-morphing'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'SVG',
+            title: { prefix: 'morphing ', accent: 'svg paths', end: '.' },
+            description:
+                'Six icons morphing one into the next on a loop. flubber pre-computes a tween between each adjacent pair; `useTransform` reads a single progress motion value and routes to whichever interpolator is active.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'flubber + useTransform' }],
+            sourceUrl: `${SOURCE_URL}path-morphing/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="Path Morphing" file="PathMorphingExample.svelte">
-    <PathMorphingExample />
-</Example>
+{#snippet defaultSection()}
+    <PathMorphingDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Shapes />
+            <span>
+                Six SVG paths, plus lightning repeated at the end so the loop is seamless.
+                <code>flubber.interpolate(a, b)</code> precomputes the segment-matched tween between each
+                adjacent pair once — flubber is expensive per-call, so we never recompute mid-flight.
+            </span>
+        </li>
+        <li>
+            <Gauge />
+            <span>
+                One <code>useMotionValue(0)</code> drives the whole loop. <code>useTransform</code>
+                reads its value: integer part = which interpolator, fractional part = where in the tween.
+                The path string is recomputed every frame from those two pieces.
+            </span>
+        </li>
+        <li>
+            <Zap />
+            <span>
+                <code>animate(0, target)</code> walks the motion value imperatively;
+                <code>onComplete</code> advances <code>pathIndex</code> and the
+                <code>$effect</code> picks up the next leg. <code>onDestroy</code> stops the in-flight
+                animation so unmount can't strand the value.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'path-morphing-default',
+                label: 'Default.svelte',
+                ...manifest['path-morphing/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/reordering/+page.svelte
+++ b/docs/src/routes/examples/reordering/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { LayoutGrid, Repeat, Zap } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import Reordering from '$lib/examples/Reordering.svelte'
+    import ReorderingDefault from '$lib/examples/reordering/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
+
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -21,8 +25,107 @@
         seo.ogFeatures = ['Drag Gestures', 'Layout Animation', 'List Reorder', 'Smooth FLIP']
         seo.ogSlug = 'examples-reordering'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'LAYOUT',
+            title: { prefix: 'shuffling ', accent: 'list items', end: '.' },
+            description:
+                'Four coloured tiles shuffle their order every second. Each tile carries `layout` — motion measures the rect before + after the array mutation, then springs each tile between positions.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'flip-reorder' }],
+            sourceUrl: `${SOURCE_URL}reordering/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="Reordering" file="Reordering.svelte">
-    <Reordering />
-</Example>
+{#snippet defaultSection()}
+    <ReorderingDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <LayoutGrid />
+            <span>
+                The list keys on <code>backgroundColor</code> — Svelte tracks the same item across re-renders
+                even when its index changes, so motion sees a position change instead of an unmount +
+                remount and can FLIP it.
+            </span>
+        </li>
+        <li>
+            <Zap />
+            <span>
+                Each <code>motion.li</code> has <code>layout</code> on it. Motion samples each item's
+                rect before and after the array mutation; the difference becomes the FLIP delta, and the
+                configured spring carries the tile to its new spot.
+            </span>
+        </li>
+        <li>
+            <Repeat />
+            <span>
+                Shuffle fires from a <code>setTimeout</code> in <code>onMount</code>, recursing via
+                <code>scheduleNextShuffle()</code>
+                so a single source schedules every cycle. <code>onMount</code>'s cleanup clears the
+                pending timeout — important when the component unmounts mid-flight.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'reordering-default',
+                label: 'Default.svelte',
+                ...manifest['reordering/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/tab-select/+page.svelte
+++ b/docs/src/routes/examples/tab-select/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { ArrowLeftRight, Eye, Hand } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import TabSelectExample from '$lib/examples/TabSelectExample.svelte'
+    import TabSelectDefault from '$lib/examples/tab-select/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
+
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -21,8 +25,107 @@
         seo.ogFeatures = ['layoutId', 'Shared Indicator', 'Tab Navigation', 'Slide Animation']
         seo.ogSlug = 'examples-tab-select'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'LAYOUTID',
+            title: { prefix: 'sliding ', accent: 'indicator', end: '.' },
+            description:
+                'A pink indicator slides between tabs on every click. Only the active tab renders one; sharing a `layoutId` lets motion animate the indicator across tab boundaries instead of mount-unmount-flash.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'layoutId-indicator' }],
+            sourceUrl: `${SOURCE_URL}tab-select/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="Tab Select" file="TabSelectExample.svelte">
-    <TabSelectExample />
-</Example>
+{#snippet defaultSection()}
+    <TabSelectDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <ArrowLeftRight />
+            <span>
+                The indicator only renders inside the active tab's <code>&lt;li&gt;</code>. As
+                <code>selectedTab</code> changes, the old indicator unmounts and the new one mounts
+                — sharing <code>layoutId="selected-indicator"</code> tells motion to animate from the
+                old position to the new one instead of fading out / in.
+            </span>
+        </li>
+        <li>
+            <Eye />
+            <span>
+                <code>&lt;AnimatePresence&gt;</code> wraps the conditional render so motion gets a chance
+                to coordinate the handoff. Without it the indicator would still animate position, but
+                the mount/unmount lifecycle wouldn't have a clean exit window.
+            </span>
+        </li>
+        <li>
+            <Hand />
+            <span>
+                Each tab button stacks two gesture props — <code>whileTap</code> for press feedback
+                and <code>whileFocus</code> for keyboard navigation. Plain object form on both; nothing
+                fancier needed.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'tab-select-default',
+                label: 'Default.svelte',
+                ...manifest['tab-select/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/toggle-switch/+page.svelte
+++ b/docs/src/routes/examples/toggle-switch/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { ArrowDownUp, Sparkles, Zap } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import ToggleSwitchExample from '$lib/examples/ToggleSwitchExample.svelte'
+    import ToggleSwitchDefault from '$lib/examples/toggle-switch/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
+
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -20,8 +24,106 @@
         seo.ogFeatures = ['Layout Animation', 'Spring Physics', 'Gesture Driven', 'State Toggle']
         seo.ogSlug = 'examples-toggle-switch'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'LAYOUT',
+            title: { prefix: 'toggle ', accent: 'switch', end: '.' },
+            description:
+                'A single `layout` prop turns a CSS flex flip into a smooth FLIP animation. Each direction picks its own transition — snappy spring on the way up, playful bounce on the way down.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'flip-toggle' }],
+            sourceUrl: `${SOURCE_URL}toggle-switch/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="Toggle Switch" file="ToggleSwitchExample.svelte">
-    <ToggleSwitchExample />
-</Example>
+{#snippet defaultSection()}
+    <ToggleSwitchDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <ArrowDownUp />
+            <span>
+                Flipping <code>align-items</code> between <code>flex-end</code> and
+                <code>flex-start</code> reflows the ball — adding <code>layout</code> on the
+                <code>motion.div</code> turns the resulting CSS reflow into a measured FLIP animation.
+            </span>
+        </li>
+        <li>
+            <Zap />
+            <span>
+                Transitions are per-direction. <code>spring</code> with high stiffness on the way up
+                gives a confident snap; a custom <code>bounceEase</code> on the way down lets the ball
+                settle playfully.
+            </span>
+        </li>
+        <li>
+            <Sparkles />
+            <span>
+                The transition value is typed as <code>MotionTransition</code> — passing a custom
+                easing function (anything <code>(t: number) =&gt; number</code>) works just as well
+                as the built-in keywords.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'toggle-switch-default',
+                label: 'Default.svelte',
+                ...manifest['toggle-switch/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/variants-dynamic/+page.svelte
+++ b/docs/src/routes/examples/variants-dynamic/+page.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { Boxes, GitBranchPlus, Hand } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import VariantsDynamicExample from '$lib/examples/VariantsDynamicExample.svelte'
+    import VariantsDynamicDefault from '$lib/examples/variants-dynamic/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
 
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
@@ -21,8 +24,106 @@
         seo.ogFeatures = ['Variants', 'custom prop', 'Staggered list', 'Function-form variants']
         seo.ogSlug = 'examples-variants-dynamic'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'VARIANTS',
+            title: { prefix: 'function-form ', accent: 'variants', end: '.' },
+            description:
+                'Seven cards. One `variants` map with three function-form states (`fanned`, `exploded`, `stacked`). Each card resolves the active state by passing its own index in via `custom={i}` — per-instance values without writing seven keyframe blocks.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'dynamic variants' }],
+            sourceUrl: `${SOURCE_URL}variants-dynamic/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="Variants Dynamic — custom prop" file="VariantsDynamicExample.svelte">
-    <VariantsDynamicExample />
-</Example>
+{#snippet defaultSection()}
+    <VariantsDynamicDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <GitBranchPlus />
+            <span>
+                Each variant value is a function — <code>(i) => keyframes</code> — instead of a
+                literal object. The function receives whatever the motion component's
+                <code>custom</code> prop holds, and resolves at evaluation time.
+            </span>
+        </li>
+        <li>
+            <Boxes />
+            <span>
+                <code>custom={`{i}`}</code> on each card forwards its array index into the variant
+                function. <code>x: offset * 22</code>, <code>rotate: offset * 9</code>, etc. become
+                per-card values; the variants map stays a single source of truth.
+            </span>
+        </li>
+        <li>
+            <Hand />
+            <span>
+                Hovering a card raises it via <code>whileHover</code> — a plain object since hover
+                doesn't need <code>custom</code>. Function and object form variants co-exist in the
+                same map.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'variants-dynamic-default',
+                label: 'Default.svelte',
+                ...manifest['variants-dynamic/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/variants-while-hover/+page.svelte
+++ b/docs/src/routes/examples/variants-while-hover/+page.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { Code2, KeyRound, Layers, Repeat2 } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import VariantsWhileHoverExample from '$lib/examples/VariantsWhileHoverExample.svelte'
+    import InlineForm from '$lib/examples/variants-while-hover/demos/InlineForm.svelte'
+    import VariantKey from '$lib/examples/variants-while-hover/demos/VariantKey.svelte'
+    // The manifest is generated at build/dev start by `demoManifestPlugin`
+    // (registered in vite.config.ts). Each entry's key is the demo file's
+    // path relative to `src/lib/examples/`. Editing any demo file
+    // regenerates the manifest and Vite reloads the page — the rendered
+    // demo and the displayed code stay in lockstep with zero per-page
+    // bookkeeping.
+    import demoManifest from '$lib/demo-manifest.json'
 
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
@@ -22,11 +32,148 @@
         seo.ogFeatures = ['Variants', 'whileHover', 'whileTap', 'String keys']
         seo.ogSlug = 'examples-variants-while-hover'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    // ── Sheet configuration ────────────────────────────────────────────
+    // One row per sheet section. Each row carries lede words for the left
+    // column and references the demo file in the manifest — the demo
+    // component is mounted as the body, and the manifest entry is fed
+    // through CodeReferenceV2 as the toggleable code panel.
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'INLINE',
+            title: { prefix: 'inline ', accent: 'keyframes', end: '.' },
+            description:
+                'Pass an object directly to whileHover / whileTap. Right for one-off interactions — the animation is co-located with the element that uses it.',
+            snippet: inlineFormSection,
+            codeSnippet: inlineFormCode,
+            notes: inlineFormNotes,
+            barCells: [{ k: 'form', v: 'inline-keyframes' }],
+            sourceUrl: `${SOURCE_URL}variants-while-hover/demos/InlineForm.svelte`
+        },
+        {
+            figId: 'FIG-002',
+            tag: 'VARIANT',
+            title: { prefix: 'variant ', accent: 'key', end: '.' },
+            description:
+                'Name the state on `variants`, reference it by string from any gesture prop. The same `"hovered"` key drives `whileHover`, and could just as easily drive `whileFocus`, `whileDrag`, or `whileInView`.',
+            snippet: variantKeySection,
+            codeSnippet: variantKeyCode,
+            notes: variantKeyNotes,
+            barCells: [{ k: 'form', v: 'variant-key' }],
+            sourceUrl: `${SOURCE_URL}variants-while-hover/demos/VariantKey.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example
-    title="whileX variant keys — reuse variants across gestures"
-    file="VariantsWhileHoverExample.svelte"
->
-    <VariantsWhileHoverExample />
-</Example>
+{#snippet inlineFormSection()}
+    <InlineForm />
+{/snippet}
+{#snippet inlineFormNotes()}
+    <ul>
+        <li>
+            <Code2 />
+            <span>
+                Best for one-off interactions where the animation only applies to a single element
+                and won't be reused.
+            </span>
+        </li>
+        <li>
+            <Repeat2 />
+            <span>
+                Repeat the object on every element if you need the same animation in multiple places
+                — that duplication is the smell that pushes you toward the variant-key form below.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet inlineFormCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'inline-form',
+                label: 'InlineForm.svelte',
+                ...manifest['variants-while-hover/demos/InlineForm.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#snippet variantKeySection()}
+    <VariantKey />
+{/snippet}
+{#snippet variantKeyNotes()}
+    <ul>
+        <li>
+            <Layers />
+            <span>
+                Define the state once on <code>variants</code>; any gesture prop on the same element
+                (or its descendants) can pull from the same map by key.
+            </span>
+        </li>
+        <li>
+            <KeyRound />
+            <span>
+                Works with <code>whileHover</code>, <code>whileTap</code>,
+                <code>whileFocus</code>, <code>whileDrag</code>, and <code>whileInView</code>. Pass
+                a single string or an array of keys (later entries override earlier ones).
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet variantKeyCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'variant-key',
+                label: 'VariantKey.svelte',
+                ...manifest['variants-while-hover/demos/VariantKey.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/while-focus/+page.svelte
+++ b/docs/src/routes/examples/while-focus/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+    import { CodeReferenceV2, ExampleV2 } from '@humanspeak/docs-kit'
+    import { Accessibility, Keyboard, MousePointer2 } from '@lucide/svelte'
+    import type { Snippet } from 'svelte'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
-    import Example from '$lib/components/general/Example.svelte'
-    import WhileFocusExample from '$lib/examples/WhileFocusExample.svelte'
+    import WhileFocusDefault from '$lib/examples/while-focus/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
+
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
     if (breadcrumbs) {
@@ -21,8 +25,105 @@
         seo.ogFeatures = ['whileFocus', 'Accessibility', 'Keyboard Focus', 'Visual Feedback']
         seo.ogSlug = 'examples-while-focus'
     }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    type Section = {
+        figId: string
+        tag: string
+        title: { prefix?: string; accent: string; end?: string }
+        description: string
+        snippet: Snippet
+        codeSnippet?: Snippet
+        notes?: Snippet
+        mode?: 'live' | 'static'
+        barCells?: { k: string; v: string }[]
+        sourceUrl?: string
+    }
+
+    type ManifestEntry = {
+        code: string
+        lang: string
+        html?: { light: string; dark: string }
+    }
+    const manifest = demoManifest as Record<string, ManifestEntry>
+
+    const sections: Section[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'FOCUS',
+            title: { prefix: 'while ', accent: 'focused', end: '.' },
+            description:
+                'Tab through the three elements below — `whileFocus` animates them while they hold focus and reverses on blur. Works on natively focusable elements (button, input) and anything with `tabindex`.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'focus-driven' }],
+            sourceUrl: `${SOURCE_URL}while-focus/demos/Default.svelte`
+        }
+    ]
+
+    const pad2 = (n: number) => String(n).padStart(2, '0')
 </script>
 
-<Example title="While Focus" file="WhileFocusExample.svelte">
-    <WhileFocusExample />
-</Example>
+{#snippet defaultSection()}
+    <WhileFocusDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Keyboard />
+            <span>
+                <code>whileFocus</code> fires for both keyboard focus (Tab) and click focus. Same
+                animation shape as <code>whileHover</code> — pass keyframes (or a variant key) and the
+                value lasts as long as the element holds focus.
+            </span>
+        </li>
+        <li>
+            <MousePointer2 />
+            <span>
+                The card uses <code>tabindex="0"</code> to opt into the focus chain — any element can
+                be focusable, not just buttons and inputs. Useful for custom UI surfaces.
+            </span>
+        </li>
+        <li>
+            <Accessibility />
+            <span>
+                Pair <code>onFocusStart</code> / <code>onFocusEnd</code> callbacks with your own state
+                if you need to react beyond the visual animation (e.g. announce to screen readers, fetch
+                preview data).
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'while-focus-default',
+                label: 'Default.svelte',
+                ...manifest['while-focus/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel="SHEET {pad2(i + 1)} / {pad2(sections.length)}"
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,4 +1,4 @@
-import { sitemapManifestPlugin } from '@humanspeak/docs-kit/vite'
+import { demoManifestPlugin, sitemapManifestPlugin } from '@humanspeak/docs-kit/vite'
 import { svelteMotionOptimize } from '@humanspeak/svelte-motion/vite'
 import { paraglideVitePlugin } from '@inlang/paraglide-js'
 import { sveltekit } from '@sveltejs/kit/vite'
@@ -20,6 +20,24 @@ export default defineConfig({
         // `examples/+page.ts` metadata sync. `blogDir: false` disables
         // docs-kit's default blog-folder scan — we don't have a blog.
         sitemapManifestPlugin({ blogDir: false }),
+        // Scans `src/lib/examples/<slug>/demos/*.svelte`, pre-highlights each
+        // demo's source with Shiki (light + dark), and emits
+        // `src/lib/demo-manifest.json`. Pages import the manifest as a
+        // virtual JSON module and feed individual entries through
+        // `CodeReferenceV2` so the rendered preview and the displayed code
+        // come from the same single source of truth — edit a demo, the
+        // page reloads and the code panel updates in lockstep.
+        //
+        // `stripComments` + `stripWrappers` let us keep an in-file
+        // positioning shell (the `.humanspeak-demo-shell` wrapper that
+        // centers the motion card inside docs-kit's `.dk-ex-body`) plus
+        // maintainer notes tagged `/* HUMANSPEAK */` — without leaking
+        // either into the published code panel. The disk file stays
+        // runnable; the manifest carries only the lesson.
+        demoManifestPlugin({
+            stripComments: ['HUMANSPEAK'],
+            stripWrappers: ['humanspeak-demo-shell']
+        }),
         svelteMotionOptimize(),
         tailwindcss(),
         sveltekit(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.5.27
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/006da929e586e7e702dd258cc99cad31bc3bac53(@humanspeak/svelte-motion@)(@internationalized/date@3.11.0)(@lucide/svelte@1.16.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(shiki@4.1.0)(svelte@5.55.8(@typescript-eslint/types@8.59.4))
+        specifier: github:humanspeak/docs-kit#2026.5.29
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/01c08c236d4270c19b9d6e9dcbff7475a2f79eb3(@humanspeak/svelte-motion@)(@internationalized/date@3.11.0)(@lucide/svelte@1.16.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(shiki@4.1.0)(svelte@5.55.8(@typescript-eslint/types@8.59.4))
       '@humanspeak/svelte-motion':
         specifier: workspace:*
         version: link:..
@@ -912,8 +912,8 @@ packages:
     resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/006da929e586e7e702dd258cc99cad31bc3bac53':
-    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/006da929e586e7e702dd258cc99cad31bc3bac53}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/01c08c236d4270c19b9d6e9dcbff7475a2f79eb3':
+    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/01c08c236d4270c19b9d6e9dcbff7475a2f79eb3}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4697,7 +4697,7 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/006da929e586e7e702dd258cc99cad31bc3bac53(@humanspeak/svelte-motion@)(@internationalized/date@3.11.0)(@lucide/svelte@1.16.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(shiki@4.1.0)(svelte@5.55.8(@typescript-eslint/types@8.59.4))':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/01c08c236d4270c19b9d6e9dcbff7475a2f79eb3(@humanspeak/svelte-motion@)(@internationalized/date@3.11.0)(@lucide/svelte@1.16.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(shiki@4.1.0)(svelte@5.55.8(@typescript-eslint/types@8.59.4))':
     dependencies:
       '@humanspeak/svelte-motion': 'link:'
       '@humanspeak/svelte-satori-fix': 0.0.3(svelte@5.55.8(@typescript-eslint/types@8.59.4))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.5.29
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/01c08c236d4270c19b9d6e9dcbff7475a2f79eb3(@humanspeak/svelte-motion@)(@internationalized/date@3.11.0)(@lucide/svelte@1.16.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(shiki@4.1.0)(svelte@5.55.8(@typescript-eslint/types@8.59.4))
+        specifier: github:humanspeak/docs-kit#2026.5.30
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/5926ef25f8172279e2f6611a79912b81b2248909(@humanspeak/svelte-motion@)(@internationalized/date@3.11.0)(@lucide/svelte@1.16.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(shiki@4.1.0)(svelte@5.55.8(@typescript-eslint/types@8.59.4))
       '@humanspeak/svelte-motion':
         specifier: workspace:*
         version: link:..
@@ -912,8 +912,8 @@ packages:
     resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/01c08c236d4270c19b9d6e9dcbff7475a2f79eb3':
-    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/01c08c236d4270c19b9d6e9dcbff7475a2f79eb3}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/5926ef25f8172279e2f6611a79912b81b2248909':
+    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/5926ef25f8172279e2f6611a79912b81b2248909}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4697,7 +4697,7 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/01c08c236d4270c19b9d6e9dcbff7475a2f79eb3(@humanspeak/svelte-motion@)(@internationalized/date@3.11.0)(@lucide/svelte@1.16.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(shiki@4.1.0)(svelte@5.55.8(@typescript-eslint/types@8.59.4))':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/5926ef25f8172279e2f6611a79912b81b2248909(@humanspeak/svelte-motion@)(@internationalized/date@3.11.0)(@lucide/svelte@1.16.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.8(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(svelte@5.55.8(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)))(mode-watcher@1.1.0(svelte@5.55.8(@typescript-eslint/types@8.59.4)))(shiki@4.1.0)(svelte@5.55.8(@typescript-eslint/types@8.59.4))':
     dependencies:
       '@humanspeak/svelte-motion': 'link:'
       '@humanspeak/svelte-satori-fix': 0.0.3(svelte@5.55.8(@typescript-eslint/types@8.59.4))


### PR DESCRIPTION
## Summary

Phase 2 of the docs UX modernization — Batch 1 migrates all 16 standalone example pages to docs-kit's `ExampleV2` brutalist sheet chrome backed by the `demoManifestPlugin`. Each migration extracts the lesson code into a per-example `demos/Default.svelte`, lets the plugin strip our positioning shell from the published source, and rebuilds the route as a `sections[]`-driven `ExampleV2` instance with lede notes, tag, code drawer, and source link. Standalone-only batch — the 23 examples consumed by `.svx` doc pages (Batch 2) keep their monolithic files for now and will follow on a separate branch.

## Changes

- ✨ Adopt `ExampleV2` + `demoManifestPlugin` chrome for the docs `examples/*` routes; pilot on `variants-while-hover` (split into `InlineForm` + `VariantKey` demos)
- ✨ Migrate 15 more standalone examples: `animated-tabs`, `toggle-switch`, `fancy-like-button`, `layout-scroll`, `layout-group`, `color-interpolation`, `while-focus`, `conic-gradient`, `characters-remaining`, `keyframes`, `variants-dynamic`, `tab-select`, `multi-state-badge`, `path-morphing`, `reordering`
- 🔧 Wire `demoManifestPlugin` with `stripComments: ['HUMANSPEAK']` and `stripWrappers: ['humanspeak-demo-shell']` in `docs/vite.config.ts` so positioning shells stay out of the published code samples
- 🔧 Adopt `ExampleLayoutV2` in `docs/src/routes/examples/+layout.svelte` with a `.dk-ex-body { flex: 1 1 auto }` override so demos center inside the sheet body and the footer anchors
- 📦 Bump docs-kit pin to `github:humanspeak/docs-kit#2026.5.30` (picks up `stripComments`/`stripWrappers` options + the `configResolved` path-resolution fix for plugin output paths)
- 🔧 Add `docs/src/lib/demo-manifest.json` to `docs/.gitignore` alongside the existing sitemap manifest

## Scope notes for reviewers

- **Old monolithic `*Example.svelte` files are still in the tree.** They're imported by `.svx` doc pages that haven't been migrated yet — they'll be deleted once Batch 2 lands.
- **Tag taxonomy is editorial, not enforced.** Tags (`INLINE`, `VARIANT`, `LAYOUTID`, `LAYOUT`, `LAYOUTSCROLL`, `LAYOUTGROUP`, `COLOR`, `FOCUS`, `USETRANSFORM`, `TRANSFORM`, `ANIMATE`, `VARIANTS`, `GESTURE`, `ANIMATE-PRESENCE`, `SVG`) come from the lesson, not a schema.
- **`UsePresenceCard.svelte` was intentionally not migrated** — it's a helper imported by the docs-embedded `use-presence` example, so it moves with Batch 2.

## Commits

- [`9a89fb2`](https://github.com/humanspeak/svelte-motion/commit/9a89fb2) feat(docs): adopt ExampleV2 + demoManifestPlugin chrome — pilot variants-while-hover
- [`3c9c4f1`](https://github.com/humanspeak/svelte-motion/commit/3c9c4f1) feat(docs): migrate animated-tabs to ExampleV2 chrome
- [`0be2f9b`](https://github.com/humanspeak/svelte-motion/commit/0be2f9b) feat(docs): migrate toggle-switch to ExampleV2 chrome
- [`b686280`](https://github.com/humanspeak/svelte-motion/commit/b686280) feat(docs): migrate fancy-like-button to ExampleV2 chrome
- [`d3543e4`](https://github.com/humanspeak/svelte-motion/commit/d3543e4) feat(docs): migrate layout-scroll to ExampleV2 chrome
- [`0d50d55`](https://github.com/humanspeak/svelte-motion/commit/0d50d55) feat(docs): migrate layout-group to ExampleV2 chrome
- [`93d1ee4`](https://github.com/humanspeak/svelte-motion/commit/93d1ee4) feat(docs): migrate color-interpolation to ExampleV2 chrome
- [`13cbf9c`](https://github.com/humanspeak/svelte-motion/commit/13cbf9c) feat(docs): migrate while-focus, conic-gradient, characters-remaining to ExampleV2
- [`8e68871`](https://github.com/humanspeak/svelte-motion/commit/8e68871) feat(docs): migrate keyframes, variants-dynamic, tab-select to ExampleV2
- [`ef57384`](https://github.com/humanspeak/svelte-motion/commit/ef57384) feat(docs): migrate multi-state-badge, path-morphing, reordering to ExampleV2
