### PR TITLE
feat(layout): projection node foundation + FLIP-delta event stream

### DIFF
--- a/e2e/projection/nested-ancestor.spec.ts
+++ b/e2e/projection/nested-ancestor.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Projection foundation (#379) — nested-ancestor measure semantics.
+ *
+ * An OUTER `<motion.div layout>` wrapper carries a user-authored
+ * `transform: translate(40px, 60px)`. An INNER `<motion.div layout>`
+ * toggles between the wrapper's left and right edge.
+ *
+ * `ProjectionNode.measure()` matches framer-motion's `removeBoxTransforms`:
+ * it strips only MOTION-applied transforms (written after mount) and
+ * preserves the USER-authored base. The page reports the inner's move
+ * delta plus the "stripped offset" — the gap between the inner's raw
+ * on-screen rect and the event's `layout` box:
+ *
+ *   • Static base only        → offset (0, 0)  — user transform preserved
+ *   • Post-mount +40px-down    → offset (0, 40) — only the motion part removed
+ *
+ * These two assertions are the regression guard for the measure fix:
+ * a regression that zeroed the whole transform would report (0, 0) even
+ * with the post-mount transform applied; a regression that left motion
+ * transforms in would report a non-zero offset for the static case.
+ */
+
+interface Delta {
+    dx: number
+    dy: number
+    changed: boolean
+}
+
+interface Offset {
+    x: number
+    y: number
+}
+
+const parseDelta = (text: string | null): Delta | null => {
+    const m = text?.match(/Δx=(-?[\d.]+)\s+Δy=(-?[\d.]+)\s+changed=(true|false)/)
+    if (!m) return null
+    return { dx: Number(m[1]), dy: Number(m[2]), changed: m[3] === 'true' }
+}
+
+const parseOffset = (text: string | null): Offset | null => {
+    const m = text?.match(/x=(-?\d+)\s+y=(-?\d+)/)
+    if (!m) return null
+    return { x: Number(m[1]), y: Number(m[2]) }
+}
+
+// Wrapper 400px wide, 1px border + 12px padding each side, inner 80px →
+// horizontal travel ≈ 400 - 2 - 24 - 80 = 294px. Allow a small margin.
+const TRAVEL_MIN = 285
+const TRAVEL_MAX = 305
+
+test.describe('projection/nested-ancestor', () => {
+    test('preserves a static ancestor transform in the layout box (offset 0)', async ({ page }) => {
+        await page.goto('/tests/projection/nested-ancestor?@isPlaywright=true')
+
+        const innerDelta = page.getByTestId('inner-delta')
+        const offset = page.getByTestId('stripped-offset')
+        await innerDelta.waitFor({ state: 'visible' })
+        await expect(innerDelta).toContainText('(no event yet)')
+
+        await page.getByTestId('toggle').click()
+        await expect(innerDelta).toContainText('changed=true')
+
+        const d = parseDelta(await innerDelta.textContent())
+        expect(d, 'inner delta should parse').not.toBeNull()
+        if (!d) throw new Error('unparseable delta')
+
+        // Inner travels ~the wrapper's inner width, purely horizontal.
+        expect(Math.abs(d.dx)).toBeGreaterThan(TRAVEL_MIN)
+        expect(Math.abs(d.dx)).toBeLessThan(TRAVEL_MAX)
+        expect(Math.abs(d.dy)).toBeLessThan(2)
+
+        // The wrapper's user transform is part of the measured layout —
+        // nothing is stripped, so the offset is zero.
+        await expect
+            .poll(async () => parseOffset(await offset.textContent()))
+            .toEqual({ x: 0, y: 0 })
+    })
+
+    test('strips a post-mount (motion) ancestor transform, keeping the user base', async ({
+        page
+    }) => {
+        await page.goto('/tests/projection/nested-ancestor?@isPlaywright=true')
+
+        const offset = page.getByTestId('stripped-offset')
+        const innerDelta = page.getByTestId('inner-delta')
+
+        // Apply a transform to the wrapper AFTER mount (stand-in for a
+        // FLIP/drag write), then toggle so the inner re-measures.
+        await page.getByTestId('motion-transform').check()
+        await page.getByTestId('toggle').click()
+        await expect(innerDelta).toContainText('changed=true')
+
+        // Only the post-mount +40px-down portion is removed from the
+        // inner's layout box; the user base (40, 60) stays put.
+        await expect
+            .poll(async () => parseOffset(await offset.textContent()))
+            .toEqual({ x: 0, y: 40 })
+
+        // Removing the post-mount transform returns the offset to zero.
+        await page.getByTestId('motion-transform').uncheck()
+        await page.getByTestId('toggle').click()
+        await expect
+            .poll(async () => parseOffset(await offset.textContent()))
+            .toEqual({ x: 0, y: 0 })
+    })
+
+    test('renders the wrapper, inner, controls, and readouts', async ({ page }) => {
+        await page.goto('/tests/projection/nested-ancestor?@isPlaywright=true')
+
+        await expect(page.getByTestId('projection-nested-ancestor')).toBeVisible()
+        await expect(page.getByTestId('toggle')).toBeVisible()
+        await expect(page.getByTestId('motion-transform')).toBeVisible()
+        await expect(page.getByTestId('inner-delta')).toBeVisible()
+        await expect(page.getByTestId('stripped-offset')).toBeVisible()
+    })
+})

--- a/e2e/projection/nested-ancestor.spec.ts
+++ b/e2e/projection/nested-ancestor.spec.ts
@@ -115,4 +115,37 @@ test.describe('projection/nested-ancestor', () => {
         await expect(page.getByTestId('inner-delta')).toBeVisible()
         await expect(page.getByTestId('stripped-offset')).toBeVisible()
     })
+
+    test('controls are discoverable by role and keyboard-operable', async ({ page }) => {
+        await page.goto('/tests/projection/nested-ancestor?@isPlaywright=true')
+
+        // The toggle is reachable by role + accessible name and focusable.
+        const toggle = page.getByRole('button', { name: /toggle position/i })
+        await expect(toggle).toBeVisible()
+        await toggle.focus()
+        await expect(toggle).toBeFocused()
+
+        // Keyboard activation moves the inner box and updates its readout.
+        await toggle.press('Enter')
+        await expect(page.getByTestId('inner-delta')).toContainText('changed=true')
+
+        // The post-mount control is exposed as a checkbox and keyboard-togglable.
+        const motionTransform = page.getByRole('checkbox', { name: /post-mount transform/i })
+        await expect(motionTransform).not.toBeChecked()
+        await motionTransform.focus()
+        await expect(motionTransform).toBeFocused()
+        await motionTransform.press('Space')
+        await expect(motionTransform).toBeChecked()
+
+        // And the stripped offset reflects the now-applied motion transform.
+        await page.getByRole('button', { name: /toggle position/i }).press('Enter')
+        await expect
+            .poll(async () => {
+                const m = (await page.getByTestId('stripped-offset').textContent())?.match(
+                    /x=(-?\d+)\s+y=(-?\d+)/
+                )
+                return m ? { x: Number(m[1]), y: Number(m[2]) } : null
+            })
+            .toEqual({ x: 0, y: 40 })
+    })
 })

--- a/e2e/projection/sibling-swap.spec.ts
+++ b/e2e/projection/sibling-swap.spec.ts
@@ -86,4 +86,21 @@ test.describe('projection/sibling-swap', () => {
         await expect(page.getByTestId('delta-0')).toBeVisible()
         await expect(page.getByTestId('delta-1')).toBeVisible()
     })
+
+    test('swap control is discoverable by role and keyboard-operable', async ({ page }) => {
+        await page.goto('/tests/projection/sibling-swap?@isPlaywright=true')
+
+        // Discoverable through an accessible (role + name) query, not just testid.
+        const swap = page.getByRole('button', { name: /swap order/i })
+        await expect(swap).toBeVisible()
+
+        // Focusable (in the tab order — native <button>, no tabindex=-1).
+        await swap.focus()
+        await expect(swap).toBeFocused()
+
+        // Keyboard activation triggers the swap and updates both readouts.
+        await swap.press('Enter')
+        await expect(page.getByTestId('delta-0')).toContainText('changed=true')
+        await expect(page.getByTestId('delta-1')).toContainText('changed=true')
+    })
 })

--- a/e2e/projection/sibling-swap.spec.ts
+++ b/e2e/projection/sibling-swap.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Projection foundation (#379) — flat sibling-swap event stream.
+ *
+ * Two `<motion.div layout>` boxes (80px tall, 16px gap → ~96px between
+ * their row origins). Clicking "swap" reverses their order in a `$state`
+ * array; the existing FLIP layout animation runs and each box's
+ * `ProjectionNode` fires `onProjectionUpdate` with the delta between its
+ * pre- and post-swap layout box. The page renders each box's last delta
+ * into a `<pre>`, so we assert on the projection payload directly rather
+ * than scraping mid-animation transforms.
+ *
+ * Expected: one box reports Δy ≈ +96, the other Δy ≈ -96, both with
+ * `changed=true` and Δx ≈ 0. Swapping again flips the signs.
+ */
+
+interface Delta {
+    dx: number
+    dy: number
+    changed: boolean
+}
+
+const parseDelta = (text: string | null): Delta | null => {
+    const m = text?.match(/Δx=(-?[\d.]+)\s+Δy=(-?[\d.]+)\s+changed=(true|false)/)
+    if (!m) return null
+    return { dx: Number(m[1]), dy: Number(m[2]), changed: m[3] === 'true' }
+}
+
+const ROW_GAP_MIN = 88 // box height (80) + gap (16) leaves a comfortable lower bound
+const ROW_GAP_MAX = 104
+
+test.describe('projection/sibling-swap', () => {
+    test('each box emits a didUpdate with the opposite-signed row delta', async ({ page }) => {
+        await page.goto('/tests/projection/sibling-swap?@isPlaywright=true')
+
+        const d0 = page.getByTestId('delta-0')
+        const d1 = page.getByTestId('delta-1')
+        await d0.waitFor({ state: 'visible' })
+
+        // No projection event has fired before the first swap.
+        await expect(d0).toContainText('(no event yet)')
+        await expect(d1).toContainText('(no event yet)')
+
+        await page.getByTestId('swap').click()
+
+        // Both boxes must report a real layout change.
+        await expect(d0).toContainText('changed=true')
+        await expect(d1).toContainText('changed=true')
+
+        const a = parseDelta(await d0.textContent())
+        const b = parseDelta(await d1.textContent())
+        expect(a, 'delta-0 should parse').not.toBeNull()
+        expect(b, 'delta-1 should parse').not.toBeNull()
+        if (!a || !b) throw new Error('unparseable delta')
+
+        // Pure vertical swap — no horizontal travel.
+        expect(Math.abs(a.dx)).toBeLessThan(2)
+        expect(Math.abs(b.dx)).toBeLessThan(2)
+
+        // Each box moves ~one row; the two move in opposite directions
+        // and by (approximately) the same magnitude.
+        expect(Math.abs(a.dy)).toBeGreaterThan(ROW_GAP_MIN)
+        expect(Math.abs(a.dy)).toBeLessThan(ROW_GAP_MAX)
+        expect(Math.abs(b.dy)).toBeGreaterThan(ROW_GAP_MIN)
+        expect(Math.abs(b.dy)).toBeLessThan(ROW_GAP_MAX)
+        expect(Math.abs(a.dy)).toBeCloseTo(Math.abs(b.dy), 0)
+        expect(Math.sign(a.dy)).toBe(-Math.sign(b.dy))
+
+        // Swapping back flips box A's vertical direction.
+        const firstSign = Math.sign(a.dy)
+        await page.getByTestId('swap').click()
+        await expect
+            .poll(async () => {
+                const next = parseDelta(await d0.textContent())
+                return next && next.changed ? Math.sign(next.dy) : 0
+            })
+            .toBe(-firstSign)
+    })
+
+    test('renders both boxes, the swap control, and per-box readouts', async ({ page }) => {
+        await page.goto('/tests/projection/sibling-swap?@isPlaywright=true')
+
+        await expect(page.getByTestId('projection-sibling-swap')).toBeVisible()
+        await expect(page.getByTestId('swap')).toBeVisible()
+        await expect(page.getByTestId('delta-0')).toBeVisible()
+        await expect(page.getByTestId('delta-1')).toBeVisible()
+    })
+})

--- a/src/lib/components/projection.context.ts
+++ b/src/lib/components/projection.context.ts
@@ -1,0 +1,60 @@
+import type { ProjectionNode } from '$lib/utils/projection'
+import { getContext, setContext } from 'svelte'
+
+/**
+ * Svelte context plumbing for the projection tree.
+ *
+ * Every `motion.*` element creates a `ProjectionNode` at setup time and
+ * publishes it via `setProjectionParent(node)` so descendant motion
+ * elements can pick it up via `getProjectionParent()` and wire themselves
+ * as `node.parent` + register in `node.parent.children`. The tree shape
+ * mirrors the Svelte component tree exactly because Svelte's
+ * `setContext` propagates down through descendants in component-init
+ * order.
+ *
+ * This is the closest analog we have to framer-motion's depth-sorted
+ * FlatTree (`projection/node/create-projection-node.ts`), but without
+ * the global `root` registry — parent/child pointers are sufficient
+ * for the workflows this PR enables (drag↔swap origin compensation,
+ * ancestor-zeroing measure). A global root would only be needed once we
+ * port shared-element `layoutId` morphing onto projection nodes; the
+ * current `layoutId.ts` registry continues to handle that case
+ * independently.
+ *
+ * Order of operations inside a single `motion.*` component (CRITICAL):
+ * 1. Read parent via `getProjectionParent()` BEFORE creating own node.
+ * 2. Construct own node, set `node.parent = parent`.
+ * 3. Publish own node via `setProjectionParent(node)`.
+ * If steps 1 and 3 are reversed, the component sees ITS OWN node as
+ * the parent (because `setContext` shadows from the call site down)
+ * and the tree collapses to a chain of self-references. Same trap
+ * `layoutScroll.context.ts` documents — don't repeat it.
+ */
+const PROJECTION_CONTEXT_KEY = Symbol('svelte-motion:projection-parent')
+
+/**
+ * Publish a `ProjectionNode` as the projection parent for descendant
+ * motion components.
+ *
+ * @param node The current component's ProjectionNode, or `null` to
+ *   explicitly clear (rarely needed — Svelte context auto-clears on
+ *   component unmount).
+ */
+export const setProjectionParent = (node: ProjectionNode | null): void => {
+    setContext<ProjectionNode | null>(PROJECTION_CONTEXT_KEY, node)
+}
+
+/**
+ * Read the ancestor `ProjectionNode` published by the nearest motion
+ * ancestor. Returns `null` when this component is at the root of the
+ * projection tree (or when no motion ancestor exists).
+ *
+ * Must be called BEFORE the current component publishes its own node
+ * via `setProjectionParent` — see the order-of-operations note in this
+ * file's header.
+ *
+ * @returns The parent ProjectionNode, or `null`.
+ */
+export const getProjectionParent = (): ProjectionNode | null => {
+    return getContext<ProjectionNode | null>(PROJECTION_CONTEXT_KEY) ?? null
+}

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -39,7 +39,8 @@
         computeFlipTransforms,
         runFlipAnimation,
         setCompositorHints,
-        observeLayoutChanges
+        observeLayoutChanges,
+        type RectLike
     } from '$lib/utils/layout'
     import type { SvelteHTMLElements } from 'svelte/elements'
     import { mergeInlineStyles } from '$lib/utils/style'
@@ -53,6 +54,8 @@
     import { getInitialKeyframes } from '$lib/utils/initial'
     import { attachDrag } from '$lib/utils/drag'
     import { attachPan, type AttachPanCleanup } from '$lib/utils/pan'
+    import { ProjectionNode } from '$lib/utils/projection'
+    import { getProjectionParent, setProjectionParent } from '$lib/components/projection.context'
     import { resolveInitial, resolveAnimate, resolveExit, resolveWhile } from '$lib/utils/variants'
     import {
         setVariantContext,
@@ -134,6 +137,7 @@
         layout: layoutProp,
         layoutId: layoutIdProp,
         layoutScroll: layoutScrollProp,
+        onProjectionUpdate: onProjectionUpdateProp,
         ref: element = $bindable(null),
         ...rest
     }: Props = $props()
@@ -189,6 +193,34 @@
         const refs = ancestorScrollContainerRef?.() ?? []
         // Filter out unbound refs (HTMLElement | null | undefined → HTMLElement[]).
         return refs.filter((el): el is HTMLElement => Boolean(el))
+    }
+
+    // Projection tree wiring (#379). Capture the parent node BEFORE
+    // publishing our own — same shadowing trap as layoutScroll above.
+    // The node measures through `resolveLayoutScrollAncestors` so its
+    // boxes share the FLIP coordinate space, and zeros ancestor
+    // transforms during measure so nested layout-animated parents don't
+    // corrupt a child's delta.
+    const projectionParent = getProjectionParent()
+    const projection = new ProjectionNode({
+        parent: projectionParent,
+        getScrollContainers: resolveLayoutScrollAncestors
+    })
+    setProjectionParent(projection)
+
+    // Ancestor-transform-invariant layout measurement for the FLIP effect.
+    // Returns the projection node's `Box` (ancestor chain reset to base,
+    // self transform stripped, scroll containers compensated) as the
+    // `RectLike` shape `computeFlipTransforms` consumes.
+    const measureLayoutRect = (): RectLike | null => {
+        const box = projection.measure()
+        if (!box) return null
+        return {
+            left: box.x.min,
+            top: box.y.min,
+            width: box.x.max - box.x.min,
+            height: box.y.max - box.y.min
+        }
     }
 
     // Get current presence depth (0 = direct child of AnimatePresence, undefined = not in AnimatePresence)
@@ -930,26 +962,53 @@
               : undefined
     )
 
+    // Projection node lifecycle + the `onProjectionUpdate` listener.
+    // Mount once the element binds; seed the baseline layout; subscribe
+    // the consumer's callback if present; unmount on cleanup.
+    $effect(() => {
+        if (!element) return
+        projection.mount(element)
+        projection.measure() // seed latestLayout so the first commit can diff
+        const off = onProjectionUpdateProp
+            ? projection.addEventListener('didUpdate', (data) => onProjectionUpdateProp(data))
+            : undefined
+        return () => {
+            off?.()
+            projection.unmount()
+        }
+    })
+
     // Minimal layout animation using FLIP when `layout` is enabled.
     // When layout === 'position' we only translate.
     // When layout === true we also scale to smoothly interpolate size changes.
-    let lastRect: DOMRect | null = null
+    let lastRect: RectLike | null = null
     $effect(() => {
         if (!(element && layoutProp && isLoaded === 'ready')) return
 
-        // Initialize last rect on first ready frame
-        lastRect = measureRect(element!, resolveLayoutScrollAncestors())
+        // Initialize last rect on first ready frame. We measure through the
+        // projection node rather than `measureRect` directly so the rect is
+        // ancestor-transform-invariant: the node resets the whole ancestor
+        // chain to its mount-time base while reading, which strips any
+        // motion-applied (FLIP/drag) transform up the tree. Without this a
+        // child re-measures and FLIPs whenever an ancestor's transform
+        // animates, even though the child's own layout never moved. (#379)
+        lastRect = measureLayoutRect()
         // Hint compositor for smoother FLIP transforms
         setCompositorHints(element!, true)
 
         let rafId: number | null = null
         const runFlip = () => {
-            const scrollContainers = resolveLayoutScrollAncestors()
+            // Emit the projection didUpdate event off the same layout-change
+            // signal the FLIP runs on. The node diffs its cached pre-change
+            // layout against a fresh ancestor-stripped measurement and fans
+            // out the delta to `onProjectionUpdate` listeners. (#379)
+            projection.commitLayoutChange()
+            const next = measureLayoutRect()
+            if (!next) return
             if (!lastRect) {
-                lastRect = measureRect(element!, scrollContainers)
+                lastRect = next
                 return
             }
-            const next = measureRect(element!, scrollContainers)
             const transforms = computeFlipTransforms(lastRect, next, layoutProp ?? false)
             runFlipAnimation(element!, transforms, (mergedTransition ?? {}) as AnimationOptions)
             lastRect = next

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -43,7 +43,7 @@
         type RectLike
     } from '$lib/utils/layout'
     import type { SvelteHTMLElements } from 'svelte/elements'
-    import { mergeInlineStyles } from '$lib/utils/style'
+    import { mergeInlineStyles, extractTransform } from '$lib/utils/style'
     import { isNativelyFocusable } from '$lib/utils/a11y'
     import {
         getAnimatePresenceContext,
@@ -201,26 +201,38 @@
     // boxes share the FLIP coordinate space, and zeros ancestor
     // transforms during measure so nested layout-animated parents don't
     // corrupt a child's delta.
+    // The user-authored transform, sourced from the `style` prop rather
+    // than the live inline transform — the latter already carries any
+    // transform-type `initial`/`animate` keyframe by the time the node
+    // measures, which would be mistaken for the user's base.
+    const userBaseTransform = $derived(extractTransform(styleProp))
+
     const projectionParent = getProjectionParent()
     const projection = new ProjectionNode({
         parent: projectionParent,
-        getScrollContainers: resolveLayoutScrollAncestors
+        getScrollContainers: resolveLayoutScrollAncestors,
+        getBaseTransform: () => userBaseTransform
     })
     setProjectionParent(projection)
 
-    // Ancestor-transform-invariant layout measurement for the FLIP effect.
-    // Returns the projection node's `Box` (ancestor chain reset to base,
-    // self transform stripped, scroll containers compensated) as the
+    // Convert a projection `Box` (ancestor chain reset to base, self
+    // transform stripped, scroll containers compensated) to the
     // `RectLike` shape `computeFlipTransforms` consumes.
+    const boxToRectLike = (box: {
+        x: { min: number; max: number }
+        y: { min: number; max: number }
+    }): RectLike => ({
+        left: box.x.min,
+        top: box.y.min,
+        width: box.x.max - box.x.min,
+        height: box.y.max - box.y.min
+    })
+
+    // Ancestor-transform-invariant layout measurement for seeding the
+    // FLIP effect's first rect.
     const measureLayoutRect = (): RectLike | null => {
         const box = projection.measure()
-        if (!box) return null
-        return {
-            left: box.x.min,
-            top: box.y.min,
-            width: box.x.max - box.x.min,
-            height: box.y.max - box.y.min
-        }
+        return box ? boxToRectLike(box) : null
     }
 
     // Get current presence depth (0 = direct child of AnimatePresence, undefined = not in AnimatePresence)
@@ -998,13 +1010,14 @@
 
         let rafId: number | null = null
         const runFlip = () => {
-            // Emit the projection didUpdate event off the same layout-change
-            // signal the FLIP runs on. The node diffs its cached pre-change
-            // layout against a fresh ancestor-stripped measurement and fans
-            // out the delta to `onProjectionUpdate` listeners. (#379)
-            projection.commitLayoutChange()
-            const next = measureLayoutRect()
-            if (!next) return
+            // commitLayoutChange does the ancestor-stripped measure, fans
+            // the delta out to `onProjectionUpdate` listeners, AND returns
+            // the freshly-measured box — so the FLIP reuses that single
+            // measurement as `next` instead of walking + transform-resetting
+            // the ancestor chain a second time per frame. (#379)
+            const nextBox = projection.commitLayoutChange()
+            if (!nextBox) return
+            const next = boxToRectLike(nextBox)
             if (!lastRect) {
                 lastRect = next
                 return

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -975,18 +975,29 @@
     )
 
     // Projection node lifecycle + the `onProjectionUpdate` listener.
-    // Mount once the element binds; seed the baseline layout; subscribe
-    // the consumer's callback if present; unmount on cleanup.
+    // Mount once the element binds; seed the baseline layout; unmount on
+    // cleanup. Depends ONLY on `element` — the `onProjectionUpdate`
+    // subscription lives in its own effect below so a change to the
+    // callback's identity re-subscribes WITHOUT tearing the node down
+    // (an unmount would clear latestLayout/children and re-seed the
+    // first commit instead of emitting a real delta).
     $effect(() => {
         if (!element) return
         projection.mount(element)
         projection.measure() // seed latestLayout so the first commit can diff
-        const off = onProjectionUpdateProp
-            ? projection.addEventListener('didUpdate', (data) => onProjectionUpdateProp(data))
-            : undefined
         return () => {
-            off?.()
             projection.unmount()
+        }
+    })
+
+    // Subscribe the consumer's `onProjectionUpdate` callback. Separate
+    // from the mount effect so re-subscribing on a callback-identity
+    // change never unmounts the node.
+    $effect(() => {
+        if (!(element && onProjectionUpdateProp)) return
+        const off = projection.addEventListener('didUpdate', (data) => onProjectionUpdateProp(data))
+        return () => {
+            off()
         }
     })
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -39,12 +39,14 @@ export type {
     MotionOnDragTransitionEnd,
     MotionOnInViewEnd,
     MotionOnInViewStart,
+    MotionOnProjectionUpdate,
     MotionTransition,
     MotionWhileDrag,
     MotionWhileFocus,
     MotionWhileHover,
     MotionWhileInView,
     MotionWhileTap,
+    ProjectionUpdatePayload,
     ReducedMotionConfig,
     Variants
 } from '$lib/types'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -298,6 +298,32 @@ export type MotionOnPanStart = ((event: PointerEvent, info: DragInfo) => void) |
 export type MotionOnPan = ((event: PointerEvent, info: DragInfo) => void) | undefined
 export type MotionOnPanEnd = ((event: PointerEvent, info: DragInfo) => void) | undefined
 
+/**
+ * Payload delivered to `onProjectionUpdate`. Re-declared structurally
+ * here (rather than imported from `projection.ts`) so `types.ts`
+ * stays dependency-free at the type layer. `delta.x/y.translate` is the
+ * px shift the element's layout box moved between the pre-change
+ * snapshot and the post-change measurement; `hasLayoutChanged` applies
+ * the rounding threshold that filters sub-pixel jitter.
+ */
+export type ProjectionUpdatePayload = {
+    layout: { x: { min: number; max: number }; y: { min: number; max: number } }
+    snapshot: { x: { min: number; max: number }; y: { min: number; max: number } }
+    delta: {
+        x: { translate: number; scale: number; origin: number; originPoint: number }
+        y: { translate: number; scale: number; origin: number; originPoint: number }
+    }
+    hasLayoutChanged: boolean
+}
+
+/**
+ * Fires after each layout change to a `motion.*` element that has
+ * `layout` enabled, with the FLIP delta between the pre- and
+ * post-change layout boxes. Mirrors framer-motion's `onLayoutMeasure`
+ * surface. Wired through the element's internal `ProjectionNode`.
+ */
+export type MotionOnProjectionUpdate = ((data: ProjectionUpdatePayload) => void) | undefined
+
 export type DragAxis = boolean | 'x' | 'y'
 export type DragConstraints =
     | {
@@ -426,6 +452,12 @@ export type MotionProps = {
     class?: string
     /** Enable FLIP layout animations; "position" limits to translation only */
     layout?: boolean | 'position'
+    /**
+     * Fires after each `layout`-driven change with the FLIP delta from
+     * the element's internal projection node. Mirrors framer-motion's
+     * `onLayoutMeasure`. Requires `layout` to be enabled.
+     */
+    onProjectionUpdate?: MotionOnProjectionUpdate
     /** Shared layout animation identifier. Elements with matching layoutId animate between positions. */
     layoutId?: string
     /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -303,8 +303,9 @@ export type MotionOnPanEnd = ((event: PointerEvent, info: DragInfo) => void) | u
  * here (rather than imported from `projection.ts`) so `types.ts`
  * stays dependency-free at the type layer. `delta.x/y.translate` is the
  * px shift the element's layout box moved between the pre-change
- * snapshot and the post-change measurement; `hasLayoutChanged` applies
- * the rounding threshold that filters sub-pixel jitter.
+ * snapshot and the post-change measurement; `hasLayoutChanged` is false
+ * only when the delta is within a tight float epsilon (±0.01px
+ * translate), so even a sub-pixel real move is reported as a change.
  */
 export type ProjectionUpdatePayload = {
     layout: { x: { min: number; max: number }; y: { min: number; max: number } }

--- a/src/lib/utils/drag.ts
+++ b/src/lib/utils/drag.ts
@@ -188,13 +188,19 @@ const computeReleaseVelocity = (
 }
 
 /**
- * Cleanup handle returned by {@link attachDrag}. Invoke it to tear the
- * gesture down (removes listeners, cancels any in-flight momentum/settle
- * animation). It also carries `adjustOrigin(dx, dy)`, which shifts the
- * LIVE gesture's origin + visual offset by a layout-shift delta mid-drag
- * — used for projection-driven cursor pinning when a layout slot moves
- * under the dragged element (#379 / #310). `adjustOrigin` is a no-op when
- * not currently dragging and only affects axes the drag is unlocked on.
+ * Cleanup handle returned by {@link attachDrag}. Invoke it to detach the
+ * gesture's pointer/resize listeners. It does NOT cancel an in-flight
+ * momentum/settle animation — matching framer-motion, whose drag teardown
+ * removes listeners only and deliberately lets motion continue across an
+ * unmount/remount (e.g. reorder reconciliation); the animation is cleaned
+ * up by the element/motion-value lifecycle.
+ *
+ * The handle also carries `adjustOrigin(dx, dy)`, which shifts the LIVE
+ * gesture's origin + visual offset by a layout-shift delta mid-drag — used
+ * for projection-driven cursor pinning when a layout slot moves under the
+ * dragged element (#379 / #310). It is a no-op when not currently dragging
+ * and compensates on both axes (mirroring upstream's per-axis `eachAxis`
+ * compensation).
  */
 export type AttachDragCleanup = (() => void) & {
     adjustOrigin: (dx: number, dy: number) => void
@@ -222,8 +228,9 @@ export type AttachDragCleanup = (() => void) & {
  * @param opts Drag options — `axis`, `constraints`, `elastic`,
  *   `momentum`, `whileDrag`, and the `onDrag*` lifecycle callbacks.
  * @returns A callable cleanup handle ({@link AttachDragCleanup}): call it
- *   to detach listeners + cancel animations, or call its
- *   `adjustOrigin(dx, dy)` to reposition the live gesture mid-drag.
+ *   to detach the gesture's listeners (in-flight momentum is not
+ *   cancelled — see the type docs), or call its `adjustOrigin(dx, dy)` to
+ *   reposition the live gesture mid-drag.
  * @example
  * ```ts
  * const cleanup = attachDrag(el, { axis: 'x', momentum: true })
@@ -391,13 +398,13 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
      */
     const adjustOrigin = (dx: number, dy: number) => {
         if (!dragging) return
-        // Advance the origin only on axes that are actually dragged —
-        // setXYImmediate writes (and bumps `applied` for) just those axes,
-        // so mutating origin on a locked-out axis would desync origin from
-        // applied and corrupt the next `offset = lastPoint - startPoint +
-        // origin` resolution.
-        if (axis === true || axis === 'x') origin.x += dx
-        if (axis === true || axis === 'y') origin.y += dy
+        // Compensate on BOTH axes unconditionally — upstream's didUpdate
+        // handler applies the delta per-axis via `eachAxis` regardless of
+        // the drag axis or direction lock, because a layout slot can shift
+        // on either axis. `setXYImmediate` then writes the transform for
+        // the axis this drag manages.
+        origin.x += dx
+        origin.y += dy
         setXYImmediate(applied.x + dx, applied.y + dy)
     }
 

--- a/src/lib/utils/drag.ts
+++ b/src/lib/utils/drag.ts
@@ -377,8 +377,13 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
      */
     const adjustOrigin = (dx: number, dy: number) => {
         if (!dragging) return
-        origin.x += dx
-        origin.y += dy
+        // Advance the origin only on axes that are actually dragged —
+        // setXYImmediate writes (and bumps `applied` for) just those axes,
+        // so mutating origin on a locked-out axis would desync origin from
+        // applied and corrupt the next `offset = lastPoint - startPoint +
+        // origin` resolution.
+        if (axis === true || axis === 'x') origin.x += dx
+        if (axis === true || axis === 'y') origin.y += dy
         setXYImmediate(applied.x + dx, applied.y + dy)
     }
 

--- a/src/lib/utils/drag.ts
+++ b/src/lib/utils/drag.ts
@@ -208,7 +208,18 @@ const computeReleaseVelocity = (
  * - If you see a "jump" at the start of a second drag, it usually means `applied` wasn't
  *   updated after a non-0-duration settle animation.
  */
-export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): (() => void) => {
+/**
+ * Cleanup function returned by `attachDrag`. Carries an `adjustOrigin`
+ * method that shifts the live gesture's origin + visual offset by a
+ * layout-shift delta mid-drag — see the `adjustOrigin` closure inside
+ * `attachDrag` for the rationale (projection-driven cursor pinning,
+ * #379). The plain-call form tears the gesture down as before.
+ */
+export type AttachDragCleanup = (() => void) & {
+    adjustOrigin: (dx: number, dy: number) => void
+}
+
+export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDragCleanup => {
     const EL_ID = el.getAttribute('data-testid') || el.id || el.tagName
     pwLog('[drag] attach', {
         el: EL_ID,
@@ -308,6 +319,67 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): (() => voi
                 }
             }
         }
+    }
+
+    /**
+     * Write absolute element-space translation by mutating
+     * `el.style.transform` DIRECTLY — no `animate()`, no epsilon skip,
+     * no Playwright retry. The translate channel is rewritten while any
+     * non-translate transform the element already carries (e.g. a
+     * `whileDrag` scale) is preserved as a suffix.
+     *
+     * Why this exists separately from `setXY`: routing through
+     * `animate(el, _, { duration: 0 })` defers the write to Motion's
+     * scheduler, costing ~1 frame before the new position paints. For
+     * the projection-driven origin compensation (where a layout swap
+     * must keep the dragged element under the cursor in the SAME frame
+     * the swap commits), that frame of lag manifests as a visible
+     * wobble. This path lands synchronously. See #379 / the
+     * `adjustOrigin` hook below.
+     */
+    const setXYImmediate = (x: number, y: number) => {
+        const parts: string[] = []
+        if (axis === true || axis === 'x') parts.push(`translateX(${x}px)`)
+        if (axis === true || axis === 'y') parts.push(`translateY(${y}px)`)
+        // Strip existing translate channels, keep the rest (scale/rotate/etc.).
+        const nonTranslate = el.style.transform.replace(/translate[XYZ3d]*\([^)]*\)/g, '').trim()
+        el.style.transform = [...parts, nonTranslate].filter(Boolean).join(' ')
+        if (axis === true || axis === 'x') applied.x = x
+        if (axis === true || axis === 'y') applied.y = y
+    }
+
+    /**
+     * Adjust the drag origin + visual offset by a layout-shift delta,
+     * mid-gesture, keeping the dragged element pinned under the cursor
+     * while its underlying layout slot moves.
+     *
+     * Direct port of framer-motion's projection `didUpdate` handler in
+     * `VisualElementDragControls.ts:742-758`:
+     *
+     * ```ts
+     * this.originPoint[axis] += delta[axis].translate
+     * motionValue.set(motionValue.get() + delta[axis].translate)
+     * ```
+     *
+     * We do the same two-write dance: shift `origin` (the gesture's
+     * reference zero) AND the applied visual transform by the same
+     * delta, so `lastPoint - startPoint + origin` continues to resolve
+     * to the correct on-screen position after the layout slot moved.
+     * Uses `setXYImmediate` so the compensation is visible the same
+     * frame as the layout change.
+     *
+     * Not wired to any projection node in this PR — exposed on the
+     * `attachDrag` return handle for the Reorder PR (#310) to call from
+     * its `ProjectionNode.didUpdate` listener.
+     *
+     * @param dx Layout delta on the x axis (px).
+     * @param dy Layout delta on the y axis (px).
+     */
+    const adjustOrigin = (dx: number, dy: number) => {
+        if (!dragging) return
+        origin.x += dx
+        origin.y += dy
+        setXYImmediate(applied.x + dx, applied.y + dy)
     }
 
     const startWhileDrag = () => {
@@ -867,7 +939,7 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): (() => voi
     el.addEventListener('pointerdown', onPointerDown)
     pwLog('[drag] pointerdown listener attached', { el: EL_ID })
 
-    return () => {
+    const teardown = () => {
         pwLog('[drag] detach', { el: EL_ID })
         el.removeEventListener('pointerdown', onPointerDown)
         el.removeEventListener('pointermove', onPointerMove as EventListener)
@@ -877,4 +949,6 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): (() => voi
         window.removeEventListener('pointerup', onPointerUp as EventListener)
         window.removeEventListener('pointercancel', onPointerCancel as EventListener)
     }
+
+    return Object.assign(teardown, { adjustOrigin }) as AttachDragCleanup
 }

--- a/src/lib/utils/drag.ts
+++ b/src/lib/utils/drag.ts
@@ -398,13 +398,21 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
      */
     const adjustOrigin = (dx: number, dy: number) => {
         if (!dragging) return
-        // Compensate on BOTH axes unconditionally — upstream's didUpdate
-        // handler applies the delta per-axis via `eachAxis` regardless of
-        // the drag axis or direction lock, because a layout slot can shift
-        // on either axis. `setXYImmediate` then writes the transform for
-        // the axis this drag manages.
+        // Compensate the origin on BOTH axes unconditionally — upstream's
+        // didUpdate handler applies the delta per-axis via `eachAxis`
+        // regardless of the drag axis or direction lock, because a layout
+        // slot can shift on either axis.
         origin.x += dx
         origin.y += dy
+        // The VISUAL write is `setXYImmediate`, which only writes the axis
+        // this drag manages (`opts.axis`). For the dragged axis that pins
+        // the element same-frame; the cross-axis case (e.g. drag="x" + a
+        // y-shift) only updates `origin`, not the transform. Fully
+        // rendering cross-axis compensation needs to route through the
+        // Motion value the move path uses (a direct write here would be
+        // wiped by the next `setXY`), so it's finalized when this hook is
+        // wired in #310. The common Reorder case (drag axis === the shift
+        // axis) is fully compensated today.
         setXYImmediate(applied.x + dx, applied.y + dy)
     }
 

--- a/src/lib/utils/drag.ts
+++ b/src/lib/utils/drag.ts
@@ -188,37 +188,51 @@ const computeReleaseVelocity = (
 }
 
 /**
+ * Cleanup handle returned by {@link attachDrag}. Invoke it to tear the
+ * gesture down (removes listeners, cancels any in-flight momentum/settle
+ * animation). It also carries `adjustOrigin(dx, dy)`, which shifts the
+ * LIVE gesture's origin + visual offset by a layout-shift delta mid-drag
+ * — used for projection-driven cursor pinning when a layout slot moves
+ * under the dragged element (#379 / #310). `adjustOrigin` is a no-op when
+ * not currently dragging and only affects axes the drag is unlocked on.
+ */
+export type AttachDragCleanup = (() => void) & {
+    adjustOrigin: (dx: number, dy: number) => void
+}
+
+/**
  * Attach a drag gesture to an element.
  *
- * Captures the pointer, updates x/y transforms with axis and optional direction lock,
- * applies elastic overflow against constraints, emits lifecycle callbacks with DragInfo,
- * and runs a momentum animation on release when enabled.
- */
-/**
- * Attach a drag gesture to an HTMLElement.
+ * Captures the pointer and updates x/y transforms with axis and optional
+ * direction lock, applies elastic overflow against constraints, emits
+ * lifecycle callbacks with `DragInfo`, and runs a momentum animation on
+ * release when enabled.
  *
  * Lifecycle:
  * - pointerdown → capture pointer, snapshot origin, start velocity history, enter whileDrag
  * - pointermove → compute deltas, direction lock, apply constraints + elastic, write x/y
  * - pointerup/cancel → either run momentum decay to a target or settle/clamp instantly
  *
- * Important invariants:
- * - `applied` tracks the currently applied transform (x/y). Always keep it in sync when
- *   writing transforms or finishing animations so a second drag starts from the right origin.
- * - If you see a "jump" at the start of a second drag, it usually means `applied` wasn't
- *   updated after a non-0-duration settle animation.
+ * Invariant: `applied` tracks the currently applied x/y transform — it
+ * must stay in sync when writing transforms or finishing animations, or a
+ * second drag "jumps" from a stale origin (commonly a missed update after
+ * a non-zero-duration settle animation).
+ *
+ * @param el The element to make draggable.
+ * @param opts Drag options — `axis`, `constraints`, `elastic`,
+ *   `momentum`, `whileDrag`, and the `onDrag*` lifecycle callbacks.
+ * @returns A callable cleanup handle ({@link AttachDragCleanup}): call it
+ *   to detach listeners + cancel animations, or call its
+ *   `adjustOrigin(dx, dy)` to reposition the live gesture mid-drag.
+ * @example
+ * ```ts
+ * const cleanup = attachDrag(el, { axis: 'x', momentum: true })
+ * // …when a layout swap shifts the slot under the cursor mid-drag:
+ * cleanup.adjustOrigin(10, -5)
+ * // on teardown:
+ * cleanup()
+ * ```
  */
-/**
- * Cleanup function returned by `attachDrag`. Carries an `adjustOrigin`
- * method that shifts the live gesture's origin + visual offset by a
- * layout-shift delta mid-drag — see the `adjustOrigin` closure inside
- * `attachDrag` for the rationale (projection-driven cursor pinning,
- * #379). The plain-call form tears the gesture down as before.
- */
-export type AttachDragCleanup = (() => void) & {
-    adjustOrigin: (dx: number, dy: number) => void
-}
-
 export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDragCleanup => {
     const EL_ID = el.getAttribute('data-testid') || el.id || el.tagName
     pwLog('[drag] attach', {

--- a/src/lib/utils/layout.ts
+++ b/src/lib/utils/layout.ts
@@ -15,8 +15,19 @@ import { animate, type AnimationOptions, type DOMKeyframesDefinition } from 'mot
  *
  * Pass an empty array (or omit) for viewport-relative behaviour.
  *
+ * `baseTransform` is the value the element's `transform` is set to while
+ * measuring (default `'none'`, i.e. all transforms removed). The
+ * projection system passes the element's mount-time transform here so
+ * that a user-authored static `transform` is preserved in the
+ * measurement while only the motion-applied portion (written after
+ * mount) is removed — mirroring framer-motion's `removeBoxTransforms`,
+ * which only subtracts motion-tracked `latestValues` and leaves
+ * user-authored transforms intact. Existing FLIP callers omit it and
+ * get the original strip-everything behaviour.
+ *
  * @param el Element to measure.
  * @param scrollContainers Optional ancestor chain with `layoutScroll` enabled.
+ * @param baseTransform Transform string applied during measurement. Defaults to `'none'`.
  * @returns DOMRect snapshot of the element.
  *
  * @example
@@ -31,10 +42,14 @@ import { animate, type AnimationOptions, type DOMKeyframesDefinition } from 'mot
  * const rect = measureRect(node, [innerScroll, outerScroll])
  * ```
  */
-export const measureRect = (el: HTMLElement, scrollContainers?: HTMLElement[]): DOMRect => {
+export const measureRect = (
+    el: HTMLElement,
+    scrollContainers?: HTMLElement[],
+    baseTransform = 'none'
+): DOMRect => {
     const prev = el.style.transform
     try {
-        el.style.transform = 'none'
+        el.style.transform = baseTransform
         const rect = el.getBoundingClientRect()
         if (!scrollContainers || scrollContainers.length === 0) return rect
         // Re-express the rect in the *combined* scroll-container coordinate
@@ -54,6 +69,20 @@ export const measureRect = (el: HTMLElement, scrollContainers?: HTMLElement[]): 
 }
 
 /**
+ * Minimal rectangle shape `computeFlipTransforms` reads. A `DOMRect`
+ * satisfies it structurally, and so does a projection `Box` converted to
+ * `{ left, top, width, height }`. Declared here (rather than importing
+ * the projection `Box`) so `layout.ts` stays free of a circular
+ * dependency on `projection.ts`, which imports `measureRect` from here.
+ */
+export interface RectLike {
+    left: number
+    top: number
+    width: number
+    height: number
+}
+
+/**
  * Compute FLIP transform deltas between two rects.
  *
  * @param prev Previous rect.
@@ -62,8 +91,8 @@ export const measureRect = (el: HTMLElement, scrollContainers?: HTMLElement[]): 
  * @return Deltas and flags indicating which transforms to apply.
  */
 export const computeFlipTransforms = (
-    prev: DOMRect,
-    next: DOMRect,
+    prev: RectLike,
+    next: RectLike,
     mode: boolean | 'position'
 ): {
     dx: number

--- a/src/lib/utils/projection.spec.ts
+++ b/src/lib/utils/projection.spec.ts
@@ -1,0 +1,482 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ProjectionNode, type Box } from './projection.js'
+
+/**
+ * jsdom doesn't run real layout, so `getBoundingClientRect` is mocked
+ * per-element with a controlled `DOMRect`. The projection node's
+ * `measure()` zeros the element's own transform (via `measureRect`)
+ * and the ancestor chain's inline transforms — the tests verify both
+ * the returned box and the restore-after invariants. A side effect of
+ * `measureRect` is that it temporarily writes `el.style.transform =
+ * 'none'` then restores; the mock doesn't care about that write, so
+ * the asserted DOMRect is what comes back.
+ */
+const mockRect = (el: HTMLElement, rect: DOMRect): ReturnType<typeof vi.spyOn> =>
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue(rect)
+
+const box = (xMin: number, xMax: number, yMin: number, yMax: number): Box => ({
+    x: { min: xMin, max: xMax },
+    y: { min: yMin, max: yMax }
+})
+
+describe('utils/projection - ProjectionNode', () => {
+    let cleanups: VoidFunction[]
+
+    beforeEach(() => {
+        vi.useRealTimers()
+        cleanups = []
+    })
+
+    afterEach(() => {
+        for (const fn of cleanups) fn()
+        vi.restoreAllMocks()
+    })
+
+    const makeEl = (): HTMLElement => {
+        const el = document.createElement('div')
+        document.body.appendChild(el)
+        cleanups.push(() => el.remove())
+        return el
+    }
+
+    describe('lifecycle', () => {
+        it('mount sets element + isMounted; unmount clears them', () => {
+            const node = new ProjectionNode()
+            const el = makeEl()
+            expect(node.isMounted).toBe(false)
+            expect(node.element).toBeNull()
+
+            node.mount(el)
+            expect(node.isMounted).toBe(true)
+            expect(node.element).toBe(el)
+
+            node.unmount()
+            expect(node.isMounted).toBe(false)
+            expect(node.element).toBeNull()
+        })
+
+        it('mount with parent registers self in parent.children', () => {
+            const parent = new ProjectionNode()
+            const child = new ProjectionNode({ parent })
+            const parentEl = makeEl()
+            const childEl = makeEl()
+            parent.mount(parentEl)
+            child.mount(childEl)
+
+            expect(parent.children.has(child)).toBe(true)
+            expect(child.parent).toBe(parent)
+        })
+
+        it('unmount detaches from parent.children and clears descendants', () => {
+            const parent = new ProjectionNode()
+            const child = new ProjectionNode({ parent })
+            parent.mount(makeEl())
+            child.mount(makeEl())
+
+            child.unmount()
+            expect(parent.children.has(child)).toBe(false)
+            expect(child.parent).toBe(parent) // parent ref preserved; only the registration is dropped
+            expect(child.children.size).toBe(0)
+        })
+
+        it('mount is idempotent for the same element', () => {
+            const node = new ProjectionNode()
+            const el = makeEl()
+            node.mount(el)
+            const parentChildrenSize = node.children.size
+            node.mount(el)
+            // Should not reset state — still mounted on same element.
+            expect(node.isMounted).toBe(true)
+            expect(node.element).toBe(el)
+            expect(node.children.size).toBe(parentChildrenSize)
+        })
+
+        it('unmount is safe to call on a never-mounted node', () => {
+            const node = new ProjectionNode()
+            expect(() => node.unmount()).not.toThrow()
+            expect(node.isMounted).toBe(false)
+        })
+    })
+
+    describe('measure', () => {
+        it('returns null for an unmounted node', () => {
+            const node = new ProjectionNode()
+            expect(node.measure()).toBeNull()
+        })
+
+        it('returns a Box derived from the element rect', () => {
+            const el = makeEl()
+            mockRect(el, new DOMRect(10, 20, 100, 50))
+            const node = new ProjectionNode()
+            node.mount(el)
+            const result = node.measure()
+            expect(result).toEqual(box(10, 110, 20, 70))
+            expect(node.latestLayout).toEqual(result)
+        })
+
+        it('preserves user-authored ancestor transforms present at mount (resets to base, not none)', () => {
+            // 3-deep DOM tree: outer → middle → inner. The ancestor
+            // transforms exist BEFORE mount, so they're user-authored —
+            // upstream's removeBoxTransforms leaves these intact.
+            const outerEl = makeEl()
+            const middleEl = document.createElement('div')
+            const innerEl = document.createElement('div')
+            outerEl.appendChild(middleEl)
+            middleEl.appendChild(innerEl)
+            outerEl.style.transform = 'translate(50px, 100px) scale(1.2)'
+            middleEl.style.transform = 'translate(20px, 30px)'
+
+            mockRect(innerEl, new DOMRect(0, 0, 200, 80))
+
+            const outer = new ProjectionNode()
+            const middle = new ProjectionNode({ parent: outer })
+            const inner = new ProjectionNode({ parent: middle })
+            outer.mount(outerEl)
+            middle.mount(middleEl)
+            inner.mount(innerEl)
+
+            // Spy AFTER mount so only the measure-time writes are captured.
+            const outerSpy = vi.spyOn(outerEl.style, 'transform', 'set')
+            const middleSpy = vi.spyOn(middleEl.style, 'transform', 'set')
+
+            const result = inner.measure()
+            expect(result).toEqual(box(0, 200, 0, 80))
+
+            // Measure resets each ancestor to its captured base (the user
+            // transform) — never to 'none'. The static transform stays.
+            expect(outerSpy).toHaveBeenCalledWith('translate(50px, 100px) scale(1.2)')
+            expect(middleSpy).toHaveBeenCalledWith('translate(20px, 30px)')
+            expect(outerSpy).not.toHaveBeenCalledWith('none')
+            expect(middleSpy).not.toHaveBeenCalledWith('none')
+
+            // Both ended up restored to their original strings.
+            expect(outerEl.style.transform).toBe('translate(50px, 100px) scale(1.2)')
+            expect(middleEl.style.transform).toBe('translate(20px, 30px)')
+        })
+
+        it('strips an ancestor transform written after mount (motion-applied) during measure', () => {
+            const outerEl = makeEl()
+            const innerEl = document.createElement('div')
+            outerEl.appendChild(innerEl)
+            // User base present at mount.
+            outerEl.style.transform = 'translate(40px, 60px)'
+
+            mockRect(innerEl, new DOMRect(0, 0, 80, 80))
+
+            const outer = new ProjectionNode()
+            const inner = new ProjectionNode({ parent: outer })
+            outer.mount(outerEl)
+            inner.mount(innerEl)
+
+            // Simulate a FLIP/drag transform written AFTER mount.
+            const motionTransform = 'translate(40px, 60px) translate(123px, 0px)'
+            outerEl.style.transform = motionTransform
+
+            const outerSpy = vi.spyOn(outerEl.style, 'transform', 'set')
+            inner.measure()
+
+            // During the read the ancestor is reset to its mount-time base,
+            // dropping the post-mount (motion) portion.
+            expect(outerSpy).toHaveBeenCalledWith('translate(40px, 60px)')
+            // Restored to the motion-applied value afterwards so the
+            // ancestor's own animation continues uninterrupted.
+            expect(outerEl.style.transform).toBe(motionTransform)
+        })
+
+        it('resets self to its mount-time base transform during measure (not none)', () => {
+            const el = makeEl()
+            el.style.transform = 'rotate(10deg)' // user base on the measured element itself
+            mockRect(el, new DOMRect(0, 0, 100, 100))
+            const node = new ProjectionNode()
+            node.mount(el)
+
+            const spy = vi.spyOn(el.style, 'transform', 'set')
+            node.measure()
+
+            expect(spy).toHaveBeenCalledWith('rotate(10deg)')
+            expect(spy).not.toHaveBeenCalledWith('none')
+            expect(el.style.transform).toBe('rotate(10deg)')
+        })
+
+        it('restores ancestor transforms even when measureRect throws', () => {
+            const outerEl = makeEl()
+            const innerEl = document.createElement('div')
+            outerEl.appendChild(innerEl)
+            outerEl.style.transform = 'scale(2)'
+            const outerPrev = outerEl.style.transform
+
+            vi.spyOn(innerEl, 'getBoundingClientRect').mockImplementation(() => {
+                throw new Error('synthetic measurement failure')
+            })
+
+            const outer = new ProjectionNode()
+            const inner = new ProjectionNode({ parent: outer })
+            outer.mount(outerEl)
+            inner.mount(innerEl)
+
+            expect(() => inner.measure()).toThrow('synthetic measurement failure')
+            // Critical guarantee: ancestor transform is restored despite the throw.
+            expect(outerEl.style.transform).toBe(outerPrev)
+        })
+
+        it('measure can be called repeatedly without destructive side effects', () => {
+            const el = makeEl()
+            const spy = mockRect(el, new DOMRect(5, 5, 100, 100))
+            const node = new ProjectionNode()
+            node.mount(el)
+
+            const first = node.measure()
+            const second = node.measure()
+            expect(first).toEqual(second)
+            expect(spy).toHaveBeenCalledTimes(2)
+        })
+    })
+
+    describe('willUpdate / didUpdate', () => {
+        it('willUpdate snapshots the current layout box', () => {
+            const el = makeEl()
+            mockRect(el, new DOMRect(0, 0, 50, 50))
+            const node = new ProjectionNode()
+            node.mount(el)
+
+            node.willUpdate()
+            expect(node.snapshot).toEqual(box(0, 50, 0, 50))
+        })
+
+        it('willUpdate is idempotent within a frame — second call does not overwrite first snapshot', () => {
+            const el = makeEl()
+            const spy = mockRect(el, new DOMRect(0, 0, 50, 50))
+            const node = new ProjectionNode()
+            node.mount(el)
+
+            node.willUpdate()
+            // Change the mock to return a different rect — if willUpdate
+            // were not idempotent, the snapshot would silently move.
+            spy.mockReturnValue(new DOMRect(200, 200, 50, 50))
+            node.willUpdate()
+            expect(node.snapshot).toEqual(box(0, 50, 0, 50))
+        })
+
+        it('didUpdate after a layout shift fires listeners with hasLayoutChanged: true + correct delta', () => {
+            const el = makeEl()
+            const spy = mockRect(el, new DOMRect(0, 0, 100, 100))
+            const node = new ProjectionNode()
+            node.mount(el)
+
+            const listener = vi.fn()
+            node.addEventListener('didUpdate', listener)
+
+            node.willUpdate()
+            // Simulate post-mutation move 60px right + 40px down.
+            spy.mockReturnValue(new DOMRect(60, 40, 100, 100))
+            node.didUpdate()
+
+            expect(listener).toHaveBeenCalledTimes(1)
+            const payload = listener.mock.calls[0][0]
+            expect(payload.hasLayoutChanged).toBe(true)
+            expect(payload.delta.x.translate).toBeCloseTo(60, 1)
+            expect(payload.delta.y.translate).toBeCloseTo(40, 1)
+            expect(payload.layout).toEqual(box(60, 160, 40, 140))
+            expect(payload.snapshot).toEqual(box(0, 100, 0, 100))
+            expect(node.snapshot).toBeNull()
+        })
+
+        it('didUpdate after zero shift fires with hasLayoutChanged: false (sub-pixel regression guard)', () => {
+            const el = makeEl()
+            mockRect(el, new DOMRect(0, 0, 100, 100))
+            const node = new ProjectionNode()
+            node.mount(el)
+
+            const listener = vi.fn()
+            node.addEventListener('didUpdate', listener)
+
+            node.willUpdate()
+            // No mutation between snapshot + didUpdate — delta should be zero.
+            node.didUpdate()
+
+            expect(listener).toHaveBeenCalledTimes(1)
+            expect(listener.mock.calls[0][0].hasLayoutChanged).toBe(false)
+        })
+
+        it('didUpdate is a no-op when willUpdate was never called', () => {
+            const el = makeEl()
+            mockRect(el, new DOMRect(0, 0, 50, 50))
+            const node = new ProjectionNode()
+            node.mount(el)
+
+            const listener = vi.fn()
+            node.addEventListener('didUpdate', listener)
+
+            node.didUpdate()
+            expect(listener).not.toHaveBeenCalled()
+            expect(node.snapshot).toBeNull()
+        })
+    })
+
+    describe('commitLayoutChange (observer-driven path)', () => {
+        it('first call after mount seeds latestLayout and fires nothing', () => {
+            const el = makeEl()
+            mockRect(el, new DOMRect(0, 0, 100, 100))
+            const node = new ProjectionNode()
+            node.mount(el)
+            node.latestLayout = null // simulate a freshly-mounted node with no seed yet
+
+            const listener = vi.fn()
+            node.addEventListener('didUpdate', listener)
+
+            node.commitLayoutChange()
+            expect(listener).not.toHaveBeenCalled()
+            expect(node.latestLayout).toEqual(box(0, 100, 0, 100))
+        })
+
+        it('fires didUpdate with the delta against the previous commit when layout changed', () => {
+            const el = makeEl()
+            const spy = mockRect(el, new DOMRect(0, 0, 100, 100))
+            const node = new ProjectionNode()
+            node.mount(el)
+            node.measure() // seed latestLayout at origin
+
+            const listener = vi.fn()
+            node.addEventListener('didUpdate', listener)
+
+            spy.mockReturnValue(new DOMRect(0, 96, 100, 100)) // moved 96px down
+            node.commitLayoutChange()
+
+            expect(listener).toHaveBeenCalledTimes(1)
+            const payload = listener.mock.calls[0][0]
+            expect(payload.hasLayoutChanged).toBe(true)
+            expect(payload.delta.y.translate).toBeCloseTo(96, 1)
+            expect(payload.snapshot).toEqual(box(0, 100, 0, 100))
+            expect(payload.layout).toEqual(box(0, 100, 96, 196))
+        })
+
+        it('does NOT fire when the measurement is unchanged (FLIP-transform re-fire guard)', () => {
+            // The FLIP animation this commit runs alongside writes its own
+            // transform every frame, which re-triggers the same observer.
+            // Those re-fires must not fan out a zero-delta event that
+            // clobbers the genuine delta from the originating change.
+            const el = makeEl()
+            mockRect(el, new DOMRect(0, 0, 100, 100))
+            const node = new ProjectionNode()
+            node.mount(el)
+            node.measure() // seed
+
+            const listener = vi.fn()
+            node.addEventListener('didUpdate', listener)
+
+            node.commitLayoutChange() // no layout change since the seed
+            node.commitLayoutChange() // observer re-fired again, still no change
+            expect(listener).not.toHaveBeenCalled()
+        })
+
+        it('is a no-op on an unmounted node', () => {
+            const node = new ProjectionNode()
+            const listener = vi.fn()
+            node.addEventListener('didUpdate', listener)
+            expect(() => node.commitLayoutChange()).not.toThrow()
+            expect(listener).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('addEventListener', () => {
+        it('returns an unsubscribe that prevents future invocations', () => {
+            const el = makeEl()
+            const spy = mockRect(el, new DOMRect(0, 0, 10, 10))
+            const node = new ProjectionNode()
+            node.mount(el)
+
+            const listener = vi.fn()
+            const off = node.addEventListener('didUpdate', listener)
+
+            node.willUpdate()
+            spy.mockReturnValue(new DOMRect(20, 20, 10, 10))
+            node.didUpdate()
+            expect(listener).toHaveBeenCalledTimes(1)
+
+            off()
+            node.willUpdate()
+            spy.mockReturnValue(new DOMRect(40, 40, 10, 10))
+            node.didUpdate()
+            expect(listener).toHaveBeenCalledTimes(1)
+        })
+
+        it('unsubscribing mid-iteration is safe — pending listeners still fire', () => {
+            const el = makeEl()
+            const spy = mockRect(el, new DOMRect(0, 0, 10, 10))
+            const node = new ProjectionNode()
+            node.mount(el)
+
+            let offSecond: (() => void) | null = null
+            const first = vi.fn(() => offSecond?.())
+            const second = vi.fn()
+            node.addEventListener('didUpdate', first)
+            offSecond = node.addEventListener('didUpdate', second)
+
+            node.willUpdate()
+            spy.mockReturnValue(new DOMRect(20, 20, 10, 10))
+            node.didUpdate()
+
+            // Both listeners fire from this didUpdate even though the
+            // first one unsubscribes the second mid-iteration — the
+            // implementation snapshots the bucket before iterating.
+            expect(first).toHaveBeenCalledTimes(1)
+            expect(second).toHaveBeenCalledTimes(1)
+
+            // Second should NOT fire on the next didUpdate.
+            node.willUpdate()
+            spy.mockReturnValue(new DOMRect(40, 40, 10, 10))
+            node.didUpdate()
+            expect(second).toHaveBeenCalledTimes(1)
+        })
+
+        it('measure fires the measure event', () => {
+            const el = makeEl()
+            mockRect(el, new DOMRect(0, 0, 50, 50))
+            const node = new ProjectionNode()
+            node.mount(el)
+
+            const onMeasure = vi.fn()
+            node.addEventListener('measure', onMeasure)
+
+            node.measure()
+            expect(onMeasure).toHaveBeenCalledTimes(1)
+            expect(onMeasure.mock.calls[0][0]).toEqual(box(0, 50, 0, 50))
+        })
+
+        it('unmount clears all listeners (no leak)', () => {
+            const el = makeEl()
+            mockRect(el, new DOMRect(0, 0, 10, 10))
+            const node = new ProjectionNode()
+            node.mount(el)
+
+            const listener = vi.fn()
+            node.addEventListener('didUpdate', listener)
+
+            node.unmount()
+            // Re-mount and try to trigger didUpdate — old listener should not fire.
+            const el2 = makeEl()
+            mockRect(el2, new DOMRect(0, 0, 10, 10))
+            node.mount(el2)
+            node.willUpdate()
+            vi.spyOn(el2, 'getBoundingClientRect').mockReturnValue(new DOMRect(50, 50, 10, 10))
+            node.didUpdate()
+            expect(listener).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('getScrollContainers option', () => {
+        it('passes scroll-container chain to measureRect via getScrollContainers thunk', () => {
+            const el = makeEl()
+            const scroller = makeEl()
+            scroller.scrollTop = 25
+            scroller.scrollLeft = 15
+            mockRect(el, new DOMRect(0, 0, 100, 100))
+
+            const node = new ProjectionNode({ getScrollContainers: () => [scroller] })
+            node.mount(el)
+            const result = node.measure()
+            // measureRect adds scrollLeft / scrollTop of every container.
+            expect(result).toEqual(box(15, 115, 25, 125))
+        })
+    })
+})

--- a/src/lib/utils/projection.spec.ts
+++ b/src/lib/utils/projection.spec.ts
@@ -96,6 +96,25 @@ describe('utils/projection - ProjectionNode', () => {
             expect(() => node.unmount()).not.toThrow()
             expect(node.isMounted).toBe(false)
         })
+
+        it('re-mounting a parent onto a new element preserves its registered children', () => {
+            const parent = new ProjectionNode()
+            const child = new ProjectionNode({ parent })
+            const parentElA = makeEl()
+            const parentElB = makeEl()
+            parent.mount(parentElA)
+            child.mount(makeEl())
+            expect(parent.children.has(child)).toBe(true)
+
+            // Swap the parent onto a different element (e.g. element rebind).
+            parent.mount(parentElB)
+
+            // The still-mounted child must remain registered — a full
+            // unmount() on re-mount would have orphaned it.
+            expect(parent.element).toBe(parentElB)
+            expect(parent.isMounted).toBe(true)
+            expect(parent.children.has(child)).toBe(true)
+        })
     })
 
     describe('measure', () => {
@@ -229,6 +248,53 @@ describe('utils/projection - ProjectionNode', () => {
             const second = node.measure()
             expect(first).toEqual(second)
             expect(spy).toHaveBeenCalledTimes(2)
+        })
+
+        it('prefers the getBaseTransform thunk over the polluted mount-time inline transform (initial+layout guard)', () => {
+            // Simulates a `<motion.div layout initial={{ x: 100 }}>`: the
+            // initial keyframe is serialized into style.transform BEFORE
+            // mount, so the mount-time inline value is a MOTION transform,
+            // not the user's. The thunk supplies the real user base ('').
+            const el = makeEl()
+            el.style.transform = 'translateX(100px)' // motion-applied initial, present at mount
+            const spy = vi.spyOn(el.style, 'transform', 'set')
+            mockRect(el, new DOMRect(0, 0, 80, 80))
+
+            const node = new ProjectionNode({ getBaseTransform: () => '' })
+            node.mount(el)
+
+            node.measure()
+            // measure() must reset self to the thunk's value ('') during the
+            // read. Without the thunk it would use the mount-captured
+            // 'translateX(100px)' and the setter would NEVER see '' (it would
+            // only ever be set/restored to 'translateX(100px)'). So a '' write
+            // is the precise proof the thunk base was used. (The final restore
+            // legitimately writes the live 'translateX(100px)' back.)
+            expect(spy).toHaveBeenCalledWith('')
+            expect(el.style.transform).toBe('translateX(100px)') // restored after measure
+        })
+
+        it('thunk supplies the ancestor base too, stripping a motion transform an ancestor carried at mount', () => {
+            const outerEl = makeEl()
+            const innerEl = document.createElement('div')
+            outerEl.appendChild(innerEl)
+            // Outer mounts with a motion-applied transform inline; the user
+            // authored translate(40px, 60px) (what the thunk returns).
+            outerEl.style.transform = 'translate(40px, 60px) translateX(100px)'
+            mockRect(innerEl, new DOMRect(0, 0, 80, 80))
+
+            const outer = new ProjectionNode({ getBaseTransform: () => 'translate(40px, 60px)' })
+            const inner = new ProjectionNode({ parent: outer })
+            outer.mount(outerEl)
+            inner.mount(innerEl)
+
+            const outerSpy = vi.spyOn(outerEl.style, 'transform', 'set')
+            inner.measure()
+
+            // During the read the ancestor is reset to the thunk's user
+            // base, dropping the motion translateX(100px).
+            expect(outerSpy).toHaveBeenCalledWith('translate(40px, 60px)')
+            expect(outerEl.style.transform).toBe('translate(40px, 60px) translateX(100px)')
         })
     })
 

--- a/src/lib/utils/projection.ts
+++ b/src/lib/utils/projection.ts
@@ -1,0 +1,461 @@
+/**
+ * Projection layout system — minimal foundation for cross-element layout
+ * coordination during gestures (drag, layoutId, future shared-element).
+ *
+ * Direct port of the surface area framer-motion's projection system
+ * exposes to consumers, slimmed down to what we actually need for the
+ * acceptance criteria of #379:
+ *
+ * - Per-element `ProjectionNode`s with parent/child wiring through the
+ *   Svelte component tree (via `projection.context.ts`).
+ * - `willUpdate()` / `didUpdate()` lifecycle around layout-mutating
+ *   operations: caller snapshots before the mutation, re-measures
+ *   after, fan-outs a `didUpdate` event with the computed delta.
+ * - Transform-stripping `measure()` — the load-bearing read primitive.
+ *   A child's `getBoundingClientRect()` is contaminated by every
+ *   ancestor's transform, so while measuring we temporarily reset the
+ *   whole ancestor chain to each node's mount-time `baseTransform`,
+ *   then restore in reverse order. Resetting to the captured base
+ *   (rather than `'none'`) strips the motion-applied portion of each
+ *   transform while preserving the user-authored one — mirroring
+ *   framer-motion's `removeBoxTransforms`, which only subtracts
+ *   motion-tracked `latestValues`. Generalises what
+ *   `layout.ts:measureRect` does for the single-element case across
+ *   the projection chain.
+ *
+ * Math helpers (`createBox`, `createDelta`, `calcBoxDelta`,
+ * `isDeltaZero`) are imported directly from `motion-dom` — no need to
+ * re-port what upstream already re-exports.
+ *
+ * KNOWN_LIMITATIONS (deferred to follow-up PRs, see #379):
+ * - No depth-sorted FlatTree / `path` array. We walk via `parent`
+ *   pointers from leaves; siblings under one parent is sufficient for
+ *   the Reorder use case and the rest of the projection tree workflows
+ *   this PR enables.
+ * - No 4-phase tree walk (propagateDirty → resolveTarget →
+ *   calcProjection → cleanDirty). Projection-transform *inheritance*
+ *   (parent target deltas affecting child positioning) is not implemented
+ *   yet. The ancestor-zeroing measure is independent of this — it's a
+ *   read-time concern, not a projection-compose concern.
+ * - No scale-correction utilities (border-radius / box-shadow). Visual
+ *   polish; defer.
+ * - No `relativeTarget` / `projectionDelta` with transform inheritance.
+ *   Only matters for full shared-element morphing through nested
+ *   transforms; current `layoutId.ts` registry handles the simple case.
+ * - No `layoutId` registry migration onto projection nodes. The
+ *   one-shot pattern in `layoutId.ts` keeps working; future PR can
+ *   route through projection nodes for richer coordination.
+ */
+import { measureRect } from '$lib/utils/layout'
+import { calcBoxDelta, createDelta, isDeltaZero } from 'motion-dom'
+
+/**
+ * Local mirrors of `motion-utils`'s `Axis` / `Box` / `AxisDelta` /
+ * `Delta` types. Inlined because `motion-utils` is a runtime-only
+ * transitive dep through `motion-dom` — the runtime helpers
+ * (`calcBoxDelta`, `createDelta`, `isDeltaZero`) are re-exported, but
+ * the type aliases are not. Same approach we use in
+ * `src/lib/components/Reorder/context.ts`.
+ *
+ * Values match upstream byte-for-byte so handoff between our types and
+ * the runtime helpers from motion-dom is implicit.
+ */
+export interface Axis {
+    min: number
+    max: number
+}
+export interface Box {
+    x: Axis
+    y: Axis
+}
+export interface AxisDelta {
+    translate: number
+    scale: number
+    origin: number
+    originPoint: number
+}
+export interface Delta {
+    x: AxisDelta
+    y: AxisDelta
+}
+
+/**
+ * Event names the projection node fans out. Mirrors framer-motion's
+ * `LayoutEvents` subset that's actually consumed externally.
+ *
+ * - `willUpdate` — fires inside `willUpdate()`, AFTER the pre-mutation
+ *   snapshot has been captured. Receives the snapshot Box.
+ * - `didUpdate` — fires inside `didUpdate()`, AFTER the post-mutation
+ *   re-measure. Receives the full `LayoutUpdateData` payload (layout,
+ *   snapshot, delta, hasLayoutChanged).
+ * - `measure` — fires every time `measure()` returns a non-null Box.
+ *   Useful for debug overlays and follow-up event consumers.
+ */
+export type ProjectionEventName = 'willUpdate' | 'didUpdate' | 'measure'
+
+/**
+ * Payload delivered to `didUpdate` listeners.
+ *
+ * `layout` is the post-mutation measurement; `snapshot` is the
+ * pre-mutation one. `delta` is `calcBoxDelta(snapshot, layout)` and is
+ * the value drag-listeners apply via `originPoint += delta.translate`
+ * + `motionValue.set(motionValue.get() + delta.translate)` to keep a
+ * dragged element under the cursor while its slot moves.
+ *
+ * `hasLayoutChanged` is `!isDeltaZero(delta)` — uses the upstream
+ * rounding threshold so sub-pixel jiggle from constraint-clamped
+ * drags doesn't cascade as false-positive layout changes.
+ */
+export interface ProjectionDidUpdateData {
+    layout: Box
+    snapshot: Box
+    delta: Delta
+    hasLayoutChanged: boolean
+}
+
+type Listener<E extends ProjectionEventName> = E extends 'didUpdate'
+    ? (data: ProjectionDidUpdateData) => void
+    : E extends 'willUpdate'
+      ? (snapshot: Box) => void
+      : (layout: Box) => void
+
+/**
+ * Options passed at `ProjectionNode` construction time. All optional —
+ * a node with no options still works as a leaf measurement target.
+ */
+export interface ProjectionNodeOptions {
+    /**
+     * Parent node in the projection tree. Wire-up is callsite-driven
+     * (the consumer reads `getProjectionParent()` from the Svelte
+     * context system and passes the result here); the node stores it
+     * as `this.parent` and registers self in `parent.children` on
+     * `mount()`.
+     */
+    parent?: ProjectionNode | null
+    /**
+     * Thunk returning the `layoutScroll` ancestor chain at measure
+     * time. Used as the second argument to `measureRect`, which
+     * shifts the returned rect by the sum of ancestor
+     * `scrollLeft`/`scrollTop` so FLIP deltas stay correct when
+     * scrollable ancestors scroll between two measurements.
+     *
+     * Returning `[]` (or omitting the option entirely) gives
+     * viewport-relative measurements — fine for the common case.
+     */
+    getScrollContainers?: () => HTMLElement[]
+}
+
+/**
+ * Convert a `DOMRect` to our `Box` shape. Inline because `motion-dom`'s
+ * `convertBoundingBoxToBox` works on a BoundingBox (already-derived
+ * `top`/`bottom`/`left`/`right`) rather than the DOMRect we get from
+ * `getBoundingClientRect`. Same math, just one less indirection.
+ */
+const rectToBox = (rect: DOMRect): Box => ({
+    x: { min: rect.left, max: rect.right },
+    y: { min: rect.top, max: rect.bottom }
+})
+
+/** Deep-copy a Box so subsequent measurements don't mutate snapshots. */
+const cloneBox = (box: Box): Box => ({
+    x: { min: box.x.min, max: box.x.max },
+    y: { min: box.y.min, max: box.y.max }
+})
+
+/**
+ * Per-element node in the projection tree. Created at component setup
+ * time in `_MotionContainer.svelte`, mounted when the element ref
+ * binds, unmounted on cleanup.
+ *
+ * Lifecycle:
+ * 1. `new ProjectionNode({ parent, getScrollContainers })` at setup.
+ * 2. `node.mount(element)` once the element ref binds.
+ * 3. `node.willUpdate()` before any layout-mutating state change (e.g.
+ *    a `values` reassign that reorders DOM children).
+ * 4. State mutates → Svelte commits the DOM update.
+ * 5. `node.didUpdate()` after the DOM update is flushed — fires
+ *    `didUpdate` listeners with the snapshot→current delta.
+ * 6. `node.unmount()` on cleanup.
+ */
+export class ProjectionNode {
+    /** The mounted element. `null` until `mount()` runs. */
+    element: HTMLElement | null = null
+    /**
+     * Parent node in the projection tree. Captured at construction
+     * from the Svelte context. Set to `null` for root-level motion
+     * elements that have no motion ancestor.
+     */
+    parent: ProjectionNode | null = null
+    /**
+     * Descendant nodes registered via `mount()`. Iterated when we
+     * need to broadcast to the subtree (none in this PR; reserved
+     * for follow-up work).
+     */
+    readonly children: Set<ProjectionNode> = new Set()
+    /** Most-recent post-mutation measurement, or `null` before first measure. */
+    latestLayout: Box | null = null
+    /**
+     * Pre-mutation snapshot captured by `willUpdate`. Cleared by
+     * `didUpdate` after the delta has been computed. Idempotent for
+     * repeat `willUpdate` calls in the same frame — only the first
+     * snapshots; subsequent calls no-op so a parent broadcasting
+     * `willUpdate` to its children doesn't clobber a child's own
+     * earlier snapshot.
+     */
+    snapshot: Box | null = null
+    /** Whether `mount()` has been called and `unmount()` has not. */
+    isMounted = false
+    /**
+     * The element's `style.transform` captured at `mount()` time — the
+     * user-authored base. Motion only ever writes a transform to the
+     * element AFTER mount (FLIP fires on a layout change, drag on
+     * pointerdown), so whatever is present at mount is the user's own
+     * styling transform and nothing else.
+     *
+     * `measure()` restores ancestors (and self, via `measureRect`) to
+     * this base rather than to `'none'`. That removes exactly the
+     * motion-applied portion of the transform while leaving the
+     * user-authored part intact — the same distinction framer-motion
+     * draws by only subtracting motion-tracked `latestValues` in
+     * `removeBoxTransforms` and skipping nodes with no tracked
+     * transform. A purely static user transform therefore stays in the
+     * measured layout box (matching upstream); a FLIP/drag transform
+     * written after mount is stripped.
+     */
+    baseTransform = ''
+
+    private readonly listeners: Map<ProjectionEventName, Set<(...args: unknown[]) => void>> =
+        new Map()
+    private readonly getScrollContainers: (() => HTMLElement[]) | undefined
+
+    constructor(options: ProjectionNodeOptions = {}) {
+        this.parent = options.parent ?? null
+        this.getScrollContainers = options.getScrollContainers
+    }
+
+    /**
+     * Register this node with its parent + bind to a DOM element.
+     * Idempotent — calling `mount()` twice on the same element is a
+     * no-op for the registration steps.
+     *
+     * @param element The DOM element this node represents.
+     */
+    mount(element: HTMLElement): void {
+        if (this.isMounted && this.element === element) return
+        if (this.isMounted) this.unmount()
+        this.element = element
+        // Capture the user-authored transform before motion ever writes
+        // one. See `baseTransform` for why mount-time is the right moment.
+        this.baseTransform = element.style.transform
+        this.isMounted = true
+        this.parent?.children.add(this)
+    }
+
+    /**
+     * Tear down. Detaches from parent, clears children references,
+     * drops all listeners. Safe to call on a never-mounted node and
+     * safe to call twice.
+     */
+    unmount(): void {
+        if (!this.isMounted) return
+        this.parent?.children.delete(this)
+        this.children.clear()
+        this.listeners.clear()
+        this.element = null
+        this.latestLayout = null
+        this.snapshot = null
+        this.baseTransform = ''
+        this.isMounted = false
+    }
+
+    /**
+     * Read the element's layout box with every ancestor's
+     * motion-applied transform temporarily removed, while preserving
+     * each ancestor's user-authored base transform.
+     *
+     * Mechanism:
+     * 1. Walk `this.parent` chain bottom-up, collecting every
+     *    mounted ancestor node (excludes self — `measureRect`
+     *    handles self's transform internally).
+     * 2. Snapshot each ancestor's current `el.style.transform`.
+     * 3. Set each to its node's `baseTransform` (the user-authored
+     *    value captured at mount). This strips any FLIP/drag transform
+     *    written after mount while keeping the user's static one — see
+     *    `baseTransform`.
+     * 4. Delegate to `measureRect(self.element, scrollContainers,
+     *    self.baseTransform)`, which applies self's base transform
+     *    inside its own try/finally and returns the scroll-compensated
+     *    DOMRect.
+     * 5. Restore ancestor transforms in reverse order inside a
+     *    `finally` block — guarantees restoration even if measure
+     *    throws.
+     * 6. Convert DOMRect → Box and cache as `latestLayout`.
+     *
+     * Returns `null` when `element` is not mounted.
+     */
+    measure(): Box | null {
+        if (!this.element) return null
+
+        // Collect ancestor nodes bottom-up. Skips ancestors that
+        // haven't bound yet (`element === null`).
+        const ancestors: ProjectionNode[] = []
+        let cursor: ProjectionNode | null = this.parent
+        while (cursor) {
+            if (cursor.element) ancestors.push(cursor)
+            cursor = cursor.parent
+        }
+
+        // Snapshot current transform; reset each ancestor to its
+        // user-authored base for the duration of the measure.
+        const restoreList: Array<{ el: HTMLElement; prev: string; base: string }> = ancestors.map(
+            (node) => ({
+                el: node.element!,
+                prev: node.element!.style.transform,
+                base: node.baseTransform
+            })
+        )
+        try {
+            for (const { el, base } of restoreList) el.style.transform = base
+            // measureRect applies self's base transform + scroll-container offset.
+            const rect = measureRect(
+                this.element,
+                this.getScrollContainers?.() ?? [],
+                this.baseTransform
+            )
+            const box = rectToBox(rect)
+            this.latestLayout = box
+            this.notify('measure', box)
+            return box
+        } finally {
+            // Reverse-order restore — important because ancestor
+            // composition cascades from outer-most down; restoring
+            // bottom-up matches the snapshot order.
+            for (let i = restoreList.length - 1; i >= 0; i--) {
+                restoreList[i].el.style.transform = restoreList[i].prev
+            }
+        }
+    }
+
+    /**
+     * Snapshot the current layout box for use by the next
+     * `didUpdate()`. Caller's contract: invoke this BEFORE the
+     * layout-mutating state change so the snapshot reflects the
+     * pre-mutation position.
+     *
+     * Idempotent within a frame — once a snapshot exists, subsequent
+     * `willUpdate()` calls are no-ops until `didUpdate()` consumes it.
+     * This means a parent that broadcasts `willUpdate` to its
+     * children before its own snapshot is fine: children snapshot
+     * themselves first via their own willUpdate, parent's broadcast
+     * is a no-op.
+     */
+    willUpdate(): void {
+        if (!this.element || this.snapshot) return
+        const measured = this.measure()
+        if (!measured) return
+        this.snapshot = cloneBox(measured)
+        this.notify('willUpdate', this.snapshot)
+    }
+
+    /**
+     * Re-measure post-mutation, compute the delta against the
+     * snapshot, fire `didUpdate` listeners. No-op when there's no
+     * snapshot (matches upstream — `willUpdate` MUST precede
+     * `didUpdate` for the cycle to fire).
+     *
+     * Always clears the snapshot at the end so the next gesture's
+     * `willUpdate`/`didUpdate` cycle starts fresh.
+     */
+    didUpdate(): void {
+        if (!this.element || !this.snapshot) {
+            this.snapshot = null
+            return
+        }
+        const layout = this.measure()
+        if (!layout) {
+            this.snapshot = null
+            return
+        }
+        const delta = createDelta()
+        calcBoxDelta(delta, this.snapshot, layout)
+        const hasLayoutChanged = !isDeltaZero(delta)
+        const payload: ProjectionDidUpdateData = {
+            layout,
+            snapshot: this.snapshot,
+            delta,
+            hasLayoutChanged
+        }
+        this.snapshot = null
+        this.notify('didUpdate', payload)
+    }
+
+    /**
+     * Observer-driven layout-change commit. Unlike the explicit
+     * `willUpdate()` → mutate → `didUpdate()` cycle (used when a
+     * consumer controls the exact mutation moment, e.g. Reorder.Group
+     * before a `values` reassign), this is for the reactive path where
+     * a layout change has ALREADY happened and we only learn about it
+     * after the fact (the existing `observeLayoutChanges` FLIP loop in
+     * `_MotionContainer`).
+     *
+     * Uses the cached `latestLayout` (the pre-change position from
+     * mount or the previous commit) as the snapshot, re-measures the
+     * post-change position, and fires `didUpdate` with the delta.
+     *
+     * First call after mount just seeds `latestLayout` (no prior
+     * position to diff against) and fires nothing.
+     *
+     * Crucially this is gated on a non-zero delta. The FLIP animation
+     * this commit runs alongside writes its own inverse `transform` to
+     * the element every frame, and those writes re-trigger the same
+     * `observeLayoutChanges` signal that drives this method. Those
+     * re-fires carry no real layout change (the ancestor-zeroed measure
+     * is identical to the previous one), so without the `isDeltaZero`
+     * gate every animation frame would fan out a `delta: 0` event and
+     * clobber the genuine delta from the originating change.
+     */
+    commitLayoutChange(): void {
+        if (!this.element) return
+        const previous = this.latestLayout
+        const layout = this.measure()
+        if (!layout) return
+        if (!previous) return // first call after mount: seed only, nothing to diff
+        const delta = createDelta()
+        calcBoxDelta(delta, previous, layout)
+        if (isDeltaZero(delta)) return // observer re-fired on our own FLIP transform write
+        this.notify('didUpdate', {
+            layout,
+            snapshot: previous,
+            delta,
+            hasLayoutChanged: true
+        })
+    }
+
+    /**
+     * Subscribe to a projection event. Returns an unsubscribe
+     * function. Safe to call after `unmount()` (becomes a no-op).
+     */
+    addEventListener<E extends ProjectionEventName>(name: E, cb: Listener<E>): () => void {
+        let bucket = this.listeners.get(name)
+        if (!bucket) {
+            bucket = new Set()
+            this.listeners.set(name, bucket)
+        }
+        const wrapped = cb as (...args: unknown[]) => void
+        bucket.add(wrapped)
+        return () => {
+            this.listeners.get(name)?.delete(wrapped)
+        }
+    }
+
+    private notify(name: 'willUpdate', payload: Box): void
+    private notify(name: 'didUpdate', payload: ProjectionDidUpdateData): void
+    private notify(name: 'measure', payload: Box): void
+    private notify(name: ProjectionEventName, payload: unknown): void {
+        const bucket = this.listeners.get(name)
+        if (!bucket || bucket.size === 0) return
+        // Snapshot the bucket so unsubscribes inside a listener don't
+        // skip the next listener in the iteration.
+        for (const cb of [...bucket]) cb(payload)
+    }
+}

--- a/src/lib/utils/projection.ts
+++ b/src/lib/utils/projection.ts
@@ -364,7 +364,9 @@ export class ProjectionNode {
             )
             const box = rectToBox(rect)
             this.latestLayout = box
-            this.notify('measure', box)
+            // Clone for the event: `box` aliases `this.latestLayout`, so a
+            // listener mutating it would corrupt the cached layout.
+            this.notify('measure', cloneBox(box))
             return box
         } finally {
             // Reverse-order restore — important because ancestor
@@ -394,7 +396,9 @@ export class ProjectionNode {
         const measured = this.measure()
         if (!measured) return
         this.snapshot = cloneBox(measured)
-        this.notify('willUpdate', this.snapshot)
+        // Clone for the event: emitting `this.snapshot` by reference would
+        // let a listener mutate the stored snapshot.
+        this.notify('willUpdate', cloneBox(this.snapshot))
     }
 
     /**

--- a/src/lib/utils/projection.ts
+++ b/src/lib/utils/projection.ts
@@ -102,9 +102,11 @@ export type ProjectionEventName = 'willUpdate' | 'didUpdate' | 'measure'
  * + `motionValue.set(motionValue.get() + delta.translate)` to keep a
  * dragged element under the cursor while its slot moves.
  *
- * `hasLayoutChanged` is `!isDeltaZero(delta)` — uses the upstream
- * rounding threshold so sub-pixel jiggle from constraint-clamped
- * drags doesn't cascade as false-positive layout changes.
+ * `hasLayoutChanged` is `!isDeltaZero(delta)`. `isDeltaZero` (from
+ * motion-dom) treats an axis as unchanged only when its translate is
+ * within ±0.01px and its scale within ±0.0001 of identity — a tight
+ * floating-point epsilon, NOT a 1px rounding threshold. A genuine
+ * sub-pixel layout shift (say 0.4px) is therefore reported as a change.
  */
 export interface ProjectionDidUpdateData {
     layout: Box
@@ -143,6 +145,20 @@ export interface ProjectionNodeOptions {
      * viewport-relative measurements — fine for the common case.
      */
     getScrollContainers?: () => HTMLElement[]
+    /**
+     * Thunk returning the element's USER-authored `transform` — the
+     * value `measure()` resets to while reading, so the motion-applied
+     * portion (`initial`/`animate`/FLIP/drag) is stripped but the user's
+     * own transform is preserved.
+     *
+     * Preferred over the mount-time `baseTransform` capture, because at
+     * mount the inline `style.transform` already carries any
+     * transform-type `initial` keyframe (it is serialized inline before
+     * effects run). The consumer therefore sources this from the `style`
+     * prop instead (see `extractTransform`). When omitted, the node
+     * falls back to the mount-captured `baseTransform`.
+     */
+    getBaseTransform?: () => string
 }
 
 /**
@@ -206,31 +222,46 @@ export class ProjectionNode {
     /** Whether `mount()` has been called and `unmount()` has not. */
     isMounted = false
     /**
-     * The element's `style.transform` captured at `mount()` time — the
-     * user-authored base. Motion only ever writes a transform to the
-     * element AFTER mount (FLIP fires on a layout change, drag on
-     * pointerdown), so whatever is present at mount is the user's own
-     * styling transform and nothing else.
+     * Fallback user-authored base transform, captured from
+     * `element.style.transform` at `mount()` time. Used only when no
+     * `getBaseTransform` thunk was provided (e.g. unit tests that
+     * construct a bare node and set the transform before mounting).
      *
-     * `measure()` restores ancestors (and self, via `measureRect`) to
-     * this base rather than to `'none'`. That removes exactly the
-     * motion-applied portion of the transform while leaving the
-     * user-authored part intact — the same distinction framer-motion
-     * draws by only subtracting motion-tracked `latestValues` in
-     * `removeBoxTransforms` and skipping nodes with no tracked
-     * transform. A purely static user transform therefore stays in the
-     * measured layout box (matching upstream); a FLIP/drag transform
-     * written after mount is stripped.
+     * For real `motion.*` elements the `getBaseTransform` thunk is
+     * preferred: capturing at mount is unsafe because a transform-type
+     * `initial` keyframe is serialized into the inline `style.transform`
+     * BEFORE effects run, so the mount-time value can be a motion
+     * transform rather than the user's. `resolveBaseTransform()` picks
+     * the thunk first.
+     *
+     * `measure()` resets ancestors (and self, via `measureRect`) to this
+     * base rather than to `'none'`, removing the motion-applied portion
+     * while leaving the user-authored part intact — the same distinction
+     * framer-motion draws by only subtracting motion-tracked
+     * `latestValues` in `removeBoxTransforms`.
      */
     baseTransform = ''
 
     private readonly listeners: Map<ProjectionEventName, Set<(...args: unknown[]) => void>> =
         new Map()
     private readonly getScrollContainers: (() => HTMLElement[]) | undefined
+    private readonly getBaseTransform: (() => string) | undefined
 
     constructor(options: ProjectionNodeOptions = {}) {
         this.parent = options.parent ?? null
         this.getScrollContainers = options.getScrollContainers
+        this.getBaseTransform = options.getBaseTransform
+    }
+
+    /**
+     * The transform `measure()` resets this node's element to while
+     * reading. Prefers the `getBaseTransform` thunk (the user's authored
+     * `style` transform, motion-independent); falls back to the
+     * mount-captured `baseTransform`. See `getBaseTransform` /
+     * `baseTransform` for why the thunk is the safe source.
+     */
+    private resolveBaseTransform(): string {
+        return this.getBaseTransform?.() ?? this.baseTransform
     }
 
     /**
@@ -238,17 +269,27 @@ export class ProjectionNode {
      * Idempotent — calling `mount()` twice on the same element is a
      * no-op for the registration steps.
      *
+     * Re-mounting onto a DIFFERENT element swaps the element in place
+     * WITHOUT a full `unmount()`. A full unmount would `children.clear()`,
+     * orphaning still-mounted descendants that registered themselves in
+     * this node's `children` (they keep their `parent` pointer but the
+     * set would never be repopulated). Listeners and children are
+     * therefore preserved across an element swap.
+     *
      * @param element The DOM element this node represents.
      */
     mount(element: HTMLElement): void {
         if (this.isMounted && this.element === element) return
-        if (this.isMounted) this.unmount()
         this.element = element
-        // Capture the user-authored transform before motion ever writes
-        // one. See `baseTransform` for why mount-time is the right moment.
+        // Fallback base capture (the consumer's getBaseTransform thunk is
+        // preferred — see `baseTransform`).
         this.baseTransform = element.style.transform
-        this.isMounted = true
-        this.parent?.children.add(this)
+        // Stale measurement from a previous element; refreshed on next measure.
+        this.latestLayout = null
+        if (!this.isMounted) {
+            this.isMounted = true
+            this.parent?.children.add(this)
+        }
     }
 
     /**
@@ -278,14 +319,13 @@ export class ProjectionNode {
      *    mounted ancestor node (excludes self — `measureRect`
      *    handles self's transform internally).
      * 2. Snapshot each ancestor's current `el.style.transform`.
-     * 3. Set each to its node's `baseTransform` (the user-authored
-     *    value captured at mount). This strips any FLIP/drag transform
-     *    written after mount while keeping the user's static one — see
-     *    `baseTransform`.
+     * 3. Set each to its node's resolved base transform (the
+     *    user-authored value, via `resolveBaseTransform`). This strips
+     *    any FLIP/drag/initial transform while keeping the user's static
+     *    one — see `getBaseTransform` / `baseTransform`.
      * 4. Delegate to `measureRect(self.element, scrollContainers,
-     *    self.baseTransform)`, which applies self's base transform
-     *    inside its own try/finally and returns the scroll-compensated
-     *    DOMRect.
+     *    self base)`, which applies self's base transform inside its own
+     *    try/finally and returns the scroll-compensated DOMRect.
      * 5. Restore ancestor transforms in reverse order inside a
      *    `finally` block — guarantees restoration even if measure
      *    throws.
@@ -311,7 +351,7 @@ export class ProjectionNode {
             (node) => ({
                 el: node.element!,
                 prev: node.element!.style.transform,
-                base: node.baseTransform
+                base: node.resolveBaseTransform()
             })
         )
         try {
@@ -320,7 +360,7 @@ export class ProjectionNode {
             const rect = measureRect(
                 this.element,
                 this.getScrollContainers?.() ?? [],
-                this.baseTransform
+                this.resolveBaseTransform()
             )
             const box = rectToBox(rect)
             this.latestLayout = box
@@ -380,7 +420,10 @@ export class ProjectionNode {
         calcBoxDelta(delta, this.snapshot, layout)
         const hasLayoutChanged = !isDeltaZero(delta)
         const payload: ProjectionDidUpdateData = {
-            layout,
+            // Clone the layout box: it aliases `this.latestLayout`, so
+            // handing the live reference out would let a listener mutate
+            // the node's cached layout and poison the next diff.
+            layout: cloneBox(layout),
             snapshot: this.snapshot,
             delta,
             hasLayoutChanged
@@ -405,30 +448,40 @@ export class ProjectionNode {
      * First call after mount just seeds `latestLayout` (no prior
      * position to diff against) and fires nothing.
      *
-     * Crucially this is gated on a non-zero delta. The FLIP animation
-     * this commit runs alongside writes its own inverse `transform` to
-     * the element every frame, and those writes re-trigger the same
-     * `observeLayoutChanges` signal that drives this method. Those
-     * re-fires carry no real layout change (the ancestor-zeroed measure
-     * is identical to the previous one), so without the `isDeltaZero`
-     * gate every animation frame would fan out a `delta: 0` event and
-     * clobber the genuine delta from the originating change.
+     * Returns the freshly-measured `Box` (or `null` when unmounted) so
+     * the caller can reuse it — the FLIP loop in `_MotionContainer` uses
+     * this as its `next` rect instead of measuring a second time per
+     * frame.
+     *
+     * The `didUpdate` fan-out is gated on a non-zero delta. The FLIP
+     * animation this commit runs alongside writes its own inverse
+     * `transform` to the element every frame, and those writes re-trigger
+     * the same `observeLayoutChanges` signal that drives this method.
+     * Those re-fires carry no real layout change (the ancestor-stripped
+     * measure is identical to the previous one), so without the
+     * `isDeltaZero` gate every animation frame would fan out a `delta: 0`
+     * event and clobber the genuine delta from the originating change.
      */
-    commitLayoutChange(): void {
-        if (!this.element) return
+    commitLayoutChange(): Box | null {
+        if (!this.element) return null
         const previous = this.latestLayout
         const layout = this.measure()
-        if (!layout) return
-        if (!previous) return // first call after mount: seed only, nothing to diff
-        const delta = createDelta()
-        calcBoxDelta(delta, previous, layout)
-        if (isDeltaZero(delta)) return // observer re-fired on our own FLIP transform write
-        this.notify('didUpdate', {
-            layout,
-            snapshot: previous,
-            delta,
-            hasLayoutChanged: true
-        })
+        if (!layout) return null
+        if (previous) {
+            const delta = createDelta()
+            calcBoxDelta(delta, previous, layout)
+            // Skip the no-op re-fires from our own FLIP transform writes.
+            if (!isDeltaZero(delta)) {
+                this.notify('didUpdate', {
+                    // Clone: `layout` aliases `this.latestLayout`.
+                    layout: cloneBox(layout),
+                    snapshot: previous,
+                    delta,
+                    hasLayoutChanged: true
+                })
+            }
+        }
+        return layout
     }
 
     /**

--- a/src/lib/utils/style.ts
+++ b/src/lib/utils/style.ts
@@ -159,6 +159,13 @@ export const mergeInlineStyles = (
  *
  * @param style The component's `style` prop.
  * @returns The user's `transform` value, or `''`.
+ * @example
+ * ```ts
+ * extractTransform('opacity: 0.5; transform: translateX(10px) scale(2)')
+ * // => 'translateX(10px) scale(2)'
+ * extractTransform('color: red') // => ''
+ * extractTransform({ color: 'red' }) // => '' (non-string)
+ * ```
  */
 export const extractTransform = (style: unknown): string => {
     if (typeof style !== 'string') return ''

--- a/src/lib/utils/style.ts
+++ b/src/lib/utils/style.ts
@@ -145,6 +145,26 @@ export const mergeInlineStyles = (
     return stringifyStyleObject(base)
 }
 
+/**
+ * Extract the user-authored `transform` declaration from a `style` prop.
+ *
+ * Used by the projection system as the "base" transform a node resets to
+ * while measuring — the value the user wrote, independent of any
+ * motion-applied transform (`initial`/`animate`/FLIP/drag) that lands on
+ * `element.style.transform` after mount. Reading it from the `style` prop
+ * rather than the live inline style is what keeps an `initial={{ x }}` (or
+ * any transform-type initial/animate) from being mistaken for the base.
+ *
+ * Returns `''` when the prop is not a string or carries no transform.
+ *
+ * @param style The component's `style` prop.
+ * @returns The user's `transform` value, or `''`.
+ */
+export const extractTransform = (style: unknown): string => {
+    if (typeof style !== 'string') return ''
+    return parseStyleString(style).transform ?? ''
+}
+
 const parseStyleString = (style: string): Record<string, string> => {
     const out: Record<string, string> = {}
     style

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -381,5 +381,26 @@
                 </li>
             </ul>
         </div>
+        <div>
+            <h2 class="mb-3 text-xl font-medium">Projection (#379)</h2>
+            <ul class="list-disc space-y-2 pl-5">
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/projection/sibling-swap') + searchParams}
+                    >
+                        Sibling swap (didUpdate delta)
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/projection/nested-ancestor') + searchParams}
+                    >
+                        Nested ancestor (zeroing correctness)
+                    </a>
+                </li>
+            </ul>
+        </div>
     </div>
 </div>

--- a/src/routes/tests/projection/nested-ancestor/+page.svelte
+++ b/src/routes/tests/projection/nested-ancestor/+page.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+    import { motion, type ProjectionUpdatePayload } from '$lib'
+
+    // Projection smoke test (#379) — nested ancestor correctness.
+    //
+    // An OUTER `<motion.div layout>` wrapper carries a user-authored
+    // `transform: translate(40px, 60px)`. An INNER `<motion.div layout>`
+    // toggles between the wrapper's left and right edge.
+    //
+    // The fix this page guards: measure() must match framer-motion's
+    // removeBoxTransforms, which strips only MOTION-applied transforms
+    // (tracked latestValues) and leaves USER-authored transforms intact.
+    // In this library motion only writes a transform AFTER mount (FLIP on
+    // a layout change, drag on pointerdown), so the node captures the
+    // mount-time transform as the user base and resets to that — not to
+    // 'none' — while measuring.
+    //
+    // We read the gap between the inner's raw on-screen rect and the
+    // event's `layout` box (the "stripped offset"):
+    //   • With only the wrapper's mount-time (user) transform, the gap is
+    //     0 — the static transform is PRESERVED in the layout box.
+    //   • Tick "post-mount transform" to add a +40px-down translate to
+    //     the wrapper after mount (a stand-in for a motion/FLIP write).
+    //     Toggle again and the gap becomes y=40 — that portion is
+    //     STRIPPED, because it wasn't part of the captured base.
+
+    let atRight = $state(false)
+    let motionApplied = $state(false)
+    let lastDelta = $state<ProjectionUpdatePayload | null>(null)
+    let strippedOffset = $state<{ x: number; y: number } | null>(null)
+
+    const BASE_TRANSFORM = 'translate(40px, 60px)'
+    const POST_MOUNT_TRANSFORM = 'translate(40px, 60px) translate(0px, 40px)'
+
+    const outerEl = (): HTMLElement | null =>
+        document.querySelector('[data-testid="projection-nested-ancestor"] .outer')
+
+    const toggle = () => {
+        atRight = !atRight
+    }
+
+    const toggleMotionTransform = () => {
+        motionApplied = !motionApplied
+        // Write directly to the DOM AFTER mount so it's never captured as
+        // the user base — exactly how a FLIP/drag transform would arrive.
+        const el = outerEl()
+        if (el) el.style.transform = motionApplied ? POST_MOUNT_TRANSFORM : BASE_TRANSFORM
+    }
+
+    const onInnerUpdate = (data: ProjectionUpdatePayload) => {
+        lastDelta = data
+        const el = document.querySelector<HTMLElement>(
+            '[data-testid="projection-nested-ancestor"] .inner'
+        )
+        if (el) {
+            // Read the inner's on-screen rect with its OWN transform
+            // removed, so an in-flight FLIP on the inner can't skew the
+            // number. The ancestor's live transform still applies, so
+            // this measures (inner slot + ancestor LIVE transform). The
+            // event's `layout` box is (inner slot + ancestor BASE), so
+            // the gap is exactly the ancestor's motion-applied portion —
+            // 0 for a static base, 40 once the post-mount transform is on.
+            const prev = el.style.transform
+            el.style.transform = 'none'
+            const visual = el.getBoundingClientRect()
+            el.style.transform = prev
+            strippedOffset = {
+                x: Math.round(visual.left - data.layout.x.min),
+                y: Math.round(visual.top - data.layout.y.min)
+            }
+        }
+    }
+</script>
+
+<svelte:head>
+    <title>Projection · nested ancestor (#379)</title>
+</svelte:head>
+
+<div class="page" data-testid="projection-nested-ancestor">
+    <header>
+        <h1>Projection — nested ancestor</h1>
+        <p>
+            The outer wrapper has a user-authored <code>transform: translate(40px, 60px)</code>. The
+            inner box toggles between the wrapper's left and right edge. <code>measure()</code>
+            matches framer-motion: it strips only <em>motion-applied</em> transforms (written after
+            mount) and preserves the <em>user-authored</em> base. The
+            <strong>stripped offset</strong>
+            below is the gap between the inner's raw on-screen rect and the event's
+            <code>layout</code> box:
+        </p>
+        <ul>
+            <li>
+                Static base only → offset <code>x=0 y=0</code> (user transform preserved, matches upstream).
+            </li>
+            <li>
+                With a post-mount transform → offset <code>x=0 y=40</code> (only that motion-applied part
+                is stripped).
+            </li>
+        </ul>
+        <div class="controls">
+            <button type="button" onclick={toggle} data-testid="toggle">Toggle position</button>
+            <label>
+                <input
+                    type="checkbox"
+                    checked={motionApplied}
+                    onchange={toggleMotionTransform}
+                    data-testid="motion-transform"
+                />
+                Post-mount transform on wrapper (+40px down)
+            </label>
+        </div>
+    </header>
+
+    <section class="stage">
+        <motion.div layout class="outer" style="transform: translate(40px, 60px);">
+            <motion.div
+                layout
+                class="inner"
+                style="align-self: {atRight ? 'flex-end' : 'flex-start'};"
+                transition={{ type: 'spring', stiffness: 400, damping: 32 }}
+                onProjectionUpdate={onInnerUpdate}
+            >
+                inner
+            </motion.div>
+        </motion.div>
+    </section>
+
+    <section class="readout">
+        <h2>Inner box last delta</h2>
+        <pre data-testid="inner-delta">{lastDelta
+                ? `Δx=${lastDelta.delta.x.translate.toFixed(1)} Δy=${lastDelta.delta.y.translate.toFixed(
+                      1
+                  )} changed=${lastDelta.hasLayoutChanged}`
+                : '(no event yet)'}</pre>
+        <h2>Ancestor offset stripped by measure()</h2>
+        <pre data-testid="stripped-offset">{strippedOffset
+                ? `x=${strippedOffset.x} y=${strippedOffset.y}`
+                : '(no event yet)'}</pre>
+        <p class="hint">
+            Wrapper width is 400px, inner is 80px → horizontal travel ≈ 294px (the Δx above). With
+            only the static base the stripped offset reads <code>x=0 y=0</code> (user transform
+            kept). Tick the checkbox, then toggle again: it reads <code>x=0 y=40</code> — only the
+            post-mount (motion) transform is removed from the inner's <code>layout</code> box.
+        </p>
+    </section>
+</div>
+
+<style>
+    .page {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1rem;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+    }
+    header p {
+        color: #475569;
+        font-size: 14px;
+        line-height: 1.5;
+    }
+    button {
+        margin-top: 8px;
+        padding: 8px 16px;
+        border-radius: 8px;
+        border: 1px solid #cbd5e1;
+        background: #fff;
+        cursor: pointer;
+        font: inherit;
+    }
+    button:hover {
+        border-color: #94a3b8;
+    }
+    .controls {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        flex-wrap: wrap;
+        margin-top: 8px;
+    }
+    .controls label {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 14px;
+        color: #334155;
+    }
+    header ul {
+        margin: 8px 0;
+        padding-left: 20px;
+        font-size: 14px;
+        color: #475569;
+        line-height: 1.6;
+    }
+    .stage {
+        margin: 32px 0 32px 0;
+        /* Leave room for the wrapper's translate(40, 60) so it stays visible. */
+        padding: 0 0 80px 0;
+    }
+    :global([data-testid='projection-nested-ancestor'] .outer) {
+        width: 400px;
+        height: 160px;
+        border-radius: 14px;
+        background: #e2e8f0;
+        border: 1px dashed #94a3b8;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        padding: 12px;
+    }
+    :global([data-testid='projection-nested-ancestor'] .inner) {
+        width: 80px;
+        height: 80px;
+        border-radius: 10px;
+        background: #10b981;
+        color: #fff;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    .readout pre {
+        margin: 4px 0;
+        font-family: ui-monospace, monospace;
+        font-size: 13px;
+        color: #0f172a;
+        background: #f1f5f9;
+        padding: 6px 10px;
+        border-radius: 6px;
+    }
+    .hint {
+        font-size: 12px;
+        color: #64748b;
+    }
+</style>

--- a/src/routes/tests/projection/sibling-swap/+page.svelte
+++ b/src/routes/tests/projection/sibling-swap/+page.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+    import { motion, type ProjectionUpdatePayload } from '$lib'
+
+    // Projection smoke test (#379) — flat sibling swap.
+    //
+    // Two `<motion.div layout>` boxes. Clicking swap flips their order in a
+    // $state array; the existing FLIP layout animation runs, and each box's
+    // internal ProjectionNode fires `onProjectionUpdate` with the delta
+    // between its pre- and post-swap layout box. We render the live payload
+    // so the event stream is verifiable without opening DevTools.
+
+    type Item = { id: number; label: string; color: string }
+    let items = $state<Item[]>([
+        { id: 0, label: 'Box A', color: '#6366f1' },
+        { id: 1, label: 'Box B', color: '#ec4899' }
+    ])
+
+    let lastDelta = $state<Record<number, ProjectionUpdatePayload>>({})
+
+    const swap = () => {
+        items = [...items].reverse()
+    }
+</script>
+
+<svelte:head>
+    <title>Projection · sibling swap (#379)</title>
+</svelte:head>
+
+<div class="page" data-testid="projection-sibling-swap">
+    <header>
+        <h1>Projection — sibling swap</h1>
+        <p>
+            Two <code>&lt;motion.div layout&gt;</code> boxes. Click swap → the FLIP animation runs
+            and each box's projection node emits a <code>didUpdate</code> with the move delta.
+            Expect
+            <code>delta.y.translate</code> ≈ one box-height (one positive, one negative) and
+            <code>hasLayoutChanged: true</code>.
+        </p>
+        <button type="button" onclick={swap} data-testid="swap">Swap order</button>
+    </header>
+
+    <section class="stack">
+        {#each items as item (item.id)}
+            <motion.div
+                layout
+                class="box"
+                style="background: {item.color};"
+                transition={{ type: 'spring', stiffness: 400, damping: 32 }}
+                onProjectionUpdate={(data) => {
+                    lastDelta = { ...lastDelta, [item.id]: data }
+                }}
+            >
+                {item.label}
+            </motion.div>
+        {/each}
+    </section>
+
+    <section class="readout">
+        <h2>Last delta per box</h2>
+        {#each items as item (item.id)}
+            <pre data-testid="delta-{item.id}">{item.label}: {lastDelta[item.id]
+                    ? `Δx=${lastDelta[item.id].delta.x.translate.toFixed(1)} Δy=${lastDelta[
+                          item.id
+                      ].delta.y.translate.toFixed(
+                          1
+                      )} changed=${lastDelta[item.id].hasLayoutChanged}`
+                    : '(no event yet)'}</pre>
+        {/each}
+    </section>
+</div>
+
+<style>
+    .page {
+        max-width: 640px;
+        margin: 0 auto;
+        padding: 2rem 1rem;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+    }
+    header p {
+        color: #475569;
+        font-size: 14px;
+        line-height: 1.5;
+    }
+    button {
+        margin-top: 8px;
+        padding: 8px 16px;
+        border-radius: 8px;
+        border: 1px solid #cbd5e1;
+        background: #fff;
+        cursor: pointer;
+        font: inherit;
+    }
+    button:hover {
+        border-color: #94a3b8;
+    }
+    .stack {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        margin: 24px 0;
+    }
+    :global([data-testid='projection-sibling-swap'] .box) {
+        height: 80px;
+        border-radius: 12px;
+        color: #fff;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    .readout pre {
+        margin: 4px 0;
+        font-family: ui-monospace, monospace;
+        font-size: 13px;
+        color: #0f172a;
+        background: #f1f5f9;
+        padding: 6px 10px;
+        border-radius: 6px;
+    }
+</style>


### PR DESCRIPTION
## Summary

Adds the **projection layout system** that underpins Reorder (#310) and future shared-element work. Per-element `ProjectionNode`s wired through a Svelte context form a tree mirroring the component hierarchy; a `didUpdate` event stream surfaces FLIP-delta payloads via a new `onProjectionUpdate` prop. The load-bearing piece is an **ancestor-transform-invariant `measure()`** that matches framer-motion's `removeBoxTransforms` — it strips only motion-applied transforms (FLIP/drag/`initial`) and preserves the user-authored ones, so a nested child computes a correct delta even while an ancestor animates.

Scope is deliberately *foundation + correct measure*. The drag↔projection origin-compensation wiring and the Reorder components ship in a follow-up keyed off #310 — this PR exposes the `adjustOrigin` hook on `attachDrag` but does not yet call it.

## Changes

- ✨ `ProjectionNode` tree (`projection.ts`) + Svelte context (`projection.context.ts`), mounted under every `motion.*` element
- ✨ `onProjectionUpdate` prop emitting `{ layout, snapshot, delta, hasLayoutChanged }`, gated on a real delta so the FLIP's own transform writes don't fan out no-op events
- 🔧 `measure()` resets the ancestor chain to each node's **user-authored** base (sourced from the `style` prop via `extractTransform`), stripping motion-applied transforms while preserving the user's — so a transform-type `initial`/`animate` is never mistaken for the base
- 🔧 Route the `layout` FLIP measurement through `projection.measure()`, fixing a pre-existing quirk where a child spuriously FLIPped when an ancestor's transform animated. `commitLayoutChange` returns its box so the FLIP reuses one measure per frame (`measureRect` gained an optional base transform; `computeFlipTransforms` takes a structural `RectLike` to avoid a circular import)
- 🔧 `drag`: `setXYImmediate` + axis-guarded `adjustOrigin` — the synchronous origin-compensation door for #310 (not yet wired)
- 🧪 Smoke routes (`sibling-swap`, `nested-ancestor`) linked from the lib root index; unit + e2e coverage for the event stream and the user-vs-motion transform distinction

## Known limitations (deferred to #310)

- Drag↔projection `didUpdate` wiring, `dragSnapToOrigin`, and the Reorder components themselves
- `willUpdate`/`didUpdate` explicit cycle, depth-sorted FlatTree, scale-correction, and `layoutId` registry migration remain out of scope

## Commits

- [`d2fb8b8`](https://github.com/humanspeak/svelte-motion/commit/d2fb8b8d07620a8d45a301840151d412c19c6eea) feat(layout): add projection node foundation + FLIP delta events
- [`5668ca4`](https://github.com/humanspeak/svelte-motion/commit/5668ca4cedb42f595ded76f35ffa9c4b4a77efa3) fix(layout): address projection review findings

Closes #379
