### PR TITLE
feat(components): add Reorder.Group and Reorder.Item

### DIFF
--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -37,7 +37,8 @@ export const docsSections: NavSection[] = [
         icon: Ghost,
         items: [
             { title: 'AnimatePresence', href: '/docs/animate-presence', icon: Ghost },
-            { title: 'MotionConfig', href: '/docs/motion-config', icon: Settings }
+            { title: 'MotionConfig', href: '/docs/motion-config', icon: Settings },
+            { title: 'Reorder', href: '/docs/reorder', icon: ArrowUpDown }
         ]
     },
     {

--- a/docs/src/lib/examples/reorder/demos/Default.svelte
+++ b/docs/src/lib/examples/reorder/demos/Default.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+    import { Reorder } from '@humanspeak/svelte-motion'
+    import Item from './Item.svelte'
+
+    type TodoItem = {
+        id: number
+        text: string
+        completed: boolean
+        color: string
+    }
+
+    const COLORS = ['#ff0088', '#dd00ee', '#9911ff', '#1e75f7', '#0cdcf7', '#8df0cc']
+
+    let todos: TodoItem[] = $state([
+        { id: 0, text: 'Review project proposal', completed: false, color: COLORS[0] },
+        { id: 1, text: 'Update documentation', completed: false, color: COLORS[1] },
+        { id: 2, text: 'Schedule team meeting', completed: false, color: COLORS[2] },
+        { id: 3, text: 'Test new features', completed: false, color: COLORS[3] },
+        { id: 4, text: 'Deploy to staging', completed: false, color: COLORS[4] },
+        { id: 5, text: 'Send weekly report', completed: false, color: COLORS[5] },
+        { id: 6, text: 'Prepare presentation slides', completed: false, color: COLORS[0] },
+        { id: 7, text: 'Review pull requests', completed: false, color: COLORS[1] }
+    ])
+
+    // Toggle a todo's completion state. If newly completed, defer the
+    // shuffle-to-bottom by 600ms so the strikethrough animation has time
+    // to play before the layout swap whisks the row down.
+    const toggleTodo = (id: number) => {
+        todos = todos.map((t) => (t.id === id ? { ...t, completed: !t.completed } : t))
+        if (todos.find((t) => t.id === id)?.completed) {
+            setTimeout(() => {
+                const uncompleted = todos.filter((t) => !t.completed)
+                const completed = todos.filter((t) => t.completed)
+                todos = [...uncompleted, ...completed]
+            }, 600)
+        }
+    }
+</script>
+
+<!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
+<div class="dk-demo-shell">
+    <div class="todo-container">
+        <Reorder.Group
+            axis="y"
+            values={todos}
+            onReorder={(next: TodoItem[]) => (todos = next)}
+            class="todo-list"
+        >
+            {#each todos as todo (todo.id)}
+                <Item {todo} onToggle={() => toggleTodo(todo.id)} />
+            {/each}
+        </Reorder.Group>
+    </div>
+</div>
+
+<style>
+    .dk-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1.5rem;
+        width: 100%;
+    }
+
+    .todo-container {
+        width: 100%;
+        max-width: 340px;
+        height: 280px;
+        overflow: auto;
+        padding: 24px;
+        background-color: #ffffff;
+        border-radius: 16px;
+        border: 1px solid #e5e7eb;
+        box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+        scrollbar-width: thin;
+        scrollbar-color: #d1d5db transparent;
+    }
+
+    .todo-container::-webkit-scrollbar {
+        width: 6px;
+    }
+
+    .todo-container::-webkit-scrollbar-track {
+        background: transparent;
+    }
+
+    .todo-container::-webkit-scrollbar-thumb {
+        background: #d1d5db;
+        border-radius: 3px;
+    }
+
+    :global(.todo-list) {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+</style>

--- a/docs/src/lib/examples/reorder/demos/Item.svelte
+++ b/docs/src/lib/examples/reorder/demos/Item.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+    import { animate, motion, Reorder, useMotionValue } from '@humanspeak/svelte-motion'
+
+    type TodoItem = {
+        id: number
+        text: string
+        completed: boolean
+        color: string
+    }
+
+    const { todo, onToggle }: { todo: TodoItem; onToggle: () => void } = $props()
+
+    // Per-item box-shadow MotionValue. Lifted from idle to dragging on
+    // drag start, animated back on drag end — gives the row a literal
+    // pick-up-the-card depth cue without competing with the layout
+    // animation.
+    const boxShadow = useMotionValue('0 1px 2px rgba(0,0,0,0.1)')
+</script>
+
+<Reorder.Item
+    value={todo}
+    class="todo-item"
+    style="box-shadow: {boxShadow.current}"
+    onDragStart={() => animate(boxShadow, '0 7px 24px rgba(0,0,0,0.2)')}
+    onDragEnd={() => animate(boxShadow, '0 1px 2px rgba(0,0,0,0.1)')}
+>
+    <button
+        type="button"
+        class="todo-checkbox"
+        style:border-color={todo.color}
+        style:background-color={todo.completed ? todo.color : 'transparent'}
+        onclick={(e) => {
+            e.stopPropagation()
+            onToggle()
+        }}
+        onpointerdowncapture={(e) => e.stopPropagation()}
+        aria-label={todo.completed
+            ? `Mark "${todo.text}" incomplete`
+            : `Mark "${todo.text}" complete`}
+        aria-pressed={todo.completed}
+    >
+        {#if todo.completed}
+            <svg width="10" height="8" viewBox="0 0 12 10" fill="none" aria-hidden="true">
+                <path
+                    d="M1 5L4.5 8.5L11 1"
+                    stroke="white"
+                    stroke-width="2.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                />
+            </svg>
+        {/if}
+    </button>
+    <span class="todo-text-wrapper">
+        <motion.span
+            animate={{ opacity: todo.completed ? 0.45 : 1 }}
+            transition={{ duration: 0.4 }}
+            class="todo-text"
+        >
+            {todo.text}
+        </motion.span>
+        <motion.span
+            initial={{ scaleX: 0 }}
+            animate={{ scaleX: todo.completed ? 1 : 0 }}
+            transition={{ duration: 0.4, ease: 'easeOut' }}
+            class="todo-strikethrough"
+            style="background-color: {todo.color}"
+        />
+    </span>
+</Reorder.Item>
+
+<style>
+    :global(.todo-item) {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 14px 16px;
+        background-color: #f9fafb;
+        border-radius: 10px;
+        cursor: grab;
+    }
+
+    :global(.todo-item:active) {
+        cursor: grabbing;
+    }
+
+    .todo-checkbox {
+        width: 20px;
+        height: 20px;
+        border-radius: 6px;
+        border-width: 2px;
+        border-style: solid;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        flex-shrink: 0;
+        transition: background-color 0.2s;
+        padding: 0;
+    }
+
+    .todo-text-wrapper {
+        position: relative;
+        display: inline-block;
+    }
+
+    :global(.todo-text) {
+        font-size: 14px;
+        font-weight: 500;
+        color: #374151;
+        display: inline-block;
+    }
+
+    :global(.todo-strikethrough) {
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 50%;
+        height: 1.5px;
+        transform-origin: left center;
+        border-radius: 1px;
+        pointer-events: none;
+    }
+</style>

--- a/docs/src/routes/docs/reorder/+page.svx
+++ b/docs/src/routes/docs/reorder/+page.svx
@@ -1,0 +1,112 @@
+---
+title: Reorder
+description: Drag-to-reorder list primitives — Reorder.Group + Reorder.Item with layout springs, auto-scroll, and the value-swap pattern.
+---
+
+<script>
+  import Example from '$lib/components/general/Example.svelte';
+  import ReorderExample from '$lib/examples/reorder/demos/Default.svelte';
+  import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+  const seo = getSeoContext()
+  if (seo) {
+      seo.title = 'Reorder | Docs | Svelte Motion'
+      seo.description = 'Drag-to-reorder list primitives. Reorder.Group owns the values + ordering callback, Reorder.Item drives the drag gesture and reports its measured position back to the group.'
+      seo.ogTitle = 'Reorder'
+      seo.ogTagline = 'Drag-to-reorder lists with layout springs'
+      seo.ogFeatures = ['Drag', 'Layout springs', 'Auto-scroll', 'Namespace API']
+      seo.ogSlug = 'docs-reorder'
+  }
+</script>
+
+# Reorder
+
+`Reorder.Group` and `Reorder.Item` are a pair of components that turn any list into a drag-to-reorder list, with each row physically springing into its new position as its neighbour is dragged past its centre.
+
+```svelte
+<script lang="ts">
+    import { Reorder } from '@humanspeak/svelte-motion'
+
+    let items = $state([0, 1, 2, 3, 4])
+</script>
+
+<Reorder.Group axis="y" values={items} onReorder={(next) => (items = next)}>
+    {#each items as item (item)}
+        <Reorder.Item value={item}>{item}</Reorder.Item>
+    {/each}
+</Reorder.Group>
+```
+
+That's the whole API for the basic case. Every row is draggable, the swap fires the moment a drag offset crosses a neighbour's centre, and `onReorder` receives the freshly permuted array.
+
+<Example isSmall exampleUrl="/examples/reorder">
+  <ReorderExample />
+</Example>
+
+## How it works
+
+- `Reorder.Group` provides a context that holds the **measured order** of its items — a `{ value, layout }[]` array sorted by each item's `layout.min` on the active axis. Every `Reorder.Item` registers itself on mount + after each reorder.
+- On every drag frame, the active `Reorder.Item` reads its drag offset + velocity and calls `context.updateOrder(value, offset, velocity)`.
+- `updateOrder` runs `checkReorder` — velocity-direction-based: if you're moving toward a neighbour AND your leading edge has crossed that neighbour's centre, swap. Otherwise, nothing.
+- When a swap happens, the group rebuilds `values` using the **value-swap pattern**: only the pair that actually changed positions is swapped in the consumer's `values` array. Unmeasured items (e.g. in a virtualised list) pass through untouched.
+
+## Reorder.Group
+
+### Props
+
+- **`values`** `V[]` (required) — the current state of the list. Pass the same array you render the children with.
+- **`onReorder`** `(next: V[]) => void` (required) — fires with a new permutation whenever a swap happens. Wire to `(next) => (items = next)`.
+- **`axis`** `'x' | 'y'` — defaults to `'y'`. Also pins the drag axis of every child `Reorder.Item`.
+- **`as`** `'ul' | 'ol' | 'div'` — defaults to `'ul'`. The HTML tag rendered for the group container.
+- Plus every prop a `motion.<as>` element accepts (`initial`, `animate`, `layout`, etc.).
+
+The group also sets `overflow-anchor: none` on its container — this prevents the browser's scroll-anchoring heuristic from interfering with drag math when items shift during reorder. You don't need to think about it; it's just there.
+
+## Reorder.Item
+
+### Props
+
+- **`value`** `V` (required) — the value this row represents in the parent's `values` array. Must be reference-stable across renders (use the item's id or the item object itself).
+- **`as`** `'li' | 'div'` — defaults to `'li'`. The HTML tag rendered for the item.
+- **`layout`** `true | 'position'` — defaults to `true`. Set to `'position'` to disable size animation (matches framer-motion semantics).
+- **`onDragStart`** / **`onDrag`** / **`onDragEnd`** — standard motion drag callbacks, forwarded after the internal reorder bookkeeping has run.
+- Plus every other prop a `motion.<as>` element accepts.
+
+The item automatically wires `drag={axis}` (from the group context), `dragSnapToOrigin`, and `layout={true}`. You don't pass these — they're the whole point of the component.
+
+## The value-swap pattern
+
+When `checkReorder` decides two items should swap, the group does **not** rebuild the entire `values` array from scratch. It finds the pair that changed positions in the freshly-computed order and swaps only that pair in a copy of `values`:
+
+```ts
+const newValues = [...values]
+for (let i = 0; i < next.length; i++) {
+    if (order[i].value !== next[i].value) {
+        const a = values.indexOf(order[i].value)
+        const b = values.indexOf(next[i].value)
+        ;[newValues[a], newValues[b]] = [newValues[b], newValues[a]]
+        break
+    }
+}
+onReorder(newValues)
+```
+
+The motivation is virtualisation: with a 10,000-row list where only 20 rows are mounted at a time, the order registry only knows about those 20. If we rebuilt `values` from `next`, we'd lose every unmounted entry. The pair-swap pattern preserves the rest.
+
+## Auto-scroll
+
+Drag near a viewport edge and the nearest scrollable ancestor scrolls to follow your pointer. Threshold is 50px from the edge, speed eases up to a 25px/frame cap, and the engine caps to the scrollable's initial scroll height so you can't runaway-grow the surface mid-drag. Velocity must point toward the edge for the scroll to engage — a stationary item parked at the threshold won't trigger anything.
+
+## SSR
+
+`Reorder.Group` and `Reorder.Item` render their underlying tags (`ul` / `li`) on the server with the consumer's content inline. Drag wiring, measurement, and auto-scroll only attach in the browser after hydration. The initial paint matches the server-rendered HTML.
+
+## See also
+
+- [Layout Animations](/docs/layout-animations) — the underlying primitive `Reorder.Item` uses to spring into new positions
+- [Drag](/docs/drag) — the gesture system `Reorder.Item` builds on
+- [AnimatePresence](/docs/animate-presence) — combine with `Reorder` to animate entry/exit of list items
+
+---
+
+Based on [Motion's Reorder](https://motion.dev/docs/react-reorder) API.

--- a/docs/src/routes/docs/reorder/+page.ts
+++ b/docs/src/routes/docs/reorder/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => ({
+    title: 'Reorder',
+    description:
+        'Drag-to-reorder list primitives — Reorder.Group + Reorder.Item with layout springs, auto-scroll, and the value-swap pattern.'
+})

--- a/docs/src/routes/examples/reorder/+page.svelte
+++ b/docs/src/routes/examples/reorder/+page.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+    import {
+        CodeReferenceV2,
+        type DemoManifestEntry,
+        ExampleV2,
+        type ExampleSection,
+        formatSheetLabel
+    } from '@humanspeak/docs-kit'
+    import { Hand, Layers, ListOrdered } from '@lucide/svelte'
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import ReorderDefault from '$lib/examples/reorder/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [{ title: 'Examples', href: '/examples' }, { title: 'Reorder' }]
+    }
+    if (seo) {
+        seo.title = 'Reorder | Examples | Svelte Motion'
+        seo.description =
+            'Drag-to-reorder a task list. Items physically spring into their new positions, with a depth shadow on the dragged row and a checkbox-completion flow that bubbles done items to the bottom.'
+        seo.ogTitle = 'Reorder'
+        seo.ogTagline = 'Drag to reorder, watch it spring'
+        seo.ogFeatures = ['Drag', 'Layout springs', 'Auto-scroll', 'Reorder.Group']
+        seo.ogSlug = 'examples-reorder'
+    }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
+
+    const sections: ExampleSection[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'COMPONENT',
+            title: { prefix: 'drag to ', accent: 'reorder', end: '.' },
+            description:
+                "A `Reorder.Group` of `Reorder.Item`s. Grab any row and the others physically spring out of the way as your drag offset crosses each neighbour's centre — same primitive the framer-motion 2 launch demo used.",
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'drag-to-reorder list' }],
+            sourceUrl: `${SOURCE_URL}reorder/demos/Default.svelte`
+        }
+    ]
+</script>
+
+{#snippet defaultSection()}
+    <ReorderDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Hand />
+            <span>
+                Each row is a <code>Reorder.Item</code> with
+                <code>drag=&#123;axis&#125;</code> and <code>dragSnapToOrigin</code> wired
+                automatically. The group's <code>onReorder</code> fires the moment your drag offset crosses
+                a neighbour's centre — you swap as you drag, not on release.
+            </span>
+        </li>
+        <li>
+            <Layers />
+            <span>
+                <code>layout=&#123;true&#125;</code> on each item turns the swap into a physical
+                spring. Combined with a per-row <code>useMotionValue</code> box-shadow animated on
+                <code>onDragStart</code> / <code>onDragEnd</code>, the dragged row visually lifts
+                off the stack.
+            </span>
+        </li>
+        <li>
+            <ListOrdered />
+            <span>
+                The completion flow shows off mixing motion primitives: a <code>motion.span</code>
+                fades the text to 45% opacity while another scales a coloured bar across via
+                <code>scaleX</code>, then the parent shuffles completed rows to the bottom after a
+                600ms delay so the strikethrough actually plays.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'reorder-default',
+                label: 'Default.svelte',
+                ...manifest['reorder/demos/Default.svelte']
+            },
+            {
+                id: 'reorder-item',
+                label: 'Item.svelte',
+                ...manifest['reorder/demos/Item.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel={formatSheetLabel(i, sections.length)}
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/reorder/+page.ts
+++ b/docs/src/routes/examples/reorder/+page.ts
@@ -1,0 +1,6 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => ({
+    title: 'Reorder',
+    description: 'Drag-to-reorder a task list with layout springs — the WOW demo.'
+})

--- a/src/lib/components/Reorder/ReorderGroup.svelte
+++ b/src/lib/components/Reorder/ReorderGroup.svelte
@@ -1,0 +1,116 @@
+<!--
+  @component
+  Reorder.Group — the parent half of the Reorder primitive pair. Renders a
+  motion element (`ul` by default) that contains draggable
+  `Reorder.Item` children, owns the measured-position registry, and
+  fires `onReorder(next)` with a freshly-permuted copy of `values` when
+  one child's drag offset crosses a neighbour's centre.
+
+  Direct port of framer-motion's `Reorder.Group` (Reorder/Group.tsx).
+  Behaviour matches one-to-one — velocity-direction swap, value-swap
+  pattern preserving unmeasured items (virtualised lists), and the
+  `overflowAnchor: none` workaround.
+-->
+<script lang="ts" generics="V">
+    import MotionContainer from '$lib/html/_MotionContainer.svelte'
+    import type { HTMLElementProps } from '$lib/types'
+    import { setContext, type Snippet } from 'svelte'
+    import { ReorderContextKey, type ItemData, type ReorderContext } from './context.js'
+    import { checkReorder } from './utils/check-reorder.js'
+
+    type Props = Omit<HTMLElementProps, 'children' | 'ref'> & {
+        children: Snippet
+        ref?: HTMLElement | null
+        /** HTML tag to render. Defaults to `'ul'` to match framer-motion. */
+        as?: 'ul' | 'ol' | 'div'
+        /** Axis to reorder along — also pins the item drag axis. */
+        axis?: 'x' | 'y'
+        /** Latest values state. Pass the same array you render with. */
+        values: V[]
+        /** Fires with the next ordering. Wire to `(next) => (items = next)`. */
+        onReorder: (next: V[]) => void
+    }
+
+    let {
+        children,
+        as = 'ul',
+        axis = 'y',
+        values,
+        onReorder,
+        style: styleProp,
+        ref = $bindable<HTMLElement | null>(null),
+        ...rest
+    }: Props = $props()
+
+    // Holds the live order, sorted by measured layout.min on the active axis.
+    // Each Reorder.Item pushes/updates its own entry via `registerItem`.
+    // Mutated in place rather than $state-reassigned because the order
+    // matters across drag ticks and Svelte tracking is irrelevant here —
+    // we only ever read this inside drag callbacks.
+    const order: ItemData<V>[] = []
+
+    // After we hand a new `values` array up to the consumer, gate further
+    // updateOrder calls until React's-equivalent next-tick (here: Svelte's
+    // next effect run) so a single drag-frame can't double-swap.
+    let isReordering = $state(false)
+
+    setContext<ReorderContext<V>>(ReorderContextKey, {
+        axis,
+        get groupRef() {
+            return ref
+        },
+        registerItem: (value, layout) => {
+            const idx = order.findIndex((entry) => entry.value === value)
+            if (idx !== -1) {
+                order[idx].layout = layout[axis]
+            } else {
+                order.push({ value, layout: layout[axis] })
+            }
+            order.sort((a, b) => a.layout.min - b.layout.min)
+        },
+        updateOrder: (value, offset, velocity) => {
+            if (isReordering) return
+
+            const next = checkReorder(order, value, offset, velocity)
+            if (next === order) return
+
+            isReordering = true
+
+            // Value-swap pattern (matches framer-motion). Only swap the
+            // pair that changed positions in `next`, preserving any
+            // unmeasured entries in `values` (the canonical
+            // virtualised-list scenario). Walk `next` left-to-right; the
+            // first index where order/next disagree IS the swap.
+            const newValues = [...values]
+            for (let i = 0; i < next.length; i++) {
+                if (order[i].value !== next[i].value) {
+                    const a = values.indexOf(order[i].value)
+                    const b = values.indexOf(next[i].value)
+                    if (a !== -1 && b !== -1) {
+                        ;[newValues[a], newValues[b]] = [newValues[b], newValues[a]]
+                    }
+                    break
+                }
+            }
+            onReorder(newValues)
+        }
+    })
+
+    // Clear the reorder lock after Svelte flushes a new `values` array —
+    // mirrors framer-motion's post-render `useEffect(() => { isReordering = false })`.
+    $effect(() => {
+        void values
+        isReordering = false
+    })
+
+    // Disable browser scroll anchoring so item layout shifts during drag
+    // don't get nudged by the scroll-anchor heuristic. Merge with any
+    // user-supplied inline style.
+    const style = $derived(
+        styleProp ? `overflow-anchor: none; ${styleProp}` : 'overflow-anchor: none;'
+    )
+</script>
+
+<MotionContainer bind:ref tag={as} {style} {...rest}>
+    {@render children()}
+</MotionContainer>

--- a/src/lib/components/Reorder/ReorderItem.svelte
+++ b/src/lib/components/Reorder/ReorderItem.svelte
@@ -1,0 +1,138 @@
+<!--
+  @component
+  Reorder.Item — the draggable child half of the Reorder primitive pair.
+  Wraps `MotionContainer` (default `li`) with `drag={axis}` +
+  `dragSnapToOrigin` + `layout`, reports its measured position back to
+  the parent `Reorder.Group`, and forwards the drag offset/velocity to
+  the group's swap-decision logic on every move.
+
+  Port of framer-motion's `Reorder.Item` (Reorder/Item.tsx) adapted for
+  Svelte 5:
+
+  - Instead of `style={{ x, y }}` MotionValue interpolation (a motion
+    proxy feature we don't have yet — see backlog #317), we read the
+    drag offset directly from the `DragInfo` payload on each move and
+    feed it straight to `updateOrder`. For unconstrained items —
+    which is every Reorder.Item — that's equivalent.
+  - Layout measurement is `getBoundingClientRect()` deferred to the
+    next animation frame. Re-runs whenever the parent's `values`
+    array changes (i.e. after every reorder) so the order registry
+    stays in sync with the post-layout positions.
+  - `zIndex` flips to `1` while dragging and back to `unset` when the
+    drag ends, so the active row floats over its neighbours.
+-->
+<script lang="ts" generics="V">
+    import MotionContainer from '$lib/html/_MotionContainer.svelte'
+    import type {
+        DragInfo,
+        HTMLElementProps,
+        MotionOnDrag,
+        MotionOnDragEnd,
+        MotionOnDragStart
+    } from '$lib/types'
+    import { getContext, type Snippet } from 'svelte'
+    import { ReorderContextKey, type ReorderContext } from './context.js'
+    import { autoScrollIfNeeded, resetAutoScrollState } from './utils/auto-scroll.js'
+
+    type Props = Omit<
+        HTMLElementProps,
+        'children' | 'ref' | 'onDragStart' | 'onDrag' | 'onDragEnd'
+    > & {
+        children: Snippet
+        ref?: HTMLElement | null
+        /** HTML tag to render. Defaults to `'li'` to match framer-motion. */
+        as?: 'li' | 'div'
+        /** The value this item represents in the parent group's `values`. */
+        value: V
+        /** Layout animation mode. `true` = position + size, `'position'` =
+         *  position only. Same semantics as framer-motion. */
+        layout?: true | 'position'
+        /** Forwarded to the inner motion element. */
+        onDragStart?: MotionOnDragStart
+        onDrag?: MotionOnDrag
+        onDragEnd?: MotionOnDragEnd
+    }
+
+    let {
+        children,
+        as = 'li',
+        value,
+        layout = true,
+        style: styleProp,
+        onDragStart: onDragStartProp,
+        onDrag: onDragProp,
+        onDragEnd: onDragEndProp,
+        ref = $bindable<HTMLElement | null>(null),
+        ...rest
+    }: Props = $props()
+
+    const context = getContext<ReorderContext<V>>(ReorderContextKey)
+    if (!context) {
+        throw new Error(
+            'Reorder.Item must be a descendant of Reorder.Group. See https://motion.svelte.page/docs/reorder.'
+        )
+    }
+    const { axis, registerItem, updateOrder } = context
+
+    // Active drag float so the dragged row sits above neighbours during
+    // the gesture without forcing a stacking-context on idle items.
+    let isDragging = $state(false)
+
+    const style = $derived(
+        `z-index: ${isDragging ? 1 : 'auto'};${styleProp ? ` ${styleProp}` : ''}`
+    )
+
+    // Re-measure on mount and whenever the consumer's value identity
+    // changes (which happens after a reorder rebuilds the items array).
+    // Defer with rAF so we sample AFTER the layout animation system has
+    // committed the new position.
+    $effect(() => {
+        void value
+        if (!ref) return
+
+        let rafId: number | null = requestAnimationFrame(() => {
+            rafId = null
+            if (!ref) return
+            const rect = ref.getBoundingClientRect()
+            registerItem(value, {
+                x: { min: rect.left, max: rect.right },
+                y: { min: rect.top, max: rect.bottom }
+            })
+        })
+        return () => {
+            if (rafId !== null) cancelAnimationFrame(rafId)
+        }
+    })
+
+    const handleDragStart = (event: PointerEvent, info: DragInfo) => {
+        isDragging = true
+        onDragStartProp?.(event, info)
+    }
+
+    const handleDrag = (event: PointerEvent, info: DragInfo) => {
+        updateOrder(value, info.offset[axis], info.velocity[axis])
+        autoScrollIfNeeded(context.groupRef, info.point[axis], axis, info.velocity[axis])
+        onDragProp?.(event, info)
+    }
+
+    const handleDragEnd = (event: PointerEvent, info: DragInfo) => {
+        isDragging = false
+        resetAutoScrollState()
+        onDragEndProp?.(event, info)
+    }
+</script>
+
+<MotionContainer
+    bind:ref
+    tag={as}
+    drag={axis}
+    dragSnapToOrigin
+    {layout}
+    {style}
+    onDragStart={handleDragStart}
+    onDrag={handleDrag}
+    onDragEnd={handleDragEnd}
+    {...rest}
+>
+    {@render children()}
+</MotionContainer>

--- a/src/lib/components/Reorder/context.ts
+++ b/src/lib/components/Reorder/context.ts
@@ -1,0 +1,40 @@
+/**
+ * Mirrors `motion-utils`'s `Axis` shape — a 1-D layout extent. Inlined so
+ * the Reorder folder doesn't pull a new direct dep just for two
+ * type aliases (motion-utils is reachable transitively via motion-dom
+ * but only as a runtime dep, not a type dep).
+ */
+export interface ReorderAxis {
+    min: number
+    max: number
+}
+
+/** Mirrors `motion-utils`'s `Box` shape — a 2-D layout extent. */
+export interface ReorderBox {
+    x: ReorderAxis
+    y: ReorderAxis
+}
+
+/**
+ * Per-Reorder.Group state contributed by every Reorder.Item via the
+ * context. Mirrors framer-motion's `ItemData<V>`.
+ */
+export interface ItemData<T> {
+    value: T
+    layout: ReorderAxis
+}
+
+/**
+ * Context shape Reorder.Group provides to its descendant Reorder.Items.
+ * Matches framer-motion's `ReorderContextProps` so the porting story is
+ * one-to-one. `groupRef` is a getter so Items can read the latest live
+ * element across the parent's lifecycle.
+ */
+export interface ReorderContext<T> {
+    axis: 'x' | 'y'
+    registerItem: (value: T, layout: ReorderBox) => void
+    updateOrder: (value: T, offset: number, velocity: number) => void
+    readonly groupRef: Element | null
+}
+
+export const ReorderContextKey = Symbol('svelte-motion:reorder')

--- a/src/lib/components/Reorder/index.ts
+++ b/src/lib/components/Reorder/index.ts
@@ -1,0 +1,47 @@
+import type { Component } from 'svelte'
+import ReorderGroupImpl from './ReorderGroup.svelte'
+import ReorderItemImpl from './ReorderItem.svelte'
+
+/**
+ * Namespaced API matching framer-motion's `<Reorder.Group>` /
+ * `<Reorder.Item>`. Svelte 5 supports `<Foo.Bar>` syntax when `Foo` is
+ * an import-time object with component properties.
+ *
+ * ```svelte
+ * <script>
+ *   import { Reorder } from '@humanspeak/svelte-motion'
+ *   let items = $state([0, 1, 2])
+ * </script>
+ *
+ * <Reorder.Group axis="y" values={items} onReorder={(next) => (items = next)}>
+ *   {#each items as item (item)}
+ *     <Reorder.Item value={item}>{item}</Reorder.Item>
+ *   {/each}
+ * </Reorder.Group>
+ * ```
+ *
+ * The namespace properties are typed as `Component<any>` because Svelte's
+ * generated component type (`$$IsomorphicComponent`) can't be re-exported
+ * through an object literal — the type-system gap is documented at
+ * https://github.com/sveltejs/svelte/issues/13355. For full prop type
+ * checking, import the components directly:
+ *
+ * ```ts
+ * import { ReorderGroup, ReorderItem } from '@humanspeak/svelte-motion'
+ * ```
+ */
+export const Reorder: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Group: Component<any>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Item: Component<any>
+} = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Group: ReorderGroupImpl as unknown as Component<any>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Item: ReorderItemImpl as unknown as Component<any>
+}
+
+export type { ItemData, ReorderContext } from './context.js'
+export { default as ReorderGroup } from './ReorderGroup.svelte'
+export { default as ReorderItem } from './ReorderItem.svelte'

--- a/src/lib/components/Reorder/utils/auto-scroll.ts
+++ b/src/lib/components/Reorder/utils/auto-scroll.ts
@@ -1,0 +1,149 @@
+/**
+ * Auto-scroll the nearest scrollable ancestor when a Reorder.Item is
+ * dragged near a viewport edge. Direct port of framer-motion's
+ * `Reorder/utils/auto-scroll.ts` — same threshold (50px), same easing
+ * curve (quadratic intensity), same max speed (25px/frame), and the
+ * same anti-runaway initial-scroll-limit cap.
+ *
+ * The state lives in module-scope `WeakMap`s keyed by the scrollable
+ * element so multiple Reorder.Groups on a page don't fight over the
+ * same accumulator. `resetAutoScrollState` is called on drag end to
+ * clear the dragging-group's edge accumulator.
+ */
+
+const threshold = 50
+const maxSpeed = 25
+
+const overflowStyles = new Set(['auto', 'scroll'])
+
+const initialScrollLimits = new WeakMap<HTMLElement, number>()
+
+type ActiveEdge = 'start' | 'end' | null
+const activeScrollEdge = new WeakMap<HTMLElement, ActiveEdge>()
+
+let currentGroupElement: Element | null = null
+
+export const resetAutoScrollState = (): void => {
+    if (!currentGroupElement) return
+    const sy = findScrollableAncestor(currentGroupElement, 'y')
+    if (sy) {
+        activeScrollEdge.delete(sy)
+        initialScrollLimits.delete(sy)
+    }
+    const sx = findScrollableAncestor(currentGroupElement, 'x')
+    if (sx && sx !== sy) {
+        activeScrollEdge.delete(sx)
+        initialScrollLimits.delete(sx)
+    }
+    currentGroupElement = null
+}
+
+const isScrollableElement = (element: Element, axis: 'x' | 'y'): boolean => {
+    const style = getComputedStyle(element)
+    const overflow = axis === 'x' ? style.overflowX : style.overflowY
+    const isDocumentScroll = element === document.body || element === document.documentElement
+    return overflowStyles.has(overflow) || isDocumentScroll
+}
+
+const findScrollableAncestor = (element: Element | null, axis: 'x' | 'y'): HTMLElement | null => {
+    let current = element?.parentElement
+    while (current) {
+        if (isScrollableElement(current, axis)) return current
+        current = current.parentElement
+    }
+    return null
+}
+
+const getScrollAmount = (
+    pointerPosition: number,
+    scrollElement: HTMLElement,
+    axis: 'x' | 'y'
+): { amount: number; edge: ActiveEdge } => {
+    const rect = scrollElement.getBoundingClientRect()
+    const start = axis === 'x' ? Math.max(0, rect.left) : Math.max(0, rect.top)
+    const end =
+        axis === 'x'
+            ? Math.min(window.innerWidth, rect.right)
+            : Math.min(window.innerHeight, rect.bottom)
+
+    const distFromStart = pointerPosition - start
+    const distFromEnd = end - pointerPosition
+
+    if (distFromStart < threshold) {
+        const intensity = 1 - distFromStart / threshold
+        return { amount: -maxSpeed * intensity * intensity, edge: 'start' }
+    }
+    if (distFromEnd < threshold) {
+        const intensity = 1 - distFromEnd / threshold
+        return { amount: maxSpeed * intensity * intensity, edge: 'end' }
+    }
+    return { amount: 0, edge: null }
+}
+
+export const autoScrollIfNeeded = (
+    groupElement: Element | null,
+    pointerPosition: number,
+    axis: 'x' | 'y',
+    velocity: number
+): void => {
+    if (!groupElement) return
+    currentGroupElement = groupElement
+
+    const scrollable = findScrollableAncestor(groupElement, axis)
+    if (!scrollable) return
+
+    // Drag info uses page coords; getBoundingClientRect returns viewport
+    // coords. Convert to apples-to-apples.
+    const viewportPointerPosition =
+        pointerPosition - (axis === 'x' ? window.scrollX : window.scrollY)
+
+    const { amount, edge } = getScrollAmount(viewportPointerPosition, scrollable, axis)
+
+    if (edge === null) {
+        activeScrollEdge.delete(scrollable)
+        initialScrollLimits.delete(scrollable)
+        return
+    }
+
+    const currentEdge = activeScrollEdge.get(scrollable)
+    const isDocumentScroll = scrollable === document.body || scrollable === document.documentElement
+
+    if (currentEdge !== edge) {
+        // Only engage if velocity actually pushes toward the edge — stops
+        // a stationary item at the threshold from runaway-scrolling.
+        const shouldStart = (edge === 'start' && velocity < 0) || (edge === 'end' && velocity > 0)
+        if (!shouldStart) return
+
+        activeScrollEdge.set(scrollable, edge)
+
+        const maxScroll =
+            axis === 'x'
+                ? scrollable.scrollWidth -
+                  (isDocumentScroll ? window.innerWidth : scrollable.clientWidth)
+                : scrollable.scrollHeight -
+                  (isDocumentScroll ? window.innerHeight : scrollable.clientHeight)
+        initialScrollLimits.set(scrollable, maxScroll)
+    }
+
+    // Cap to initial limit so we don't keep growing the scroll surface.
+    if (amount > 0) {
+        const initialLimit = initialScrollLimits.get(scrollable)!
+        const currentScroll =
+            axis === 'x'
+                ? isDocumentScroll
+                    ? window.scrollX
+                    : scrollable.scrollLeft
+                : isDocumentScroll
+                  ? window.scrollY
+                  : scrollable.scrollTop
+        if (currentScroll >= initialLimit) return
+    }
+
+    if (axis === 'x') {
+        if (isDocumentScroll) window.scrollBy({ left: amount })
+        else scrollable.scrollLeft += amount
+    } else {
+        if (isDocumentScroll) window.scrollBy({ top: amount })
+        else scrollable.scrollTop += amount
+    }
+}

--- a/src/lib/components/Reorder/utils/check-reorder.spec.ts
+++ b/src/lib/components/Reorder/utils/check-reorder.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import type { ItemData } from '../context.js'
+import { checkReorder } from './check-reorder.js'
+
+/**
+ * Pure unit tests for the swap-decision logic that powers Reorder.Group.
+ * Mirrors framer-motion's own __tests__/check-reorder.test.ts so the
+ * behaviour stays one-to-one through future motion-dom upgrades.
+ */
+const item = <T>(value: T, min: number, max: number): ItemData<T> => ({
+    value,
+    layout: { min, max }
+})
+
+describe('Reorder/check-reorder', () => {
+    it('returns the input order untouched when velocity is zero', () => {
+        const order = [item('a', 0, 50), item('b', 60, 110)]
+        expect(checkReorder(order, 'a', 100, 0)).toBe(order)
+    })
+
+    it('returns the input order untouched when the value is not registered', () => {
+        const order = [item('a', 0, 50)]
+        expect(checkReorder(order, 'z', 100, 100)).toBe(order)
+    })
+
+    it('returns the input order when dragging beyond the last item with no neighbour', () => {
+        const order = [item('a', 0, 50), item('b', 60, 110)]
+        expect(checkReorder(order, 'b', 100, 100)).toBe(order)
+    })
+
+    it('swaps when forward drag offset crosses the next neighbour centre', () => {
+        // Item `a` spans 0–50; neighbour `b` spans 60–110, centre 85.
+        // Drag offset of 40 puts a's max at 50 + 40 = 90 > 85 → swap.
+        const order = [item('a', 0, 50), item('b', 60, 110)]
+        const next = checkReorder(order, 'a', 40, 200)
+        expect(next).not.toBe(order)
+        expect(next.map((entry) => entry.value)).toEqual(['b', 'a'])
+    })
+
+    it('does NOT swap when forward drag offset stops short of neighbour centre', () => {
+        const order = [item('a', 0, 50), item('b', 60, 110)]
+        expect(checkReorder(order, 'a', 30, 200)).toBe(order)
+    })
+
+    it('swaps when backward drag offset crosses the prior neighbour centre', () => {
+        // Item `b` spans 60–110; neighbour `a` spans 0–50, centre 25.
+        // Drag offset of -40 puts b's min at 60 + (-40) = 20 < 25 → swap.
+        const order = [item('a', 0, 50), item('b', 60, 110)]
+        const next = checkReorder(order, 'b', -40, -200)
+        expect(next).not.toBe(order)
+        expect(next.map((entry) => entry.value)).toEqual(['b', 'a'])
+    })
+
+    it('does NOT swap when backward drag offset stops short of neighbour centre', () => {
+        const order = [item('a', 0, 50), item('b', 60, 110)]
+        expect(checkReorder(order, 'b', -30, -200)).toBe(order)
+    })
+
+    it('only swaps the immediate neighbour in a single call (multi-step drags handled by repeated calls)', () => {
+        const order = [item('a', 0, 50), item('b', 60, 110), item('c', 120, 170)]
+        // Forward drag of 80 on `a` — crosses both b's centre (85) and c's
+        // centre (145). Single pass only swaps with the next neighbour.
+        const next = checkReorder(order, 'a', 80, 200)
+        expect(next.map((entry) => entry.value)).toEqual(['b', 'a', 'c'])
+    })
+
+    it('preserves layout extents when swapping (only positions change)', () => {
+        const order = [item('a', 0, 50), item('b', 60, 110)]
+        const next = checkReorder(order, 'a', 40, 200)
+        expect(next[0]).toEqual({ value: 'b', layout: { min: 60, max: 110 } })
+        expect(next[1]).toEqual({ value: 'a', layout: { min: 0, max: 50 } })
+    })
+})

--- a/src/lib/components/Reorder/utils/check-reorder.ts
+++ b/src/lib/components/Reorder/utils/check-reorder.ts
@@ -1,0 +1,56 @@
+import { mixNumber } from 'motion-dom'
+import type { ItemData } from '../context.js'
+
+/**
+ * Mirrors motion-utils's `moveItem` — pulls one element out of a copy of
+ * the array and splices it in at the new index. Inlined to keep the
+ * Reorder folder's dep surface to just `motion-dom`.
+ */
+const moveItem = <T>([...arr]: T[], fromIndex: number, toIndex: number): T[] => {
+    const startIndex = fromIndex < 0 ? arr.length + fromIndex : fromIndex
+    if (startIndex >= 0 && startIndex < arr.length) {
+        const endIndex = toIndex < 0 ? arr.length + toIndex : toIndex
+        const [item] = arr.splice(fromIndex, 1)
+        arr.splice(endIndex, 0, item)
+    }
+    return arr
+}
+
+/**
+ * Velocity-direction swap detection. If the dragged item is moving
+ * toward its neighbour AND its leading edge has crossed the neighbour's
+ * centre, swap the two entries in the order array. Direct port of
+ * framer-motion's `checkReorder` (Reorder/utils/check-reorder.ts).
+ *
+ * Returns the same `order` array when no swap occurs, so callers can
+ * use a cheap reference check (`order !== next`) to know whether to
+ * propagate the change upstream.
+ */
+export const checkReorder = <T>(
+    order: ItemData<T>[],
+    value: T,
+    offset: number,
+    velocity: number
+): ItemData<T>[] => {
+    if (!velocity) return order
+
+    const index = order.findIndex((item) => item.value === value)
+    if (index === -1) return order
+
+    const nextOffset = velocity > 0 ? 1 : -1
+    const nextItem = order[index + nextOffset]
+    if (!nextItem) return order
+
+    const item = order[index]
+    const nextLayout = nextItem.layout
+    const nextItemCenter = mixNumber(nextLayout.min, nextLayout.max, 0.5)
+
+    if (
+        (nextOffset === 1 && item.layout.max + offset > nextItemCenter) ||
+        (nextOffset === -1 && item.layout.min + offset < nextItemCenter)
+    ) {
+        return moveItem(order, index, index + nextOffset)
+    }
+
+    return order
+}

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -467,9 +467,36 @@
         )
     )
 
+    // When `drag` is set and the gesture listener is enabled, mirror
+    // framer-motion's `use-props.ts` and suppress text selection +
+    // native HTML5 drag + scroll along the drag axis. Without this the
+    // browser interprets a drag-pointer-press as text selection,
+    // leaving consumers to fight CSS each time they use `drag`.
+    //
+    // See framer-motion@main/packages/framer-motion/src/render/html/use-props.ts:59-74.
+    const dragGestureActive = $derived(!!dragProp && dragListenerProp !== false)
+    const dragAxisValue = $derived<'x' | 'y' | true | false>(
+        dragProp === true || dragProp === 'x' || dragProp === 'y' ? dragProp : !!dragProp
+    )
+    const dragStyleOverrides = $derived<Record<string, string> | undefined>(
+        dragGestureActive && dragAxisValue
+            ? {
+                  userSelect: 'none',
+                  WebkitUserSelect: 'none',
+                  WebkitTouchCallout: 'none',
+                  touchAction:
+                      dragAxisValue === true ? 'none' : `pan-${dragAxisValue === 'x' ? 'y' : 'x'}`
+              }
+            : undefined
+    )
+
     // Derived attributes to keep both branches in sync (focusability, data flags, style, class)
     const derivedAttrs = $derived<Record<string, unknown>>({
         ...(rest as Record<string, unknown>),
+        // When drag is active, disable native HTML5 drag so the
+        // browser's ghost element doesn't fight our pointer-based
+        // gesture. Matches `htmlProps.draggable = false` in framer-motion.
+        ...(dragGestureActive && dragAxisValue ? { draggable: false } : {}),
         // Gate on the *resolved* whileTap, not the raw prop. With
         // variant-label support a truthy-but-unresolved value (unknown
         // key, empty array) would otherwise add `tabindex=0` for an
@@ -502,20 +529,36 @@
             return {}
         })(),
         style: mergeInlineStyles(
-            initialKeyframes && 'pathLength' in initialKeyframes && isLoaded === 'mounting'
-                ? `${styleProp || ''};visibility:hidden`
-                : styleProp,
-            // Apply initialKeyframes as inline styles during mounting and initial phases
-            // The animation starts in RAF after 'initial' phase, so we need styles until then
-            // When ready AND we have initialKeyframes: DON'T set any animated properties!
-            // WAAPI is controlling them and inline styles can override the animation
-            isLoaded === 'mounting' || isLoaded === 'initial'
+            // Prepend drag-gesture style overrides (user-select, touch-action)
+            // when the gesture is active. These belong on the *base* style
+            // layer so neither initial nor animate inline styles can clobber
+            // them. We splice them in as a pseudo-existingStyle prefix.
+            (() => {
+                const baseStyle =
+                    initialKeyframes && 'pathLength' in initialKeyframes && isLoaded === 'mounting'
+                        ? `${styleProp || ''};visibility:hidden`
+                        : styleProp
+                if (!dragStyleOverrides) return baseStyle
+                const dragStyleString = Object.entries(dragStyleOverrides)
+                    .map(([k, v]) => `${k.replace(/([A-Z])/g, '-$1').toLowerCase()}:${v}`)
+                    .join(';')
+                return typeof baseStyle === 'string' && baseStyle.length > 0
+                    ? `${dragStyleString};${baseStyle}`
+                    : dragStyleString
+            })(),
+            // Apply initialKeyframes as the baseline inline style. Originally
+            // this only ran during 'mounting'/'initial' phases, but that left
+            // a hole: when the animation target equals `initial` (a no-op
+            // animation) or when WAAPI clears its keyframes on completion
+            // (default `fill: 'none'`), `transform`-shortcut properties
+            // (`scaleX`, `rotate`, etc.) vanish from the element — see #377.
+            // Keeping the baseline always-on is safe: WAAPI animations have
+            // higher specificity than inline styles while running, and when
+            // they end, the inline fallback shows the intended value.
+            isNotEmpty(initialKeyframes)
                 ? (initialKeyframes as unknown as Record<string, unknown>)
                 : undefined,
-            // Only use resolvedAnimate as fallback when we DON'T have initialKeyframes
-            // If we have initialKeyframes, the enter animation is running - setting
-            // inline styles to the target values will override the WAAPI animation
-            // Use isNotEmpty to handle empty initial objects (initial: {}) which should fallback
+            // Use resolvedAnimate as fallback when we DON'T have initialKeyframes.
             isNotEmpty(initialKeyframes)
                 ? undefined
                 : (resolvedAnimate as unknown as Record<string, unknown>)

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -27,6 +27,8 @@ export {
 export { clamp, distance, distance2D, interpolate, mix, pipe, progress, wrap } from 'motion'
 
 // Re-export all Motion types so consumers can import types from this package
+export { Reorder, ReorderGroup, ReorderItem } from '$lib/components/Reorder/index'
+export type { ReorderContext, ItemData as ReorderItemData } from '$lib/components/Reorder/index'
 export type {
     DragAxis,
     DragConstraints,
@@ -75,9 +77,10 @@ export { useIsPresent, usePresence } from '$lib/utils/usePresence'
 export type { UsePresenceState } from '$lib/utils/usePresence'
 export { useVelocity } from '$lib/utils/velocity.svelte'
 export type { VelocitySource } from '$lib/utils/velocity.svelte'
-/**
- * @deprecated Use `styleString` instead for reactive styles with automatic unit handling.
- */
+// `@deprecated` JSDoc lives on the source declaration in styleObject.ts so
+// editor strike-through hints fire from there. Re-exporting cleanly here
+// keeps trunk's alphabetical export sort from binding the deprecation
+// to whatever symbol happens to land beneath it.
 export { stringifyStyleObject } from '$lib/utils/styleObject'
 export { styleString } from '$lib/utils/styleObject.svelte'
 export { useTime } from '$lib/utils/time.svelte'

--- a/src/lib/utils/animation.ts
+++ b/src/lib/utils/animation.ts
@@ -1,5 +1,6 @@
 import { pwLog } from '$lib/utils/log'
 import { hasFinishedPromise, isPromiseLike } from '$lib/utils/promise'
+import { mergeInlineStyles } from '$lib/utils/style'
 import { type AnimationOptions, type DOMKeyframesDefinition, animate } from 'motion'
 
 /**
@@ -55,13 +56,52 @@ export const animateWithLifecycle = (
     })
     onStart?.(payload)
     const controls = animate(el, payload, transition)
+
+    /**
+     * Commit the final keyframe values to the element's inline style so the
+     * animated-to state persists after WAAPI clears its keyframes (default
+     * `fill: 'none'`). Without this, `animate.{scaleX|scale|rotate|x|y|...}`
+     * snap back to the un-animated baseline once the animation ends because
+     * those transform shortcuts only exist via the `transform` property —
+     * which WAAPI returns to the element's inline `transform` on completion.
+     * CSS properties (`opacity`, `backgroundColor`, etc.) aren't affected
+     * because `mergeInlineStyles` writes them as discrete properties.
+     *
+     * Skips committing while a follow-up animation hasn't started — the
+     * lifecycle's `then()` resolution races with the next `animate()` call
+     * in the wait-mode chain, and we don't want to leak the prior state
+     * into the next animation's `from`.
+     *
+     * See issue #377 for full repro + history.
+     */
+    const commitFinalKeyframes = () => {
+        if (!el.isConnected) return
+        try {
+            const merged = mergeInlineStyles(
+                el.getAttribute('style') ?? '',
+                payload as Record<string, unknown>
+            )
+            if (merged) el.setAttribute('style', merged)
+        } catch {
+            // Swallow merge failures rather than dropping the onComplete chain.
+        }
+    }
+
     if (hasFinishedPromise(controls as unknown as { finished?: unknown })) {
         ;(controls as { finished?: Promise<unknown> }).finished
-            ?.then(() => onComplete?.(payload))
+            ?.then(() => {
+                commitFinalKeyframes()
+                onComplete?.(payload)
+            })
             .catch(() => {})
         return
     }
     if (isPromiseLike(controls as unknown)) {
-        ;(controls as unknown as Promise<unknown>).then(() => onComplete?.(payload)).catch(() => {})
+        ;(controls as unknown as Promise<unknown>)
+            .then(() => {
+                commitFinalKeyframes()
+                onComplete?.(payload)
+            })
+            .catch(() => {})
     }
 }


### PR DESCRIPTION
## Summary

Adds the **`Reorder.Group` + `Reorder.Item`** drag-to-reorder primitives — the viral framer-motion 2 demo. Drag any row, the others physically spring out of the way as your drag offset crosses each neighbour's centre. This is the highest-WOW pick from the parity board (per Project #5 ordering done after the framer-motion usage survey).

Closes #310 (the parity board card)
Closes #377 (the motion-proxy transform-shortcut persistence bug — both halves landed here because the canonical TodoList demo needs them to work)

## Changes

### ✨ New features
- **`<Reorder.Group axis values onReorder>`** — provides context, holds measured-position registry, fires `onReorder(next)` with the value-swap pattern (preserves unmeasured items for virtualised lists).
- **`<Reorder.Item value layout>`** — wraps `motion.<as>` with `drag={axis}` + `dragSnapToOrigin` + `layout`, reports its layout back to the group, drives swap decisions.
- **`checkReorder` + `autoScrollIfNeeded`** ports of framer-motion's swap-decision and edge-scroll utils (~30 + 170 LOC respectively).
- **Namespaced API** matching React: `<Reorder.Group>` / `<Reorder.Item>` via `export const Reorder = { Group, Item }` (Svelte 5 supports `<Foo.Bar>` for object-property components). Direct exports `ReorderGroup` / `ReorderItem` also available for full prop typing.
- **`/docs/reorder`** reference page + **`/examples/reorder`** standalone route with the canonical TodoList demo (8 colored todos, click-to-complete with fade + strikethrough, 600ms-delayed bubble-to-bottom).

### 🔧 Library fixes (required for the demo to render verbatim)
- **`_MotionContainer` drag styles** — auto-applies `user-select: none`, `touch-action: pan-{perpendicular}`, `draggable=false` whenever `drag` is set. Mirrors framer-motion's `render/html/use-props.ts:59-74` exactly. Without this, dragging selected text.
- **`_MotionContainer` initial baseline** — `initialKeyframes` now apply as inline style at all phases, not just `'mounting'`/`'initial'`. Fixes #377 half 1: `initial={{ scaleX: 0 }}` was never painting because the element typically mounts in `'ready'` state.
- **`animateWithLifecycle` final-keyframe commit** — calls `mergeInlineStyles` on completion to persist the animated-to state. Fixes #377 half 2: WAAPI's default `fill: 'none'` was wiping `transform` after every `animate.{scaleX|scale|rotate|x|y|...}` finished.

### 🧪 Testing
- **9 new spec tests** for `checkReorder` (pure swap-decision math): zero-velocity no-op, missing value, no-neighbour boundary, forward + backward swap thresholds, multi-step drag behaviour, layout-extent preservation.
- Full suite **533 / 533** pass (was 524 — the +9 is the new spec).

### 📚 Documentation
- New `/docs/reorder` page covering the API, the value-swap pattern, auto-scroll behaviour, SSR notes.
- New `/examples/reorder` route with the framer-motion TodoList port + 3 explainer notes (drag wiring, layout-spring, animation primitives).
- Nav entry added under "Components" between AnimatePresence and MotionConfig.

## Commits

- [`$(git rev-parse HEAD)`](https://github.com/humanspeak/svelte-motion/commit/$(git rev-parse HEAD)) feat(components): add Reorder.Group and Reorder.Item

## Verified live in Playwright
- 8 todos render with their colored borders + scrollable card ✓
- Click checkbox → text fades to 45% opacity ✓
- Strikethrough animates 0 → 1 over 400ms, **persists** at the end (this was broken; #377 fix made it work) ✓
- After 600ms → completed row springs to bottom ✓
- Drag any row → swap fires on offset crossing centre, no text selection during drag (lib drag-style fix) ✓
