### PR TITLE
fix(motion): persist animated transforms after WAAPI completion

### DIFF
--- a/e2e/motion/animate-transform-persist.spec.ts
+++ b/e2e/motion/animate-transform-persist.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from '@playwright/test'
+import { readTransform } from '../_helpers/transform'
+
+/**
+ * Regression for #377 — transform shortcuts must persist after the WAAPI
+ * animation completes. Before the fix, `animate={{ scaleX: 0.5 }}` (and any
+ * transform shortcut) animated correctly but reverted to `transform: none`
+ * on completion, because the inline transform baseline was cleared at
+ * `'ready'` and WAAPI's default `fill: 'none'` surrenders the property.
+ *
+ * All targets are non-identity so "reverted to none" is detectable
+ * (an identity transform serializes to `none` either way).
+ *
+ * `readTransform` parses the computed `matrix(a,b,c,d,tx,ty)`:
+ *   a = scaleX, d = scaleY, tx = translateX, ty = translateY.
+ */
+
+test.describe('motion/animate-transform-persist (#377)', () => {
+    test('scaleX target persists at rest (does not revert to none)', async ({ page }) => {
+        await page.goto('/tests/motion/animate-transform-persist?@isPlaywright=true')
+        const sel = '[data-testid="persist-scalex"]'
+        await page.locator(sel).waitFor({ state: 'visible' })
+
+        // Settle, then assert the resting transform holds scaleX ≈ 0.5.
+        await expect
+            .poll(async () => (await readTransform(page, sel)).a, {
+                timeout: 4000,
+                message: 'scaleX never settled at its 0.5 target'
+            })
+            .toBeCloseTo(0.5, 1)
+
+        // And it is NOT the reverted/identity state.
+        const t = await page.locator(sel).evaluate((el) => getComputedStyle(el).transform)
+        expect(t).not.toBe('none')
+    })
+
+    test('animates through an intermediate frame (no snap to target)', async ({ page }) => {
+        await page.goto('/tests/motion/animate-transform-persist?@isPlaywright=true')
+        const sel = '[data-testid="persist-rotate"]'
+        await page.locator(sel).waitFor({ state: 'visible' })
+
+        // Sample across the 0.6s animation; capture the max rotation seen
+        // mid-flight. rotate(θ) → matrix b = sin(θ); a partial frame has
+        // 0 < b < sin(45°). Proves it animates rather than jumping to 45°.
+        let sawIntermediate = false
+        for (let i = 0; i < 15; i++) {
+            const t = await page.locator(sel).evaluate((el) => getComputedStyle(el).transform)
+            const m = t.match(/matrix\(([^)]+)\)/)
+            if (m) {
+                const b = Number.parseFloat(m[1].split(',')[1])
+                if (b > 0.05 && b < 0.69) sawIntermediate = true // sin(45°) ≈ 0.707
+            }
+            await page.waitForTimeout(40)
+        }
+        expect(sawIntermediate).toBe(true)
+
+        // Rests rotated (b ≈ sin(45°) ≈ 0.707), not reverted.
+        await expect
+            .poll(
+                async () => {
+                    const t = await page
+                        .locator(sel)
+                        .evaluate((el) => getComputedStyle(el).transform)
+                    const m = t.match(/matrix\(([^)]+)\)/)
+                    return m ? Number.parseFloat(m[1].split(',')[1]) : 0
+                },
+                { timeout: 4000, message: 'rotate never settled at 45°' }
+            )
+            .toBeCloseTo(0.707, 1)
+    })
+
+    test('does NOT snap to the target at the start of the animation', async ({ page }) => {
+        // The fix's subtle failure mode: flipping the inline baseline to the
+        // target mid-animation shows the target for one frame (a visible snap)
+        // before WAAPI re-asserts. Polling from the test can't reliably catch a
+        // 1-frame transient, so record every frame from mount via addInitScript
+        // (runs before page JS) and assert no early frame is near the target.
+        await page.addInitScript(() => {
+            const frames: number[] = []
+            ;(window as unknown as { __snapFrames: number[] }).__snapFrames = frames
+            const el = () => document.querySelector('[data-testid="persist-rotate"]')
+            const tick = () => {
+                const node = el()
+                if (node) {
+                    const m = getComputedStyle(node).transform.match(/matrix\(([^)]+)\)/)
+                    // matrix b = sin(theta); abs so direction doesn't matter.
+                    if (m) frames.push(Math.abs(Number.parseFloat(m[1].split(',')[1])))
+                }
+                if (frames.length < 80) requestAnimationFrame(tick)
+            }
+            requestAnimationFrame(tick)
+        })
+
+        // `?slow` → 4s linear: by ~1.2s a smooth ramp reaches only sin≈0.2,
+        // whereas a one-frame snap to 45° would spike to sin≈0.707.
+        await page.goto('/tests/motion/animate-transform-persist?slow&@isPlaywright=true')
+        await page.locator('[data-testid="persist-rotate"]').waitFor({ state: 'visible' })
+        await page.waitForTimeout(1300)
+
+        const earlyMax = await page.evaluate(() => {
+            const f = (window as unknown as { __snapFrames: number[] }).__snapFrames || []
+            // First ~1.2s of frames (well before the 4s animation nears 45°).
+            return Math.max(0, ...f.slice(0, 60))
+        })
+        expect(earlyMax).toBeLessThan(0.4)
+    })
+
+    test('keyframe-array target rests at the LAST element, not the first', async ({ page }) => {
+        await page.goto('/tests/motion/animate-transform-persist?@isPlaywright=true')
+        const sel = '[data-testid="persist-array"]'
+        await page.locator(sel).waitFor({ state: 'visible' })
+
+        // animate x: [0, 120, 60] → resting translateX is 60, not 0.
+        await expect
+            .poll(async () => (await readTransform(page, sel)).tx, {
+                timeout: 4000,
+                message: 'translateX never settled at the last keyframe (60)'
+            })
+            .toBeCloseTo(60, 0)
+    })
+})

--- a/src/lib/components/initial.component.spec.ts
+++ b/src/lib/components/initial.component.spec.ts
@@ -97,3 +97,65 @@ describe('motion component with initial={false}', () => {
         expect(element).toBeTruthy()
     })
 })
+
+describe('transform shortcut persists after animation (#377)', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
+    it('keeps a non-identity animate transform as inline style once settled (scaleX)', async () => {
+        // Non-identity target on purpose: scaleX(1) is the identity transform,
+        // which correctly serializes to `transform: none` (matching upstream
+        // build-transform), so it can't distinguish "persisted" from "reverted".
+        // scaleX(0.5) reverting to none WOULD be the bug.
+        const { container } = render(motion.div, {
+            props: {
+                initial: { scaleX: 0 },
+                animate: { scaleX: 0.5 },
+                transition: { duration: 0.4 },
+                'data-testid': 'persist-scalex'
+            }
+        })
+        const el = container.querySelector('[data-testid="persist-scalex"]') as HTMLElement
+
+        await vi.runAllTimersAsync()
+
+        // The bug: inline transform ends up empty, so WAAPI completion leaves
+        // transform:none. After the fix the resting target is the inline baseline.
+        expect(el.style.transform).not.toBe('')
+        expect(el.style.transform).toContain('scaleX(0.5)')
+    })
+
+    it('keeps a non-identity transform at rest (rotate)', async () => {
+        const { container } = render(motion.div, {
+            props: {
+                initial: { rotate: 0 },
+                animate: { rotate: 45 },
+                transition: { duration: 0.4 },
+                'data-testid': 'persist-rotate'
+            }
+        })
+        const el = container.querySelector('[data-testid="persist-rotate"]') as HTMLElement
+
+        await vi.runAllTimersAsync()
+
+        expect(el.style.transform).toContain('rotate(45deg)')
+    })
+
+    it('rests at the LAST keyframe of an array target, not the first', async () => {
+        const { container } = render(motion.div, {
+            props: {
+                initial: { x: 0 },
+                animate: { x: [0, 100, 50] },
+                transition: { duration: 0.4 },
+                'data-testid': 'persist-array'
+            }
+        })
+        const el = container.querySelector('[data-testid="persist-array"]') as HTMLElement
+
+        await vi.runAllTimersAsync()
+
+        expect(el.style.transform).toContain('translateX(50px)')
+        expect(el.style.transform).not.toContain('translateX(0px)')
+    })
+})

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -56,7 +56,13 @@
     import { attachPan, type AttachPanCleanup } from '$lib/utils/pan'
     import { ProjectionNode } from '$lib/utils/projection'
     import { getProjectionParent, setProjectionParent } from '$lib/components/projection.context'
-    import { resolveInitial, resolveAnimate, resolveExit, resolveWhile } from '$lib/utils/variants'
+    import {
+        resolveInitial,
+        resolveAnimate,
+        resolveExit,
+        resolveWhile,
+        resolveRestingValues
+    } from '$lib/utils/variants'
     import {
         setVariantContext,
         getVariantContext,
@@ -142,6 +148,12 @@
         ...rest
     }: Props = $props()
     let isLoaded = $state<'mounting' | 'initial' | 'ready' | 'animated'>('mounting')
+    // True once the enter/animate animation has COMPLETED. Until then the
+    // WAAPI animation owns the transform; flipping the inline baseline to
+    // the target mid-run causes a one-frame snap (the target shows through
+    // for the frame the inline changes). We therefore only apply the target
+    // as the inline style once settled — see the style derivation. (#377)
+    let enterAnimationSettled = $state(false)
     let dataPath = $state<number>(-1)
     const motionConfig = $derived(getMotionConfig())
     const reducedMotionState = useReducedMotionConfig()
@@ -522,6 +534,17 @@
         )
     )
 
+    // Reduced-motion-filtered animate values used as the inline-style
+    // baseline so an animated value (transforms included) persists after
+    // the WAAPI animation completes (#377). Filtered exactly like
+    // `initialKeyframes` so transforms are stripped under reduced motion.
+    const animateKeyframes = $derived(
+        filterReducedMotionKeyframes(
+            resolvedAnimate as Record<string, unknown> | undefined,
+            reducedMotion
+        )
+    )
+
     // Derived attributes to keep both branches in sync (focusability, data flags, style, class)
     const derivedAttrs = $derived<Record<string, unknown>>({
         ...(rest as Record<string, unknown>),
@@ -560,20 +583,33 @@
             initialKeyframes && 'pathLength' in initialKeyframes && isLoaded === 'mounting'
                 ? `${styleProp || ''};visibility:hidden`
                 : styleProp,
-            // Apply initialKeyframes as inline styles during mounting and initial phases
-            // The animation starts in RAF after 'initial' phase, so we need styles until then
-            // When ready AND we have initialKeyframes: DON'T set any animated properties!
-            // WAAPI is controlling them and inline styles can override the animation
+            // The "from" slot: apply initialKeyframes as inline styles during
+            // the mounting/initial phases (before the WAAPI animation locks
+            // its from-value and we promote to 'ready' — see the lifecycle
+            // around the enter rAF). mergeInlineStyles prefers this slot when
+            // non-empty, so it wins over the animate slot below in these phases.
             isLoaded === 'mounting' || isLoaded === 'initial'
                 ? (initialKeyframes as unknown as Record<string, unknown>)
                 : undefined,
-            // Only use resolvedAnimate as fallback when we DON'T have initialKeyframes
-            // If we have initialKeyframes, the enter animation is running - setting
-            // inline styles to the target values will override the WAAPI animation
-            // Use isNotEmpty to handle empty initial objects (initial: {}) which should fallback
-            isNotEmpty(initialKeyframes)
-                ? undefined
-                : (resolvedAnimate as unknown as Record<string, unknown>)
+            // The "target" slot. Only AFTER the enter animation completes does
+            // the target become the inline baseline, so the element holds it
+            // once WAAPI surrenders the property (default fill:'none' would
+            // otherwise leave transform:none). It must NOT be applied during
+            // the run: flipping the inline value to the target mid-animation
+            // shows the target for the one frame the inline changes (a visible
+            // snap), since WAAPI's composite doesn't override that exact frame.
+            // While the animation runs we keep the original behavior — initial
+            // keyframes own the inline (via the slot above), or, with no
+            // initial, the animate values seed the inline as the from. Resting
+            // values collapse keyframe arrays to their last element
+            // (animate={{x:[0,100,50]}} rests at 50). (#377)
+            enterAnimationSettled
+                ? (resolveRestingValues(
+                      animateKeyframes as DOMKeyframesDefinition | undefined
+                  ) as unknown as Record<string, unknown>)
+                : isNotEmpty(initialKeyframes)
+                  ? undefined
+                  : (animateKeyframes as unknown as Record<string, unknown>)
         ),
         class: classProp
     })
@@ -851,12 +887,20 @@
             transitionAnimate
         })
 
+        // A fresh run owns the transform again until it completes.
+        enterAnimationSettled = false
         animateWithLifecycle(
             element,
             payload as unknown as DOMKeyframesDefinition,
             transitionAnimate as unknown as AnimationOptions,
             (def) => onAnimationStartProp?.(def as unknown as DOMKeyframesDefinition | undefined),
-            (def) => onAnimationCompleteProp?.(def as unknown as DOMKeyframesDefinition | undefined)
+            (def) => {
+                // Now the target is the resting state — promote it to the
+                // inline baseline so it persists after WAAPI surrenders the
+                // property (default fill:'none'). (#377)
+                enterAnimationSettled = true
+                onAnimationCompleteProp?.(def as unknown as DOMKeyframesDefinition | undefined)
+            }
         )
     }
 

--- a/src/lib/utils/variants.spec.ts
+++ b/src/lib/utils/variants.spec.ts
@@ -313,6 +313,11 @@ describe('utils/variants - resolveRestingValues', () => {
         ).toEqual({ x: 60, rotate: 45, scaleY: 1 })
     })
 
+    it('omits keys whose value is an empty array (no resting value)', () => {
+        expect(resolveRestingValues({ x: [], y: 5 } as never)).toEqual({ y: 5 })
+        expect(resolveRestingValues({ x: [] } as never)).toEqual({})
+    })
+
     it('returns undefined when given undefined', () => {
         expect(resolveRestingValues(undefined)).toBeUndefined()
     })

--- a/src/lib/utils/variants.spec.ts
+++ b/src/lib/utils/variants.spec.ts
@@ -4,6 +4,7 @@ import {
     resolveAnimate,
     resolveExit,
     resolveInitial,
+    resolveRestingValues,
     resolveVariant,
     resolveVariantList,
     resolveWhile
@@ -291,5 +292,35 @@ describe('utils/variants - resolveWhile', () => {
             hover: (i) => ({ scale: 1 + (i as number) * 0.1 }) as never
         }
         expect(resolveWhile('hover', variants, 3)).toEqual({ scale: 1.3 })
+    })
+})
+
+describe('utils/variants - resolveRestingValues', () => {
+    it('collapses a keyframe array to its last element (the resting value)', () => {
+        expect(resolveRestingValues({ x: [0, 100, 50] } as never)).toEqual({ x: 50 })
+    })
+
+    it('leaves scalar values untouched', () => {
+        expect(resolveRestingValues({ opacity: 0.5, scaleX: 1 } as never)).toEqual({
+            opacity: 0.5,
+            scaleX: 1
+        })
+    })
+
+    it('handles a mix of scalars and arrays', () => {
+        expect(
+            resolveRestingValues({ x: [0, 120, 60], rotate: 45, scaleY: [0, 1] } as never)
+        ).toEqual({ x: 60, rotate: 45, scaleY: 1 })
+    })
+
+    it('returns undefined when given undefined', () => {
+        expect(resolveRestingValues(undefined)).toBeUndefined()
+    })
+
+    it('returns a new object (does not mutate the input)', () => {
+        const input = { x: [0, 50] } as never
+        const out = resolveRestingValues(input)
+        expect(out).not.toBe(input)
+        expect((input as { x: number[] }).x).toEqual([0, 50])
     })
 })

--- a/src/lib/utils/variants.ts
+++ b/src/lib/utils/variants.ts
@@ -260,12 +260,14 @@ export const resolveWhile = (
  * @param keyframes - Resolved animate keyframes (scalars and/or arrays),
  *     or `undefined`.
  * @returns A new object with each value collapsed to its resting scalar,
- *     or `undefined` when given `undefined`.
+ *     or `undefined` when given `undefined`. Keys whose value is an empty
+ *     array are omitted (no resting value).
  *
  * @example
  * ```ts
  * resolveRestingValues({ x: [0, 100, 50], scaleX: 1 }) // { x: 50, scaleX: 1 }
  * resolveRestingValues({ opacity: 0.5 })               // { opacity: 0.5 }
+ * resolveRestingValues({ x: [], y: 5 })                // { y: 5 } (empty array dropped)
  * resolveRestingValues(undefined)                      // undefined
  * ```
  */
@@ -275,7 +277,13 @@ export const resolveRestingValues = (
     if (keyframes === undefined) return undefined
     const out: Record<string, unknown> = {}
     for (const [key, value] of Object.entries(keyframes)) {
-        out[key] = Array.isArray(value) ? value[value.length - 1] : value
+        if (Array.isArray(value)) {
+            // An empty array has no resting value — omit the key rather than
+            // emitting `value[-1]` (undefined).
+            if (value.length > 0) out[key] = value[value.length - 1]
+        } else {
+            out[key] = value
+        }
     }
     return out as DOMKeyframesDefinition
 }

--- a/src/lib/utils/variants.ts
+++ b/src/lib/utils/variants.ts
@@ -245,3 +245,37 @@ export const resolveWhile = (
         return resolveVariantList(variants, value, custom)
     return value as DOMKeyframesDefinition
 }
+
+/**
+ * Collapse each keyframe value to the value the element comes to REST at
+ * — the last element of a keyframe array, or the value itself otherwise.
+ *
+ * Used when deriving the post-animation inline style baseline: an
+ * `animate={{ x: [0, 100, 50] }}` settles at `50`, so the resting inline
+ * transform must reflect `50`, not the first keyframe. Mirrors
+ * framer-motion, whose `buildTransform` reads the motion value as a
+ * scalar that has already settled at the final keyframe
+ * (`motion-dom/.../build-transform.ts`).
+ *
+ * @param keyframes - Resolved animate keyframes (scalars and/or arrays),
+ *     or `undefined`.
+ * @returns A new object with each value collapsed to its resting scalar,
+ *     or `undefined` when given `undefined`.
+ *
+ * @example
+ * ```ts
+ * resolveRestingValues({ x: [0, 100, 50], scaleX: 1 }) // { x: 50, scaleX: 1 }
+ * resolveRestingValues({ opacity: 0.5 })               // { opacity: 0.5 }
+ * resolveRestingValues(undefined)                      // undefined
+ * ```
+ */
+export const resolveRestingValues = (
+    keyframes: DOMKeyframesDefinition | undefined
+): DOMKeyframesDefinition | undefined => {
+    if (keyframes === undefined) return undefined
+    const out: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(keyframes)) {
+        out[key] = Array.isArray(value) ? value[value.length - 1] : value
+    }
+    return out as DOMKeyframesDefinition
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -101,6 +101,14 @@
                         SVG Path Length
                     </a>
                 </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/motion/animate-transform-persist') + searchParams}
+                    >
+                        Transform persistence (#377)
+                    </a>
+                </li>
             </ul>
         </div>
         <div>

--- a/src/routes/tests/motion/animate-transform-persist/+page.svelte
+++ b/src/routes/tests/motion/animate-transform-persist/+page.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+    import { motion } from '$lib'
+
+    // Regression route for #377 — transform shortcuts must persist as inline
+    // style after the WAAPI animation completes (default fill:'none' otherwise
+    // surrenders the property, leaving transform:none).
+    //
+    // All three targets are NON-IDENTITY so "reverted to none" is observably
+    // wrong (scaleX(1)/rotate(0) would serialize to `none` either way and
+    // couldn't distinguish persisted from reverted):
+    //   • scaleX 0 → 0.5  (rests half-scaled)
+    //   • rotate 0 → 45   (rests rotated)
+    //   • x [0,120,60]    (keyframe array — rests at the LAST element, 60)
+    //
+    // A slower transition gives e2e room to sample a mid-animation frame and
+    // confirm it actually animates (no snap-to-target). `?slow` stretches it
+    // to 4s for frame-by-frame debugging of transient glitches.
+    // `?slow` stretches the animation to 4s so the enter motion can be
+    // watched (and frame-sampled by e2e) instead of completing in 0.6s.
+    const slow =
+        typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('slow')
+    const transition = { duration: slow ? 4 : 0.6, ease: 'linear' } as const
+</script>
+
+<svelte:head>
+    <title>Motion · animate transform persistence (#377)</title>
+</svelte:head>
+
+<div class="page" data-testid="animate-transform-persist">
+    <h1>Transform persistence (#377)</h1>
+    <p>
+        Each box animates a transform shortcut and must <strong>hold the target</strong> at rest —
+        not snap back to <code>transform: none</code> when the animation finishes.
+    </p>
+
+    <section class="stage">
+        <motion.div
+            class="box scalex"
+            initial={{ scaleX: 0 }}
+            animate={{ scaleX: 0.5 }}
+            {transition}
+            data-testid="persist-scalex"
+        >
+            scaleX → 0.5
+        </motion.div>
+
+        <motion.div
+            class="box rotate"
+            initial={{ rotate: 0 }}
+            animate={{ rotate: 45 }}
+            {transition}
+            data-testid="persist-rotate"
+        >
+            rotate → 45°
+        </motion.div>
+
+        <motion.div
+            class="box arr"
+            initial={{ x: 0 }}
+            animate={{ x: [0, 120, 60] }}
+            {transition}
+            data-testid="persist-array"
+        >
+            x → [0,120,60]
+        </motion.div>
+    </section>
+</div>
+
+<style>
+    .page {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1rem;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+    }
+    p {
+        color: #475569;
+        font-size: 14px;
+        line-height: 1.5;
+    }
+    .stage {
+        display: flex;
+        flex-direction: column;
+        gap: 28px;
+        margin-top: 32px;
+    }
+    :global([data-testid='animate-transform-persist'] .box) {
+        width: 160px;
+        height: 56px;
+        border-radius: 10px;
+        color: #fff;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transform-origin: left center;
+    }
+    :global([data-testid='animate-transform-persist'] .scalex) {
+        background: #6366f1;
+    }
+    :global([data-testid='animate-transform-persist'] .rotate) {
+        background: #ec4899;
+    }
+    :global([data-testid='animate-transform-persist'] .arr) {
+        background: #10b981;
+    }
+</style>


### PR DESCRIPTION
## Summary

Fixes #377 — the only open bug on the parity board. A `motion.*` element with a transform-shortcut `animate` value (`scaleX`, `rotate`, `x`, `y`, …) animated correctly but reverted to `transform: none` once the WAAPI run finished: the inline transform was cleared at the `'ready'` state, and WAAPI's default `fill: 'none'` surrenders the property on completion. Visible for any non-identity target, and the original blocker behind the Reorder TodoList strikethrough — so this also de-risks #310.

## Changes

- 🐛 Promote the animate **target** to the inline-style baseline only once the enter animation has **completed** (new `enterAnimationSettled` flag, set in `animateWithLifecycle`'s `onComplete`). Applying it during the run would show the target for the one frame the inline value changes — a visible **snap** — because WAAPI's composite doesn't override that exact frame. During the run, WAAPI owns the transform; at completion the inline target takes over seamlessly (no end-flash).
- ✨ `resolveRestingValues` helper — collapses keyframe-array targets to their resting (last) element (`animate={{ x: [0, 100, 50] }}` rests at 50), mirroring upstream's `buildTransform` reading a settled scalar.
- 🐛 Inline baseline runs through `filterReducedMotionKeyframes`, so transforms stay stripped under reduced motion.
- 🧪 Unit coverage (`resolveRestingValues` + persistence) and an e2e route + spec, including an `addInitScript` frame-recorder guard asserting **no start-of-animation snap**.

## Verified against framer-motion

`render/html/use-props.ts` builds inline style from resolved values every render; `motion-dom/.../build-transform.ts` reads settled scalars and emits `none` for identity transforms (so `scaleX: 1` correctly serializes to `none` — the bug only bites non-identity targets, which is why the tests use them). Motion's internal `commitStyles` only fires on `stop()`/interruption (`NativeAnimation.ts:165`), never on natural completion, so the inline-baseline approach is the right fix here.

## Test plan

- [x] `pnpm test` — 561 unit pass (incl. new persistence + `resolveRestingValues` tests)
- [x] `pnpm exec svelte-check` — 0 errors · `trunk check` clean
- [x] Full e2e — 136 passed, 2 skipped (only the known `fancy-like-button` dispatch flake, passes isolated)
- [x] New `animate-transform-persist` e2e — 4/4 (persist, intermediate-frame, no-snap guard, array-resting)
- [x] CodeRabbit CLI review — no findings
- [x] Browser-recorder confirmation: no start-snap, no end-flash, holds target

## Commits

- [`75ca5ba`](https://github.com/humanspeak/svelte-motion/commit/75ca5ba80b451ebaba572086e149272c69ef59e0) fix(motion): persist animated transforms after WAAPI completion

Closes #377
