### PR TITLE
feat: add optimized appear animation handoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,3 +38,12 @@ When asked to implement a new feature, handle it end-to-end by default:
 
 - Match the motion.dev example: `AnimatePresence mode="sync"` is only used in the label.
 - The icon `AnimatePresence` should use default mode (no explicit `mode` prop).
+
+## Failed e2e review workflow
+
+- When a full Playwright/e2e run fails, review failures one at a time.
+- For each failure, open the related test/demo page in the in-app browser before changing code.
+- Explain what the page is supposed to demonstrate, what the failing test asserted,
+  and what is visible on the page.
+- Decide with the user whether the behavior is wrong or the test is too tight/stale
+  before moving to the next failing page.

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -107,7 +107,10 @@ export const docsSections: NavSection[] = [
     {
         title: 'Performance',
         icon: Zap,
-        items: [{ title: 'Tree Shaking', href: '/docs/tree-shaking', icon: Zap }]
+        items: [
+            { title: 'Optimized appear', href: '/docs/optimized-appear', icon: Zap },
+            { title: 'Tree Shaking', href: '/docs/tree-shaking', icon: Zap }
+        ]
     },
     {
         title: 'shadcn/ui',

--- a/docs/src/lib/examples/optimized-appear/demos/Default.svelte
+++ b/docs/src/lib/examples/optimized-appear/demos/Default.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+    import { motion } from '@humanspeak/svelte-motion'
+
+    let replayId = $state(0)
+</script>
+
+<!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
+<div class="dk-demo-shell">
+    {#key replayId}
+        <motion.article
+            class="appear-card"
+            initial={{ opacity: 0, y: 32, scale: 0.9 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1] }}
+        >
+            <span class="rail"></span>
+            <h3>Hydrated cleanly</h3>
+            <p>Opacity and transform start before the component runtime claims the element.</p>
+        </motion.article>
+    {/key}
+
+    <button type="button" class="replay" onclick={() => (replayId += 1)}>Replay</button>
+</div>
+
+<style>
+    .dk-demo-shell {
+        min-height: 300px;
+        display: grid;
+        place-items: center;
+        gap: 1rem;
+        padding: 2rem;
+    }
+
+    :global(.appear-card) {
+        width: min(100%, 360px);
+        border: 1px solid rgba(125, 211, 252, 0.35);
+        border-radius: 8px;
+        padding: 1.4rem;
+        background: linear-gradient(135deg, rgba(8, 47, 73, 0.92), rgba(20, 83, 45, 0.74));
+        color: white;
+        box-shadow: 0 24px 70px rgba(0, 0, 0, 0.34);
+    }
+
+    :global(.appear-card h3) {
+        margin: 1rem 0 0.35rem;
+        font-size: 1.25rem;
+    }
+
+    :global(.appear-card p) {
+        margin: 0;
+        color: rgba(255, 255, 255, 0.78);
+        line-height: 1.55;
+    }
+
+    .rail {
+        display: block;
+        width: 76px;
+        height: 6px;
+        border-radius: 999px;
+        background: #7dd3fc;
+    }
+
+    .replay {
+        font-size: 12px;
+        padding: 4px 10px;
+        border-radius: 6px;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        background: transparent;
+        color: rgba(255, 255, 255, 0.7);
+        cursor: pointer;
+    }
+</style>

--- a/docs/src/lib/examples/optimized-appear/demos/Default.svelte
+++ b/docs/src/lib/examples/optimized-appear/demos/Default.svelte
@@ -1,25 +1,19 @@
 <script lang="ts">
     import { motion } from '@humanspeak/svelte-motion'
-
-    let replayId = $state(0)
 </script>
 
 <!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
 <div class="dk-demo-shell">
-    {#key replayId}
-        <motion.article
-            class="appear-card"
-            initial={{ opacity: 0, y: 32, scale: 0.9 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1] }}
-        >
-            <span class="rail"></span>
-            <h3>Hydrated cleanly</h3>
-            <p>Opacity and transform start before the component runtime claims the element.</p>
-        </motion.article>
-    {/key}
-
-    <button type="button" class="replay" onclick={() => (replayId += 1)}>Replay</button>
+    <motion.article
+        class="appear-card"
+        initial={{ opacity: 0, y: 32, scale: 0.9 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1] }}
+    >
+        <span class="rail"></span>
+        <h3>Hydrated cleanly</h3>
+        <p>Opacity and transform start before the component runtime claims the element.</p>
+    </motion.article>
 </div>
 
 <style>
@@ -58,15 +52,5 @@
         height: 6px;
         border-radius: 999px;
         background: #7dd3fc;
-    }
-
-    .replay {
-        font-size: 12px;
-        padding: 4px 10px;
-        border-radius: 6px;
-        border: 1px solid rgba(255, 255, 255, 0.12);
-        background: transparent;
-        color: rgba(255, 255, 255, 0.7);
-        cursor: pointer;
     }
 </style>

--- a/docs/src/routes/docs/optimized-appear/+page.svx
+++ b/docs/src/routes/docs/optimized-appear/+page.svx
@@ -1,0 +1,61 @@
+---
+title: Optimized appear
+description: Start SSR appear animations before hydration
+---
+
+<script>
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+    const seo = getSeoContext()
+    if (seo) {
+        seo.title = 'Optimized appear | Docs | Svelte Motion'
+        seo.description =
+            'Start server-rendered entrance animations before Svelte hydrates the motion runtime.'
+        seo.ogTitle = 'Optimized appear'
+        seo.ogTagline = 'SSR entrance animations without the flash'
+        seo.ogFeatures = ['SSR', 'Hydration', 'WAAPI', 'Appear handoff']
+        seo.ogSlug = 'docs-optimized-appear'
+    }
+</script>
+
+# Optimized appear
+
+Optimized appear starts mount animations from the server-rendered DOM before Svelte hydrates. It mirrors Framer Motion's `data-framer-appear-id` handoff: the SSR element receives an appear id, an inline bootstrap starts WAAPI opacity/transform animation, and the Svelte Motion runtime commits and continues from that visual state during hydration.
+
+```svelte
+<script>
+    import { motion } from '@humanspeak/svelte-motion'
+</script>
+
+<motion.div
+    initial={{ opacity: 0, y: 24, scale: 0.94 }}
+    animate={{ opacity: 1, y: 0, scale: 1 }}
+    transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
+/>
+```
+
+No additional prop is required. Svelte Motion enables optimized appear when all of these are true:
+
+- `initial` resolves to non-empty keyframes.
+- `animate` resolves to non-empty keyframes.
+- `initial={false}` is not set.
+- The enter animation includes WAAPI-friendly `opacity` and/or transform values.
+
+## Public helpers
+
+`startOptimizedAppearAnimation` is exported for low-level integrations that need to start a handoff animation manually.
+
+```ts
+import { optimizedAppearDataAttribute, startOptimizedAppearAnimation } from '@humanspeak/svelte-motion'
+
+element.setAttribute(optimizedAppearDataAttribute, 'hero')
+startOptimizedAppearAnimation(element, 'opacity', [0, 1], { duration: 0.4 })
+```
+
+Most applications should use declarative `motion.*` components instead of calling the helper directly.
+
+## Related
+
+- [API Reference](/docs/api-reference) — exported helpers and SSR behavior
+- [Tree Shaking](/docs/tree-shaking) — import only the animation surface you need
+- [Optimized appear example](/examples/optimized-appear) — live SSR handoff demo

--- a/docs/src/routes/docs/optimized-appear/+page.ts
+++ b/docs/src/routes/docs/optimized-appear/+page.ts
@@ -1,0 +1,11 @@
+import type { PageLoad } from './$types'
+
+/**
+ * Provides metadata for the optimized appear docs page.
+ *
+ * @returns Page title and description metadata.
+ */
+export const load: PageLoad = () => ({
+    title: 'Optimized appear',
+    description: 'Start SSR appear animations before hydration to avoid first-paint flashes.'
+})

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -72,6 +72,10 @@ const EXAMPLES: Record<string, ExampleEntry> = {
         title: 'Notifications Stack',
         description: 'Interactive notifications stack animation example using Svelte Motion.'
     },
+    'optimized-appear': {
+        title: 'Optimized appear',
+        description: 'Start SSR appear animations before Svelte hydrates the motion runtime.'
+    },
     'path-morphing': {
         title: 'Path Morphing',
         description: 'Interactive path morphing animation example using Svelte Motion.'

--- a/docs/src/routes/examples/optimized-appear/+page.svelte
+++ b/docs/src/routes/examples/optimized-appear/+page.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+    import {
+        CodeReferenceV2,
+        type DemoManifestEntry,
+        ExampleV2,
+        type ExampleSection,
+        formatSheetLabel
+    } from '@humanspeak/docs-kit'
+    import { Gauge, Sparkles } from '@lucide/svelte'
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import OptimizedAppearDefault from '$lib/examples/optimized-appear/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'Optimized appear' }
+        ]
+    }
+    if (seo) {
+        seo.title = 'Optimized appear | Examples | Svelte Motion'
+        seo.description =
+            'Use optimized appear animations to start SSR entrance motion before hydration.'
+        seo.ogTitle = 'Optimized appear'
+        seo.ogTagline = 'SSR entrance animations without the flash'
+        seo.ogFeatures = ['SSR', 'Hydration', 'WAAPI', 'Appear handoff']
+        seo.ogSlug = 'examples-optimized-appear'
+    }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
+
+    const sections: ExampleSection[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'SSR',
+            title: { prefix: 'start ', accent: 'before hydration', end: '.' },
+            description:
+                'The server renders the initial opacity/transform and an inline handoff script starts the same transition before Svelte Motion mounts.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'handoff', v: 'data-framer-appear-id' }],
+            sourceUrl: `${SOURCE_URL}optimized-appear/demos/Default.svelte`
+        }
+    ]
+</script>
+
+{#snippet defaultSection()}
+    <OptimizedAppearDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Gauge />
+            <span>
+                The optimized appear bootstrap uses WAAPI for opacity and transform so the first
+                visible frame already belongs to the entrance animation.
+            </span>
+        </li>
+        <li>
+            <Sparkles />
+            <span>
+                Hydration hands the animation back to the normal motion runtime using the upstream
+                <code>data-framer-appear-id</code> contract.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'optimized-appear-default',
+                label: 'Default.svelte',
+                ...manifest['optimized-appear/demos/Default.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel={formatSheetLabel(i, sections.length)}
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/optimized-appear/+page.ts
+++ b/docs/src/routes/examples/optimized-appear/+page.ts
@@ -1,0 +1,13 @@
+import type { PageLoad } from './$types'
+
+/**
+ * Provides metadata for the optimized appear examples page.
+ *
+ * @returns Page title and description metadata.
+ */
+export const load: PageLoad = async () => {
+    return {
+        title: 'Optimized appear',
+        description: 'Start SSR appear animations before Svelte hydrates the motion runtime.'
+    }
+}

--- a/e2e/_helpers/projection.ts
+++ b/e2e/_helpers/projection.ts
@@ -1,0 +1,19 @@
+export interface ProjectionDelta {
+    dx: number
+    dy: number
+    changed: boolean
+}
+
+export const parseProjectionDelta = (text: string | null): ProjectionDelta | null => {
+    const m = text?.match(/Δx=(-?[\d.]+)\s+Δy=(-?[\d.]+)\s+changed=(true|false)/)
+    if (!m) return null
+    return { dx: Number(m[1]), dy: Number(m[2]), changed: m[3] === 'true' }
+}
+
+export const isIdleDelta = (text: string | null): boolean => {
+    const delta = parseProjectionDelta(text)
+    return (
+        !!text?.includes('(no event yet)') ||
+        !!(delta && !delta.changed && Math.abs(delta.dx) < 0.5 && Math.abs(delta.dy) < 0.5)
+    )
+}

--- a/e2e/animate-presence/layout-button.spec.ts
+++ b/e2e/animate-presence/layout-button.spec.ts
@@ -22,6 +22,43 @@ type ButtonSample = {
     labelHeight: number
 }
 
+type ButtonBox = {
+    documentTop: number
+    height: number
+    text: string
+    width: number
+}
+
+type ShellBox = {
+    centerX: number
+    centerY: number
+    top: number
+}
+
+const sampleButtonBox = async (
+    page: import('@playwright/test').Page,
+    testIdPrefix: string
+): Promise<ButtonBox> =>
+    page.getByTestId(`${testIdPrefix}-button`).evaluate((button) => {
+        const rect = button.getBoundingClientRect()
+        return {
+            documentTop: rect.top + window.scrollY,
+            height: rect.height,
+            text: button.textContent?.trim() ?? '',
+            width: rect.width
+        }
+    })
+
+const sampleRollingShellBox = async (page: import('@playwright/test').Page): Promise<ShellBox> =>
+    page.getByTestId('rolling-button').evaluate((button) => {
+        const rect = button.getBoundingClientRect()
+        return {
+            centerX: rect.left + rect.width / 2,
+            centerY: rect.top + rect.height / 2,
+            top: rect.top
+        }
+    })
+
 const parseScaleX = (transform: string): number => {
     if (!transform || transform === 'none') return 1
     const matrix = transform.match(/^matrix\(([^)]+)\)$/)
@@ -169,7 +206,97 @@ const expectReadyCopyState = async (
     })
 }
 
+const expectReadableRollingState = async (
+    page: import('@playwright/test').Page,
+    state: 'copy' | 'copied'
+) => {
+    await expect
+        .poll(
+            async () =>
+                page.getByTestId('rolling-button').evaluate((button, expectedState) => {
+                    const buttonRect = button.getBoundingClientRect()
+                    const stateElement = button.querySelector<HTMLElement>(
+                        `[data-testid="rolling-${expectedState}-state"]`
+                    )
+                    if (!stateElement) return undefined
+
+                    const stateRect = stateElement.getBoundingClientRect()
+                    const stateStyle = getComputedStyle(stateElement)
+
+                    const sample = {
+                        opacity: Number.parseFloat(stateStyle.opacity),
+                        filter: stateStyle.filter,
+                        text: stateElement.textContent?.trim() ?? '',
+                        contained:
+                            stateRect.left >= buttonRect.left - 4 &&
+                            stateRect.right <= buttonRect.right + 4 &&
+                            stateRect.top >= buttonRect.top - 4 &&
+                            stateRect.bottom <= buttonRect.bottom + 4
+                    }
+
+                    return (
+                        sample.text.includes(expectedState) &&
+                        sample.opacity >= 0.99 &&
+                        sample.filter === 'blur(0px)' &&
+                        sample.contained
+                    )
+                }, state),
+            { message: `${state} should settle into a readable state`, timeout: 2200 }
+        )
+        .toBe(true)
+}
+
+const expectRollingShellAnchored = async (
+    page: import('@playwright/test').Page,
+    baseline: ShellBox,
+    label: string
+) => {
+    await expect
+        .poll(
+            async () => {
+                const current = await sampleRollingShellBox(page)
+                return (
+                    Math.abs(current.centerX - baseline.centerX) <= 1 &&
+                    Math.abs(current.centerY - baseline.centerY) <= 1 &&
+                    Math.abs(current.top - baseline.top) <= 1
+                )
+            },
+            { message: `${label} should not move the rolling button shell`, timeout: 1200 }
+        )
+        .toBe(true)
+}
+
 test.describe('AnimatePresence layout button dogfood', () => {
+    test('runs the interactive rolling copy control', async ({ page }) => {
+        await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+
+        const button = page.getByTestId('rolling-button')
+        await expect(button).toBeVisible()
+        await expect(button).toHaveAttribute('data-stage', 'copy')
+        await expectReadableRollingState(page, 'copy')
+
+        const copyWidth = await button.evaluate((element) => element.getBoundingClientRect().width)
+        const baselineShell = await sampleRollingShellBox(page)
+
+        await button.hover()
+        await expectRollingShellAnchored(page, baselineShell, 'hover')
+        await button.click()
+        await expect(button).toHaveAttribute('data-stage', 'copied', { timeout: 1200 })
+        await expect(page.getByTestId('rolling-copied-state')).toBeVisible()
+        await expectReadableRollingState(page, 'copied')
+        await expectRollingShellAnchored(page, baselineShell, 'click')
+
+        const copiedWidth = await button.evaluate(
+            (element) => element.getBoundingClientRect().width
+        )
+        expect(copiedWidth).toBeGreaterThan(copyWidth + 4)
+
+        await expect(button).toHaveAttribute('data-stage', 'copy', { timeout: 3000 })
+        await expect(page.getByTestId('rolling-copy-state')).toBeVisible()
+        await expectReadableRollingState(page, 'copy')
+        await expectRollingShellAnchored(page, baselineShell, 'reset')
+    })
+
     test('renders status icons as SVG instead of font glyphs', async ({ page }) => {
         await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
 
@@ -677,7 +804,21 @@ test.describe('AnimatePresence layout button dogfood', () => {
             )
             expect(readableCopiedSamples.length, prefix).toBeGreaterThan(5)
 
-            for (let i = 1; i < readableCopiedSamples.length; i += 1) {
+            // Wait mode can expose one handoff sample as the new label replaces
+            // the exiting label. This test guards the tracked label after that
+            // handoff; centering during the handoff is covered above.
+            const startIndex =
+                prefix === 'wait' &&
+                readableCopiedSamples.length > 1 &&
+                Math.abs(
+                    readableCopiedSamples[1].labelCenterX - readableCopiedSamples[0].labelCenterX
+                ) > 1
+                    ? 1
+                    : 0
+
+            expect(readableCopiedSamples.length - startIndex, prefix).toBeGreaterThan(5)
+
+            for (let i = startIndex + 1; i < readableCopiedSamples.length; i += 1) {
                 const movement = Math.abs(
                     readableCopiedSamples[i].labelCenterX -
                         readableCopiedSamples[i - 1].labelCenterX
@@ -865,6 +1006,81 @@ test.describe('AnimatePresence layout button dogfood', () => {
                 sample.labelText
             ).toBeLessThanOrEqual(1)
         }
+    })
+
+    test('restores button size after the page scrolls during layout animation', async ({
+        page
+    }) => {
+        const prefixes = ['wait', 'sync']
+
+        for (const prefix of prefixes) {
+            await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+            await page.evaluate(() => window.scrollTo(0, 0))
+
+            const button = page.getByTestId(`${prefix}-button`)
+            await expect(button).toBeVisible()
+            await expect(button).toHaveText('copy')
+            await expect(button).toHaveAttribute('data-is-loaded', 'ready', { timeout: 3000 })
+            await expectReadyCopyState(page, prefix)
+
+            const before = await sampleButtonBox(page, prefix)
+
+            await button.click()
+            await page.waitForTimeout(350)
+            await page.evaluate(() => window.scrollBy(0, 240))
+            await expect(button).toHaveText('copy', { timeout: prefix === 'wait' ? 9000 : 7000 })
+            await page.waitForFunction(
+                (testIdPrefix) => {
+                    const buttonElement = document.querySelector<HTMLElement>(
+                        `[data-testid="${testIdPrefix}-button"]`
+                    )
+                    return !buttonElement?.hasAttribute('data-layout-size-animation')
+                },
+                prefix,
+                { timeout: 3500 }
+            )
+
+            const after = await sampleButtonBox(page, prefix)
+            expect(after.text, prefix).toBe(before.text)
+            expect(Math.abs(after.documentTop - before.documentTop), prefix).toBeLessThanOrEqual(1)
+            expect(Math.abs(after.height - before.height), prefix).toBeLessThanOrEqual(1)
+            expect(Math.abs(after.width - before.width), prefix).toBeLessThanOrEqual(1)
+        }
+    })
+
+    test('wait mode settles copied size when release happens fully offscreen', async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 360 })
+        await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+        await page.evaluate(() => window.scrollTo(0, 0))
+
+        const button = page.getByTestId('wait-button')
+        await expect(button).toBeVisible()
+        await expect(button).toHaveText('copy')
+        await expect(button).toHaveAttribute('data-is-loaded', 'ready', { timeout: 3000 })
+        await expectReadyCopyState(page, 'wait')
+
+        const before = await sampleButtonBox(page, 'wait')
+
+        await button.click()
+        await page.waitForTimeout(150)
+        await button.evaluate((element) => {
+            const rect = element.getBoundingClientRect()
+            window.scrollBy(0, rect.bottom + 32)
+        })
+        await page.waitForFunction(() => {
+            const buttonElement = document.querySelector<HTMLElement>('[data-testid="wait-button"]')
+            return !!buttonElement && buttonElement.getBoundingClientRect().bottom <= 0
+        })
+        await expect(page.getByTestId('wait-copied-state')).not.toHaveAttribute(
+            'data-presence-wait-hidden',
+            'true',
+            { timeout: 4000 }
+        )
+        await page.evaluate(() => window.scrollTo(0, 0))
+
+        const returned = await sampleButtonBox(page, 'wait')
+        expect(returned.text).toBe('copied')
+        expect(returned.width).toBeGreaterThan(before.width + 4)
     })
 
     test('animates button width instead of snapping to the final size', async ({ page }) => {

--- a/e2e/animate-presence/layout-button.spec.ts
+++ b/e2e/animate-presence/layout-button.spec.ts
@@ -687,6 +687,186 @@ test.describe('AnimatePresence layout button dogfood', () => {
         }
     })
 
+    test('keeps sync shell anchored while both states are present', async ({ page }) => {
+        await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+
+        const button = page.getByTestId('sync-button')
+        await expect(button).toBeVisible()
+        await expect(button).toHaveText('copy')
+        await expect(button).toHaveAttribute('data-is-loaded', 'ready', { timeout: 3000 })
+        await expectReadyCopyState(page, 'sync')
+
+        await button.click()
+
+        const samples = await page.evaluate(async () => {
+            const samples: Array<{
+                buttonTop: number
+                buttonHeight: number
+                buttonCenterX: number
+                labelCenterX: number
+                labelOpacity: number
+                labelText: string
+            }> = []
+            const started = performance.now()
+
+            return await new Promise<typeof samples>((resolve) => {
+                const frame = () => {
+                    const buttonElement = document.querySelector<HTMLElement>(
+                        '[data-testid="sync-button"]'
+                    )
+                    const labelElement =
+                        buttonElement &&
+                        Array.from(buttonElement.querySelectorAll<HTMLElement>('.state'))
+                            .map((state) => {
+                                const style = getComputedStyle(state)
+                                const rect = state.getBoundingClientRect()
+                                return {
+                                    element: state,
+                                    opacity: Number.parseFloat(style.opacity),
+                                    rect,
+                                    visible:
+                                        style.display !== 'none' &&
+                                        state.getAttribute('data-presence-wait-hidden') !==
+                                            'true' &&
+                                        !state.closest('[data-clone="true"]') &&
+                                        rect.width > 0 &&
+                                        rect.height > 0
+                                }
+                            })
+                            .filter((state) => state.visible)
+                            .sort((a, b) => b.opacity - a.opacity)[0]
+
+                    if (buttonElement && labelElement) {
+                        const buttonRect = buttonElement.getBoundingClientRect()
+                        samples.push({
+                            buttonTop: buttonRect.top,
+                            buttonHeight: buttonRect.height,
+                            buttonCenterX: buttonRect.left + buttonRect.width / 2,
+                            labelCenterX: labelElement.rect.left + labelElement.rect.width / 2,
+                            labelOpacity: labelElement.opacity,
+                            labelText: labelElement.element.textContent?.trim() ?? ''
+                        })
+                    }
+
+                    if (performance.now() - started < 900) requestAnimationFrame(frame)
+                    else resolve(samples)
+                }
+                requestAnimationFrame(frame)
+            })
+        })
+
+        const visibleSamples = samples.filter((sample) => sample.labelOpacity > 0.2)
+        expect(visibleSamples.length).toBeGreaterThan(5)
+
+        for (let i = 1; i < visibleSamples.length; i += 1) {
+            const movement = Math.abs(visibleSamples[i].buttonTop - visibleSamples[i - 1].buttonTop)
+            expect(movement, `top jump at sample ${i}`).toBeLessThanOrEqual(1)
+        }
+
+        for (const sample of visibleSamples) {
+            expect(sample.buttonHeight, sample.labelText).toBeLessThanOrEqual(33)
+            expect(
+                Math.abs(sample.labelCenterX - sample.buttonCenterX),
+                sample.labelText
+            ).toBeLessThanOrEqual(1)
+        }
+    })
+
+    test('keeps sync shell anchored during reset', async ({ page }) => {
+        await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+
+        const button = page.getByTestId('sync-button')
+        await expect(button).toBeVisible()
+        await expect(button).toHaveText('copy')
+        await expect(button).toHaveAttribute('data-is-loaded', 'ready', { timeout: 3000 })
+        await expectReadyCopyState(page, 'sync')
+
+        await button.click()
+        await expect(page.getByTestId('sync-copied-state')).toBeVisible({ timeout: 300 })
+        await page.waitForTimeout(3100)
+
+        const samples = await page.evaluate(async () => {
+            const samples: Array<{
+                buttonCenterX: number
+                buttonHeight: number
+                buttonTop: number
+                buttonWidth: number
+                labelCenterX: number
+                labelOpacity: number
+                labelText: string
+            }> = []
+            const started = performance.now()
+
+            return await new Promise<typeof samples>((resolve) => {
+                const frame = () => {
+                    const buttonElement = document.querySelector<HTMLElement>(
+                        '[data-testid="sync-button"]'
+                    )
+                    const labelElement =
+                        buttonElement &&
+                        Array.from(buttonElement.querySelectorAll<HTMLElement>('.state'))
+                            .map((state) => {
+                                const style = getComputedStyle(state)
+                                const rect = state.getBoundingClientRect()
+                                return {
+                                    element: state,
+                                    opacity: Number.parseFloat(style.opacity),
+                                    rect,
+                                    visible:
+                                        style.display !== 'none' &&
+                                        state.getAttribute('data-presence-wait-hidden') !==
+                                            'true' &&
+                                        !state.closest('[data-clone="true"]') &&
+                                        rect.width > 0 &&
+                                        rect.height > 0
+                                }
+                            })
+                            .filter((state) => state.visible)
+                            .sort((a, b) => b.opacity - a.opacity)[0]
+
+                    if (buttonElement && labelElement) {
+                        const buttonRect = buttonElement.getBoundingClientRect()
+                        samples.push({
+                            buttonCenterX: buttonRect.left + buttonRect.width / 2,
+                            buttonHeight: buttonRect.height,
+                            buttonTop: buttonRect.top,
+                            buttonWidth: buttonRect.width,
+                            labelCenterX: labelElement.rect.left + labelElement.rect.width / 2,
+                            labelOpacity: labelElement.opacity,
+                            labelText: labelElement.element.textContent?.trim() ?? ''
+                        })
+                    }
+
+                    if (performance.now() - started < 900) requestAnimationFrame(frame)
+                    else resolve(samples)
+                }
+                requestAnimationFrame(frame)
+            })
+        })
+
+        const visibleSamples = samples.filter((sample) => sample.labelOpacity > 0.2)
+        expect(visibleSamples.length).toBeGreaterThan(5)
+
+        for (let i = 1; i < visibleSamples.length; i += 1) {
+            const topMovement = Math.abs(
+                visibleSamples[i].buttonTop - visibleSamples[i - 1].buttonTop
+            )
+            const centerMovement = Math.abs(
+                visibleSamples[i].labelCenterX - visibleSamples[i - 1].labelCenterX
+            )
+            expect(topMovement, `top jump at sample ${i}`).toBeLessThanOrEqual(1)
+            expect(centerMovement, `label jump at sample ${i}`).toBeLessThanOrEqual(1)
+        }
+
+        for (const sample of visibleSamples) {
+            expect(sample.buttonHeight, sample.labelText).toBeLessThanOrEqual(33)
+            expect(
+                Math.abs(sample.labelCenterX - sample.buttonCenterX),
+                sample.labelText
+            ).toBeLessThanOrEqual(1)
+        }
+    })
+
     test('animates button width instead of snapping to the final size', async ({ page }) => {
         await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
 

--- a/e2e/animate-presence/layout-button.spec.ts
+++ b/e2e/animate-presence/layout-button.spec.ts
@@ -1,0 +1,912 @@
+import { expect, test } from '@playwright/test'
+
+type ButtonSample = {
+    buttonText: string
+    hiddenWaitStates: number
+    labelClassName: string
+    buttonFontSize: string
+    buttonLineHeight: string
+    buttonColor: string
+    buttonBackgroundColor: string
+    buttonBorderColor: string
+    buttonAppearance: string
+    buttonOverflow: string
+    buttonTransform: string
+    labelFontSize: string
+    labelLineHeight: string
+    labelColor: string
+    labelOpacity: string
+    labelOverflow: string
+    labelTransform: string
+    labelWidth: number
+    labelHeight: number
+}
+
+const parseScaleX = (transform: string): number => {
+    if (!transform || transform === 'none') return 1
+    const matrix = transform.match(/^matrix\(([^)]+)\)$/)
+    if (!matrix) return 1
+    const [a] = matrix[1].split(',').map((value) => Number.parseFloat(value.trim()))
+    return Number.isFinite(a) ? a : 1
+}
+
+const visibleStateSelector = '.state:not([data-presence-wait-hidden="true"])'
+
+const sampleButton = async (
+    page: import('@playwright/test').Page,
+    testIdPrefix: string
+): Promise<ButtonSample> =>
+    page.getByTestId(`${testIdPrefix}-button`).evaluate((button) => {
+        const buttonElement = button as HTMLButtonElement
+        const labelElement =
+            Array.from(buttonElement.querySelectorAll<HTMLElement>('.state')).find((state) => {
+                const style = getComputedStyle(state)
+                const rect = state.getBoundingClientRect()
+                return (
+                    style.display !== 'none' &&
+                    state.getAttribute('data-presence-wait-hidden') !== 'true' &&
+                    !state.closest('[data-clone="true"]') &&
+                    rect.width > 0 &&
+                    rect.height > 0
+                )
+            }) ?? buttonElement.querySelector<HTMLElement>(visibleStateSelector)
+        if (!labelElement) throw new Error('missing label state')
+
+        const buttonStyle = getComputedStyle(buttonElement)
+        const labelStyle = getComputedStyle(labelElement)
+        const labelRect = labelElement.getBoundingClientRect()
+
+        return {
+            buttonText: buttonElement.textContent?.trim() ?? '',
+            hiddenWaitStates: buttonElement.querySelectorAll('[data-presence-wait-hidden="true"]')
+                .length,
+            labelClassName: labelElement.className,
+            buttonFontSize: buttonStyle.fontSize,
+            buttonLineHeight: buttonStyle.lineHeight,
+            buttonColor: buttonStyle.color,
+            buttonBackgroundColor: buttonStyle.backgroundColor,
+            buttonBorderColor: buttonStyle.borderColor,
+            buttonAppearance: buttonStyle.appearance,
+            buttonOverflow: buttonStyle.overflow,
+            buttonTransform: buttonStyle.transform,
+            labelFontSize: labelStyle.fontSize,
+            labelLineHeight: labelStyle.lineHeight,
+            labelColor: labelStyle.color,
+            labelOpacity: labelStyle.opacity,
+            labelOverflow: labelStyle.overflow,
+            labelTransform: labelStyle.transform,
+            labelWidth: labelRect.width,
+            labelHeight: labelRect.height
+        }
+    })
+
+const collectSamples = async (
+    page: import('@playwright/test').Page,
+    testIdPrefix: string,
+    durationMs: number
+): Promise<ButtonSample[]> =>
+    page.evaluate(
+        async ({ duration, prefix }) => {
+            const samples: ButtonSample[] = []
+            const started = performance.now()
+
+            const read = () => {
+                const buttonElement = document.querySelector<HTMLButtonElement>(
+                    `[data-testid="${prefix}-button"]`
+                )
+                const labelElement =
+                    buttonElement &&
+                    (Array.from(buttonElement.querySelectorAll<HTMLElement>('.state')).find(
+                        (state) => {
+                            const style = getComputedStyle(state)
+                            const rect = state.getBoundingClientRect()
+                            return (
+                                style.display !== 'none' &&
+                                state.getAttribute('data-presence-wait-hidden') !== 'true' &&
+                                !state.closest('[data-clone="true"]') &&
+                                rect.width > 0 &&
+                                rect.height > 0
+                            )
+                        }
+                    ) ??
+                        buttonElement.querySelector<HTMLElement>(
+                            '.state:not([data-presence-wait-hidden="true"])'
+                        ))
+                if (!buttonElement || !labelElement) return
+
+                const buttonStyle = getComputedStyle(buttonElement)
+                const labelStyle = getComputedStyle(labelElement)
+                const labelRect = labelElement.getBoundingClientRect()
+                samples.push({
+                    buttonText: buttonElement.textContent?.trim() ?? '',
+                    hiddenWaitStates: buttonElement.querySelectorAll(
+                        '[data-presence-wait-hidden="true"]'
+                    ).length,
+                    labelClassName: labelElement.className,
+                    buttonFontSize: buttonStyle.fontSize,
+                    buttonLineHeight: buttonStyle.lineHeight,
+                    buttonColor: buttonStyle.color,
+                    buttonBackgroundColor: buttonStyle.backgroundColor,
+                    buttonBorderColor: buttonStyle.borderColor,
+                    buttonAppearance: buttonStyle.appearance,
+                    buttonOverflow: buttonStyle.overflow,
+                    buttonTransform: buttonStyle.transform,
+                    labelFontSize: labelStyle.fontSize,
+                    labelLineHeight: labelStyle.lineHeight,
+                    labelColor: labelStyle.color,
+                    labelOpacity: labelStyle.opacity,
+                    labelOverflow: labelStyle.overflow,
+                    labelTransform: labelStyle.transform,
+                    labelWidth: labelRect.width,
+                    labelHeight: labelRect.height
+                })
+            }
+
+            return new Promise<ButtonSample[]>((resolve) => {
+                const frame = () => {
+                    read()
+                    if (performance.now() - started < duration) {
+                        requestAnimationFrame(frame)
+                    } else {
+                        resolve(samples)
+                    }
+                }
+                requestAnimationFrame(frame)
+            })
+        },
+        { duration: durationMs, prefix: testIdPrefix }
+    )
+
+const expectReadyCopyState = async (
+    page: import('@playwright/test').Page,
+    testIdPrefix: string
+) => {
+    const copyState = page.getByTestId(`${testIdPrefix}-copy-state`)
+    await expect(copyState).toBeVisible({ timeout: 3000 })
+    await expect(copyState).toHaveAttribute('data-is-loaded', 'ready', { timeout: 3000 })
+    await expect(copyState).not.toHaveAttribute('data-presence-wait-hidden', 'true', {
+        timeout: 3000
+    })
+}
+
+test.describe('AnimatePresence layout button dogfood', () => {
+    test('renders status icons as SVG instead of font glyphs', async ({ page }) => {
+        await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+
+        const button = page.getByTestId('wait-button')
+        await expect(button).toBeVisible()
+        await expect(button).toHaveText('copy')
+        await expectReadyCopyState(page, 'wait')
+
+        await expect(button.locator('svg[data-testid="wait-copy-icon"]')).toBeVisible()
+        expect(
+            await button
+                .locator('svg[data-testid="wait-copy-icon"]')
+                .evaluate((icon) => icon.textContent)
+        ).toBe('')
+
+        await button.click()
+        await expect(page.getByTestId('wait-copied-state')).not.toHaveAttribute(
+            'data-presence-wait-hidden',
+            'true',
+            { timeout: 2500 }
+        )
+        await expect(button).toHaveText('copied')
+        await expect(button.locator('svg[data-testid="wait-copied-icon"]')).toBeVisible()
+        expect(
+            await button
+                .locator('svg[data-testid="wait-copied-icon"]')
+                .evaluate((icon) => icon.textContent)
+        ).toBe('')
+    })
+
+    test('keeps interactive paint metrics on whole pixels', async ({ page }) => {
+        const prefixes = ['wait', 'sync', 'pop-layout']
+
+        for (const prefix of prefixes) {
+            await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+
+            const button = page.getByTestId(`${prefix}-button`)
+            await expect(button).toBeVisible()
+            await expect(button).toHaveText('copy')
+            await expect(button).toHaveAttribute('data-is-loaded', 'ready', { timeout: 3000 })
+            await expectReadyCopyState(page, prefix)
+
+            const readMetrics = async (label: string) =>
+                button.evaluate((buttonElement, snapshotLabel) => {
+                    const stateElement =
+                        Array.from(buttonElement.querySelectorAll<HTMLElement>('.state')).find(
+                            (state) => {
+                                const style = getComputedStyle(state)
+                                const rect = state.getBoundingClientRect()
+                                return (
+                                    style.display !== 'none' &&
+                                    state.getAttribute('data-presence-wait-hidden') !== 'true' &&
+                                    !state.closest('[data-clone="true"]') &&
+                                    rect.width > 0 &&
+                                    rect.height > 0
+                                )
+                            }
+                        ) ??
+                        buttonElement.querySelector<HTMLElement>(
+                            '.state:not([data-presence-wait-hidden="true"])'
+                        )
+                    if (!stateElement) throw new Error('missing visible state')
+
+                    const buttonStyle = getComputedStyle(buttonElement)
+                    const stateStyle = getComputedStyle(stateElement)
+                    const buttonRect = buttonElement.getBoundingClientRect()
+                    const stateRect = stateElement.getBoundingClientRect()
+
+                    return {
+                        label: snapshotLabel,
+                        buttonHeight: buttonRect.height,
+                        buttonLineHeight: Number.parseFloat(buttonStyle.lineHeight),
+                        stateHeight: stateRect.height,
+                        stateLineHeight: Number.parseFloat(stateStyle.lineHeight),
+                        stateText: stateElement.textContent?.trim() ?? ''
+                    }
+                }, label)
+
+            const samples = [await readMetrics('idle')]
+            expect(await sampleButton(page, prefix)).toMatchObject({
+                buttonAppearance: 'none'
+            })
+
+            await button.hover()
+            await button.focus()
+            samples.push(await readMetrics('hover-focus'))
+
+            await button.click()
+            await expect(page.getByTestId(`${prefix}-copied-state`)).toBeVisible({
+                timeout: 3000
+            })
+            await page.waitForFunction((testIdPrefix) => {
+                const buttonElement = document.querySelector<HTMLElement>(
+                    `[data-testid="${testIdPrefix}-button"]`
+                )
+                return buttonElement && buttonElement.style.width === ''
+            }, prefix)
+            samples.push(await readMetrics('copied-settled'))
+
+            const resetTimeout = prefix === 'wait' ? 6200 : 4200
+            await expect(button).toHaveText('copy', { timeout: resetTimeout })
+            await expect(page.getByTestId(`${prefix}-copy-state`)).toBeVisible({
+                timeout: 3000
+            })
+            await page.waitForFunction((testIdPrefix) => {
+                const buttonElement = document.querySelector<HTMLElement>(
+                    `[data-testid="${testIdPrefix}-button"]`
+                )
+                return buttonElement && buttonElement.style.width === ''
+            }, prefix)
+            samples.push(await readMetrics('reset-settled'))
+
+            for (const sample of samples) {
+                for (const [metric, value] of Object.entries(sample)) {
+                    if (typeof value !== 'number') continue
+
+                    expect(
+                        Math.abs(value - Math.round(value)),
+                        `${prefix} ${sample.label} ${metric}=${value}`
+                    ).toBeLessThanOrEqual(0.01)
+                }
+            }
+        }
+    })
+
+    test('keeps copy label typography stable during layout/presence swap', async ({ page }) => {
+        await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+
+        const button = page.getByTestId('wait-button')
+        await expect(button).toBeVisible()
+        await expect(button).toHaveText('copy')
+        await expect(button).toHaveAttribute('data-is-loaded', 'ready', { timeout: 3000 })
+        await expectReadyCopyState(page, 'wait')
+
+        const baseline = await sampleButton(page, 'wait')
+        const copyStateColor = baseline.labelColor
+        const copyShellBorderColor = baseline.buttonBorderColor
+        const copyShellBackgroundColor = baseline.buttonBackgroundColor
+        const baselineFontSize = Number.parseFloat(baseline.labelFontSize)
+        const baselineLineHeight = Number.parseFloat(baseline.labelLineHeight)
+        expect(baselineLineHeight).toBeGreaterThanOrEqual(baselineFontSize * 1.15)
+        expect(baseline.buttonOverflow).not.toBe('hidden')
+        expect(baseline.labelOverflow).not.toBe('hidden')
+        await button.click()
+        const clickSamples = await collectSamples(page, 'wait', 620)
+
+        await expect(button).toHaveText('copied', { timeout: 2500 })
+        await expect(page.getByTestId('wait-copied-state')).toBeVisible({ timeout: 2500 })
+        const copiedSample = await sampleButton(page, 'wait')
+        const copiedStateColor = copiedSample.labelColor
+        const copiedShellBorderColor = copiedSample.buttonBorderColor
+        const copiedShellBackgroundColor = copiedSample.buttonBackgroundColor
+        await page.waitForTimeout(2200)
+        await expect(button).toHaveText('copied')
+        await page.waitForTimeout(3300)
+        const resetSamples = await collectSamples(page, 'wait', 620)
+
+        const samples = [...clickSamples, ...resetSamples]
+        expect(samples.length).toBeGreaterThan(5)
+
+        for (const sample of samples) {
+            expect(sample.buttonFontSize).toBe(baseline.buttonFontSize)
+            expect(sample.buttonLineHeight).toBe(baseline.buttonLineHeight)
+            expect(sample.labelFontSize).toBe(baseline.labelFontSize)
+            expect(sample.labelLineHeight).toBe(baseline.labelLineHeight)
+            expect(sample.buttonOverflow).not.toBe('hidden')
+            expect(sample.labelOverflow).not.toBe('hidden')
+
+            // Layout descendants should keep an effective glyph scale of 1.
+            // The implementation can get there via parent FLIP scale with
+            // correction or by animating the parent box size directly.
+            const effectiveLabelScale =
+                parseScaleX(sample.buttonTransform) * parseScaleX(sample.labelTransform)
+            expect(Math.abs(effectiveLabelScale - 1)).toBeLessThanOrEqual(0.001)
+
+            // Text state colors shouldn't be inherited from the shell state.
+            // Otherwise the outgoing "copy" label flashes accent blue as soon
+            // as the parent receives the copied class.
+            if (sample.labelClassName.includes('copy-state')) {
+                expect(sample.labelColor).toBe(copyStateColor)
+                expect(sample.buttonBorderColor).toBe(copyShellBorderColor)
+                expect(sample.buttonBackgroundColor).toBe(copyShellBackgroundColor)
+            }
+            if (sample.labelClassName.includes('copied-state')) {
+                expect(sample.labelColor).toBe(copiedStateColor)
+                expect(sample.buttonBorderColor).toBe(copiedShellBorderColor)
+                expect(sample.buttonBackgroundColor).toBe(copiedShellBackgroundColor)
+            }
+
+            if (
+                sample.labelClassName.includes('copy-state') &&
+                Number.parseFloat(sample.labelOpacity) > 0.2
+            ) {
+                expect(Math.abs(parseScaleX(sample.labelTransform) - 1)).toBeLessThanOrEqual(0.02)
+            }
+
+            expect(sample.labelWidth).toBeGreaterThan(0)
+            expect(sample.labelHeight).toBeGreaterThan(0)
+        }
+    })
+
+    test('keeps the readable label fully opaque during the swap', async ({ page }) => {
+        await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+
+        const button = page.getByTestId('wait-button')
+        await expect(button).toBeVisible()
+        await expect(button).toHaveText('copy')
+        await expect(button).toHaveAttribute('data-is-loaded', 'ready', { timeout: 3000 })
+        await expectReadyCopyState(page, 'wait')
+
+        await button.click()
+
+        const samples = await page.evaluate(async () => {
+            const samples: Array<{ opacity: number; text: string; className: string }> = []
+            const started = performance.now()
+
+            return await new Promise<typeof samples>((resolve) => {
+                const frame = () => {
+                    const button = document.querySelector<HTMLElement>(
+                        '[data-testid="wait-button"]'
+                    )
+                    const buttonRect = button?.getBoundingClientRect()
+                    const states = Array.from(
+                        document.querySelectorAll<HTMLElement>('.state, .copy-button')
+                    )
+                    const visibleState = states.find((state) => {
+                        const style = getComputedStyle(state)
+                        const rect = state.getBoundingClientRect()
+                        return (
+                            buttonRect &&
+                            style.display !== 'none' &&
+                            style.visibility !== 'hidden' &&
+                            rect.width > 0 &&
+                            rect.height > 0 &&
+                            rect.right >= buttonRect.left - 4 &&
+                            rect.left <= buttonRect.right + 4 &&
+                            rect.bottom >= buttonRect.top - 4 &&
+                            rect.top <= buttonRect.bottom + 4
+                        )
+                    })
+
+                    if (visibleState) {
+                        const style = getComputedStyle(visibleState)
+                        samples.push({
+                            opacity: Number.parseFloat(style.opacity),
+                            text: visibleState.textContent?.trim() ?? '',
+                            className: visibleState.className
+                        })
+                    }
+
+                    if (performance.now() - started < 1700) requestAnimationFrame(frame)
+                    else resolve(samples)
+                }
+                requestAnimationFrame(frame)
+            })
+        })
+        expect(samples.length).toBeGreaterThan(5)
+
+        for (const sample of samples) {
+            expect(
+                sample.opacity,
+                `${sample.text} ${sample.className} opacity`
+            ).toBeGreaterThanOrEqual(0.99)
+        }
+    })
+
+    test('keeps copy label contained during slow layout animation', async ({ page }) => {
+        const prefixes = ['wait', 'sync', 'pop-layout']
+
+        for (const prefix of prefixes) {
+            await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+
+            const button = page.getByTestId(`${prefix}-button`)
+            await expect(button).toBeVisible()
+            await expect(button).toHaveText('copy')
+            await expect(button).toHaveAttribute('data-is-loaded', 'ready', { timeout: 3000 })
+            await expectReadyCopyState(page, prefix)
+
+            await button.click()
+
+            const samples = await page.evaluate(async (testIdPrefix) => {
+                const samples: Array<{
+                    buttonRect: { left: number; right: number; top: number; bottom: number }
+                    stateRect: { left: number; right: number; top: number; bottom: number }
+                    stateOpacity: number
+                    stateText: string
+                }> = []
+                const started = performance.now()
+
+                return await new Promise<typeof samples>((resolve) => {
+                    const frame = () => {
+                        const buttonElement = document.querySelector<HTMLElement>(
+                            `[data-testid="${testIdPrefix}-button"]`
+                        )
+                        const stateElement =
+                            buttonElement &&
+                            Array.from(buttonElement.querySelectorAll<HTMLElement>('.state')).find(
+                                (state) => {
+                                    const style = getComputedStyle(state)
+                                    const rect = state.getBoundingClientRect()
+                                    return (
+                                        style.display !== 'none' &&
+                                        state.getAttribute('data-presence-wait-hidden') !==
+                                            'true' &&
+                                        !state.closest('[data-clone="true"]') &&
+                                        rect.width > 0 &&
+                                        rect.height > 0
+                                    )
+                                }
+                            )
+                        if (buttonElement && stateElement) {
+                            const buttonRect = buttonElement.getBoundingClientRect()
+                            const stateRect = stateElement.getBoundingClientRect()
+                            const stateStyle = getComputedStyle(stateElement)
+                            samples.push({
+                                buttonRect: {
+                                    left: buttonRect.left,
+                                    right: buttonRect.right,
+                                    top: buttonRect.top,
+                                    bottom: buttonRect.bottom
+                                },
+                                stateRect: {
+                                    left: stateRect.left,
+                                    right: stateRect.right,
+                                    top: stateRect.top,
+                                    bottom: stateRect.bottom
+                                },
+                                stateOpacity: Number.parseFloat(stateStyle.opacity),
+                                stateText: stateElement.textContent?.trim() ?? ''
+                            })
+                        }
+
+                        if (performance.now() - started < 3600) requestAnimationFrame(frame)
+                        else resolve(samples)
+                    }
+                    requestAnimationFrame(frame)
+                })
+            }, prefix)
+
+            const tolerance = prefix === 'sync' ? 8 : 1
+            const visibleSamples = samples.filter((sample) => sample.stateOpacity > 0.2)
+            expect(visibleSamples.length, prefix).toBeGreaterThan(5)
+
+            for (const sample of visibleSamples) {
+                expect(sample.stateRect.left, prefix).toBeGreaterThanOrEqual(
+                    sample.buttonRect.left - tolerance
+                )
+                expect(sample.stateRect.right, prefix).toBeLessThanOrEqual(
+                    sample.buttonRect.right + tolerance
+                )
+                expect(sample.stateRect.top, prefix).toBeGreaterThanOrEqual(
+                    sample.buttonRect.top - tolerance
+                )
+                expect(sample.stateRect.bottom, prefix).toBeLessThanOrEqual(
+                    sample.buttonRect.bottom + tolerance
+                )
+            }
+        }
+    })
+
+    test('keeps the readable active label visually centered during the swap', async ({ page }) => {
+        const prefixes = ['wait', 'sync', 'pop-layout']
+
+        for (const prefix of prefixes) {
+            await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+
+            const button = page.getByTestId(`${prefix}-button`)
+            await expect(button).toBeVisible()
+            await expect(button).toHaveText('copy')
+            await expect(button).toHaveAttribute('data-is-loaded', 'ready', { timeout: 3000 })
+            await expectReadyCopyState(page, prefix)
+
+            await button.click()
+
+            const samples = await page.evaluate(async (testIdPrefix) => {
+                const samples: Array<{
+                    buttonWidth: number
+                    labelWidth: number
+                    labelOpacity: number
+                    labelText: string
+                    centerDelta: number
+                    leftInset: number
+                    rightInset: number
+                }> = []
+                const started = performance.now()
+
+                return await new Promise<typeof samples>((resolve) => {
+                    const frame = () => {
+                        const buttonElement = document.querySelector<HTMLElement>(
+                            `[data-testid="${testIdPrefix}-button"]`
+                        )
+                        const labelElements = buttonElement
+                            ? Array.from(buttonElement.querySelectorAll<HTMLElement>('.state'))
+                            : []
+
+                        for (const labelElement of labelElements) {
+                            const style = getComputedStyle(labelElement)
+                            const labelRect = labelElement.getBoundingClientRect()
+                            if (
+                                style.display === 'none' ||
+                                labelElement.getAttribute('data-presence-wait-hidden') === 'true' ||
+                                labelElement.closest('[data-clone="true"]') ||
+                                labelRect.width <= 0 ||
+                                labelRect.height <= 0
+                            ) {
+                                continue
+                            }
+
+                            const buttonRect = buttonElement!.getBoundingClientRect()
+                            samples.push({
+                                buttonWidth: buttonRect.width,
+                                labelWidth: labelRect.width,
+                                labelOpacity: Number.parseFloat(style.opacity),
+                                labelText: labelElement.textContent?.trim() ?? '',
+                                centerDelta:
+                                    labelRect.left +
+                                    labelRect.width / 2 -
+                                    (buttonRect.left + buttonRect.width / 2),
+                                leftInset: labelRect.left - buttonRect.left,
+                                rightInset: buttonRect.right - labelRect.right
+                            })
+                        }
+
+                        if (performance.now() - started < 3600) requestAnimationFrame(frame)
+                        else resolve(samples)
+                    }
+                    requestAnimationFrame(frame)
+                })
+            }, prefix)
+
+            const readableCopiedSamples = samples.filter(
+                (sample) => sample.labelText.includes('copied') && sample.labelOpacity > 0.2
+            )
+            expect(readableCopiedSamples.length, prefix).toBeGreaterThan(5)
+
+            for (const sample of readableCopiedSamples) {
+                expect(Math.abs(sample.centerDelta), prefix).toBeLessThanOrEqual(1)
+                expect(Math.abs(sample.leftInset - sample.rightInset), prefix).toBeLessThanOrEqual(
+                    1
+                )
+            }
+        }
+    })
+
+    test('moves the readable active label without one-frame jumps', async ({ page }) => {
+        const prefixes = ['wait', 'sync', 'pop-layout']
+
+        for (const prefix of prefixes) {
+            await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+
+            const button = page.getByTestId(`${prefix}-button`)
+            await expect(button).toBeVisible()
+            await expect(button).toHaveText('copy')
+            await expect(button).toHaveAttribute('data-is-loaded', 'ready', { timeout: 3000 })
+            await expectReadyCopyState(page, prefix)
+
+            await button.click()
+
+            const samples = await page.evaluate(async (testIdPrefix) => {
+                const samples: Array<{
+                    labelCenterX: number
+                    labelOpacity: number
+                    labelText: string
+                }> = []
+                const started = performance.now()
+
+                return await new Promise<typeof samples>((resolve) => {
+                    const frame = () => {
+                        const buttonElement = document.querySelector<HTMLElement>(
+                            `[data-testid="${testIdPrefix}-button"]`
+                        )
+                        const labelElements = buttonElement
+                            ? Array.from(buttonElement.querySelectorAll<HTMLElement>('.state'))
+                            : []
+
+                        for (const labelElement of labelElements) {
+                            const style = getComputedStyle(labelElement)
+                            const labelRect = labelElement.getBoundingClientRect()
+                            if (
+                                style.display === 'none' ||
+                                labelElement.getAttribute('data-presence-wait-hidden') === 'true' ||
+                                labelElement.closest('[data-clone="true"]') ||
+                                labelRect.width <= 0 ||
+                                labelRect.height <= 0
+                            ) {
+                                continue
+                            }
+
+                            samples.push({
+                                labelCenterX: labelRect.left + labelRect.width / 2,
+                                labelOpacity: Number.parseFloat(style.opacity),
+                                labelText: labelElement.textContent?.trim() ?? ''
+                            })
+                        }
+
+                        if (performance.now() - started < 3600) requestAnimationFrame(frame)
+                        else resolve(samples)
+                    }
+                    requestAnimationFrame(frame)
+                })
+            }, prefix)
+
+            const readableCopiedSamples = samples.filter(
+                (sample) => sample.labelText.includes('copied') && sample.labelOpacity > 0.2
+            )
+            expect(readableCopiedSamples.length, prefix).toBeGreaterThan(5)
+
+            for (let i = 1; i < readableCopiedSamples.length; i += 1) {
+                const movement = Math.abs(
+                    readableCopiedSamples[i].labelCenterX -
+                        readableCopiedSamples[i - 1].labelCenterX
+                )
+                expect(movement, prefix).toBeLessThanOrEqual(1)
+            }
+        }
+    })
+
+    test('animates button width instead of snapping to the final size', async ({ page }) => {
+        await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+
+        const button = page.getByTestId('wait-button')
+        await expect(button).toBeVisible()
+        await expect(button).toHaveText('copy')
+        await expect(button).toHaveAttribute('data-is-loaded', 'ready', { timeout: 3000 })
+        await expectReadyCopyState(page, 'wait')
+
+        const baselineWidth = await button.evaluate(
+            (element) => element.getBoundingClientRect().width
+        )
+
+        await button.click()
+        await expect(page.getByTestId('wait-copied-state')).not.toHaveAttribute(
+            'data-presence-wait-hidden',
+            'true',
+            { timeout: 2500 }
+        )
+
+        const samples = await page.evaluate(async () => {
+            const buttonElement = document.querySelector<HTMLElement>('[data-testid="wait-button"]')
+            if (!buttonElement) throw new Error('missing wait button')
+
+            const widths: number[] = []
+            const started = performance.now()
+
+            return await new Promise<number[]>((resolve) => {
+                const frame = () => {
+                    widths.push(buttonElement.getBoundingClientRect().width)
+                    if (performance.now() - started < 2600) requestAnimationFrame(frame)
+                    else resolve(widths)
+                }
+                requestAnimationFrame(frame)
+            })
+        })
+
+        await page.waitForFunction(() => {
+            const buttonElement = document.querySelector<HTMLElement>('[data-testid="wait-button"]')
+            return buttonElement && buttonElement.style.width === ''
+        })
+
+        const settledWidth = await button.evaluate(
+            (element) => element.getBoundingClientRect().width
+        )
+        expect(settledWidth).toBeGreaterThan(baselineWidth + 4)
+
+        const intermediateWidths = samples.filter(
+            (width) => width > baselineWidth + 1 && width < settledWidth - 1
+        )
+        expect(intermediateWidths.length).toBeGreaterThan(3)
+        expect(Math.max(...samples)).toBeLessThanOrEqual(settledWidth + 2)
+    })
+
+    test('keeps wait-mode copied label at natural scale without width reversal', async ({
+        page
+    }) => {
+        await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+
+        const button = page.getByTestId('wait-button')
+        await expect(button).toBeVisible()
+        await expect(button).toHaveText('copy')
+        await expect(button).toHaveAttribute('data-is-loaded', 'ready', { timeout: 3000 })
+        await expectReadyCopyState(page, 'wait')
+
+        const baselineWidth = await button.evaluate(
+            (element) => element.getBoundingClientRect().width
+        )
+
+        await button.click()
+        await expect(page.getByTestId('wait-copied-state')).not.toHaveAttribute(
+            'data-presence-wait-hidden',
+            'true',
+            { timeout: 2500 }
+        )
+
+        const samples = await page.evaluate(async () => {
+            type WidthSample = {
+                buttonWidth: number
+                buttonCenterX: number
+                buttonScaleX: number
+                labelCenterX: number
+                labelScaleX: number
+                labelOpacity: number
+                labelText: string
+            }
+
+            const parseScaleX = (transform: string): number => {
+                if (!transform || transform === 'none') return 1
+                const matrix = transform.match(/^matrix\(([^)]+)\)$/)
+                if (!matrix) return 1
+                const [a] = matrix[1].split(',').map((value) => Number.parseFloat(value.trim()))
+                return Number.isFinite(a) ? a : 1
+            }
+
+            const samples: WidthSample[] = []
+            const started = performance.now()
+
+            return await new Promise<WidthSample[]>((resolve) => {
+                const frame = () => {
+                    const buttonElement = document.querySelector<HTMLElement>(
+                        '[data-testid="wait-button"]'
+                    )
+                    const labelElement =
+                        buttonElement &&
+                        Array.from(buttonElement.querySelectorAll<HTMLElement>('.state')).find(
+                            (state) => {
+                                const style = getComputedStyle(state)
+                                const rect = state.getBoundingClientRect()
+                                return (
+                                    style.display !== 'none' &&
+                                    state.getAttribute('data-presence-wait-hidden') !== 'true' &&
+                                    !state.closest('[data-clone="true"]') &&
+                                    rect.width > 0 &&
+                                    rect.height > 0
+                                )
+                            }
+                        )
+
+                    if (buttonElement && labelElement) {
+                        const buttonStyle = getComputedStyle(buttonElement)
+                        const labelStyle = getComputedStyle(labelElement)
+                        const buttonRect = buttonElement.getBoundingClientRect()
+                        const labelRect = labelElement.getBoundingClientRect()
+                        samples.push({
+                            buttonWidth: buttonRect.width,
+                            buttonCenterX: buttonRect.left + buttonRect.width / 2,
+                            buttonScaleX: parseScaleX(buttonStyle.transform),
+                            labelCenterX: labelRect.left + labelRect.width / 2,
+                            labelScaleX: parseScaleX(labelStyle.transform),
+                            labelOpacity: Number.parseFloat(labelStyle.opacity),
+                            labelText: labelElement.textContent?.trim() ?? ''
+                        })
+                    }
+
+                    if (performance.now() - started < 3200) requestAnimationFrame(frame)
+                    else resolve(samples)
+                }
+                requestAnimationFrame(frame)
+            })
+        })
+
+        const visibleCopiedSamples = samples.filter(
+            (sample) => sample.labelText.includes('copied') && sample.labelOpacity > 0.2
+        )
+        expect(visibleCopiedSamples.length).toBeGreaterThan(10)
+
+        for (const sample of visibleCopiedSamples) {
+            expect(Math.abs(sample.buttonScaleX * sample.labelScaleX - 1)).toBeLessThanOrEqual(
+                0.001
+            )
+        }
+
+        const opaqueCopiedSamples = visibleCopiedSamples.filter(
+            (sample) => sample.labelOpacity >= 0.99
+        )
+        expect(opaqueCopiedSamples.length).toBeGreaterThan(5)
+
+        for (const sample of opaqueCopiedSamples) {
+            expect(Math.abs(sample.labelCenterX - sample.buttonCenterX)).toBeLessThanOrEqual(1)
+        }
+
+        const grownSamples = visibleCopiedSamples.filter(
+            (sample) => sample.buttonWidth > baselineWidth + 2
+        )
+        expect(grownSamples.length).toBeGreaterThan(5)
+
+        let largestSeenWidth = baselineWidth
+        for (const sample of visibleCopiedSamples) {
+            if (sample.buttonWidth > largestSeenWidth) {
+                largestSeenWidth = sample.buttonWidth
+            }
+            expect(sample.buttonWidth).toBeGreaterThanOrEqual(largestSeenWidth - 1)
+        }
+
+        const maxWidth = Math.max(...grownSamples.map((sample) => sample.buttonWidth))
+        const finalWidth = grownSamples.at(-1)?.buttonWidth ?? 0
+        expect(finalWidth).toBeGreaterThanOrEqual(maxWidth - 1)
+    })
+
+    test('coordinates layout participation by presence mode', async ({ page }) => {
+        await page.goto('/tests/animate-presence/layout-button?@isPlaywright=true')
+
+        const waitButton = page.getByTestId('wait-button')
+        const syncButton = page.getByTestId('sync-button')
+        const popLayoutButton = page.getByTestId('pop-layout-button')
+
+        await expect(waitButton).toHaveAttribute('data-layout', 'true', { timeout: 3000 })
+        await expect(syncButton).toHaveAttribute('data-layout', 'true')
+        await expect(popLayoutButton).toHaveAttribute('data-layout', 'true')
+
+        await waitButton.click()
+        await expect(page.getByTestId('wait-copied-state')).toHaveAttribute(
+            'data-presence-wait-hidden',
+            'true',
+            { timeout: 300 }
+        )
+        await expect(page.getByTestId('wait-copied-state')).not.toHaveAttribute(
+            'data-presence-wait-hidden',
+            'true',
+            { timeout: 2500 }
+        )
+
+        await syncButton.click()
+        await expect(page.getByTestId('sync-copied-state')).not.toHaveAttribute(
+            'data-presence-wait-hidden',
+            'true',
+            { timeout: 300 }
+        )
+        await expect(page.getByTestId('sync-button')).toContainText('copied', { timeout: 300 })
+
+        await popLayoutButton.click()
+        await expect(page.getByTestId('pop-layout-copied-state')).not.toHaveAttribute(
+            'data-presence-wait-hidden',
+            'true',
+            { timeout: 300 }
+        )
+        await expect(page.getByTestId('pop-layout-button')).toContainText('copied', {
+            timeout: 300
+        })
+        await expect(page.locator('[data-presence-placeholder="true"]')).toHaveCount(0)
+    })
+})

--- a/e2e/animate-presence/layout-button.spec.ts
+++ b/e2e/animate-presence/layout-button.spec.ts
@@ -286,10 +286,16 @@ test.describe('AnimatePresence layout button dogfood', () => {
         await expectReadableRollingState(page, 'copied')
         await expectRollingShellAnchored(page, baselineShell, 'click')
 
-        const copiedWidth = await button.evaluate(
-            (element) => element.getBoundingClientRect().width
-        )
-        expect(copiedWidth).toBeGreaterThan(copyWidth + 4)
+        await expect
+            .poll(
+                async () =>
+                    button.evaluate((element) => {
+                        const rect = element.getBoundingClientRect()
+                        return rect.width
+                    }),
+                { message: 'copied state should grow the shell wider than copy', timeout: 1200 }
+            )
+            .toBeGreaterThan(copyWidth + 4)
 
         await expect(button).toHaveAttribute('data-stage', 'copy', { timeout: 3000 })
         await expect(page.getByTestId('rolling-copy-state')).toBeVisible()

--- a/e2e/drag/settle-cancel.spec.ts
+++ b/e2e/drag/settle-cancel.spec.ts
@@ -50,18 +50,22 @@ test.describe('drag/settle-cancel', () => {
         expect(midTranslate).toBeGreaterThan(10)
         expect(midTranslate).toBeLessThan(190)
 
-        // Re-grab without moving, hold 250 ms.
+        // Re-grab without moving. Take the baseline after pointerdown so
+        // one final in-flight frame before the re-grab isn't counted as
+        // drift while held.
         await page.mouse.move(midCx, cy)
         await page.mouse.down()
+        await page.evaluate(() => new Promise(requestAnimationFrame))
+        const grabbedTranslate = await readTranslateX(page, '[data-testid="snap-card"]')
         await page.waitForTimeout(250)
         const heldTranslate = await readTranslateX(page, '[data-testid="snap-card"]')
         await page.mouse.up()
 
         // With cancel: translate barely changes. Without cancel: card
         // creeps further toward 0 by tens of px in 250 ms.
-        // 12 px tolerance covers sub-frame timing between pointerdown
-        // dispatch and the cancel hook firing. Pre-fix value was ~60–90 px.
-        expect(Math.abs(heldTranslate - midTranslate)).toBeLessThanOrEqual(12)
+        // 8 px tolerance covers sub-frame style flushing after pointerdown.
+        // Pre-fix value was ~60–90 px.
+        expect(Math.abs(heldTranslate - grabbedTranslate)).toBeLessThanOrEqual(8)
     })
 
     test('no-momentum settle animation freezes when user re-grabs without moving', async ({
@@ -101,9 +105,13 @@ test.describe('drag/settle-cancel', () => {
         expect(midTranslate).toBeGreaterThan(130)
         expect(midTranslate).toBeLessThan(390)
 
-        // Re-grab without moving. Hold for 250 ms.
+        // Re-grab without moving. Take the baseline after pointerdown so
+        // one final in-flight frame before the re-grab isn't counted as
+        // drift while held.
         await page.mouse.move(midCx, cy)
         await page.mouse.down()
+        await page.evaluate(() => new Promise(requestAnimationFrame))
+        const grabbedTranslate = await readTranslateX(page, '[data-testid="settle-card"]')
         await page.waitForTimeout(250)
         const heldTranslate = await readTranslateX(page, '[data-testid="settle-card"]')
         await page.mouse.up()
@@ -111,8 +119,8 @@ test.describe('drag/settle-cancel', () => {
         // With cancel: translate barely changes during the hold (within a
         // few px for sub-frame jitter). Without cancel: translate creeps
         // toward +120 by tens of pixels over 250 ms.
-        // 12 px tolerance covers sub-frame timing between pointerdown
-        // dispatch and the cancel hook firing. Pre-fix value was ~60–90 px.
-        expect(Math.abs(heldTranslate - midTranslate)).toBeLessThanOrEqual(12)
+        // 8 px tolerance covers sub-frame style flushing after pointerdown.
+        // Pre-fix value was ~60–90 px.
+        expect(Math.abs(heldTranslate - grabbedTranslate)).toBeLessThanOrEqual(8)
     })
 })

--- a/e2e/motion/enter-animation.test.ts
+++ b/e2e/motion/enter-animation.test.ts
@@ -2,38 +2,77 @@ import { expect, test } from '@playwright/test'
 
 test.describe('Enter Animation', () => {
     test('should animate from invisible to visible', async ({ page }) => {
+        await page.addInitScript(() => {
+            const frames: Array<{ opacity: number; scale: number }> = []
+            ;(window as unknown as { __enterFrames: typeof frames }).__enterFrames = frames
+            const readFrame = () => {
+                const element = document.querySelector('[data-testid="motion-div"]')
+                if (element) {
+                    const style = getComputedStyle(element)
+                    const transform = style.transform
+                    const matrix = transform.match(/matrix\(([^)]+)\)/)
+                    frames.push({
+                        opacity: Number(style.opacity),
+                        scale: matrix
+                            ? Number.parseFloat(matrix[1].split(',')[0])
+                            : transform === 'none'
+                              ? 1
+                              : 0
+                    })
+                }
+                if (frames.length < 80) requestAnimationFrame(readFrame)
+            }
+            requestAnimationFrame(readFrame)
+        })
+
         // Navigate with query param
-        await page.goto('/tests/motion/enter-animation?@isPlaywright=true')
+        await page.goto('/tests/motion/enter-animation?slow&@isPlaywright=true')
 
         // Wait specifically for the element to appear with initial state
         const element = page.getByTestId('motion-div')
 
-        // Ensure we are on the initial code path for Playwright
-        await expect(element).toHaveAttribute('data-path', '1')
+        // Optimized appear is the expected SSR enter path when available.
+        await expect(element).toHaveAttribute('data-path', '6')
         await expect(element).toHaveAttribute('data-playwright', 'true')
 
-        // Wait until data-is-loaded is a stable non-null value ('initial' or 'ready')
-        const handle = await element.elementHandle()
-        const stateHandle = await page.waitForFunction(
-            (el) => {
-                const v = el.getAttribute('data-is-loaded')
-                return v === 'initial' || v === 'ready' ? v : null
-            },
-            handle,
-            { timeout: 1500 }
-        )
-        const state = (await stateHandle.jsonValue()) as string
+        await expect
+            .poll(
+                async () => {
+                    const frames = await page.evaluate(
+                        () =>
+                            (
+                                window as unknown as {
+                                    __enterFrames?: Array<{ opacity: number; scale: number }>
+                                }
+                            ).__enterFrames ?? []
+                    )
+                    return frames.some(
+                        (frame) =>
+                            frame.opacity > 0.05 &&
+                            frame.opacity < 0.95 &&
+                            frame.scale > 0.05 &&
+                            frame.scale < 0.95
+                    )
+                },
+                { timeout: 2000, message: 'never observed an intermediate enter frame' }
+            )
+            .toBe(true)
 
-        if (state === 'initial') {
-            // While in initial, opacity should be 0
-            await expect(element).toHaveCSS('opacity', '0')
-            // Then it should promote to ready
-            await expect(element).toHaveAttribute('data-is-loaded', 'ready')
-        } else {
-            await expect(element).toHaveAttribute('data-is-loaded', 'ready')
-        }
+        const firstFrame = await page.evaluate(() => {
+            const frames =
+                (
+                    window as unknown as {
+                        __enterFrames?: Array<{ opacity: number; scale: number }>
+                    }
+                ).__enterFrames ?? []
+            return frames.find((frame) => Number.isFinite(frame.opacity))
+        })
+
+        expect(firstFrame?.opacity).toBeLessThanOrEqual(0.3)
+        expect(firstFrame?.scale).toBeLessThanOrEqual(0.3)
 
         // Wait and verify final state (CSS-driven)
+        await expect(element).toHaveAttribute('data-is-loaded', 'ready')
         await expect(element).toHaveCSS('opacity', '1')
         await expect(element).toHaveCSS('background-color', 'rgb(255, 0, 0)')
         await expect(element).toHaveCSS('border-radius', '50%')

--- a/e2e/motion/optimized-appear.spec.ts
+++ b/e2e/motion/optimized-appear.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('optimized appear animations', () => {
+    test('starts SSR appear animations before hydration handoff', async ({ page }) => {
+        await page.addInitScript(() => {
+            const samples: number[] = []
+            const ids: string[] = []
+            Object.defineProperty(window, '__optimizedAppearOpacitySamples', {
+                value: samples
+            })
+            Object.defineProperty(window, '__optimizedAppearIds', {
+                value: ids
+            })
+            const sample = () => {
+                const element = document.querySelector('[data-framer-appear-id]')
+                if (element) {
+                    samples.push(Number(getComputedStyle(element).opacity))
+                    ids.push(element.getAttribute('data-framer-appear-id') ?? '')
+                }
+                requestAnimationFrame(sample)
+            }
+            requestAnimationFrame(sample)
+        })
+
+        await page.goto('/tests/optimized-appear?@isPlaywright=true')
+
+        const card = page.getByTestId('optimized-appear-card')
+        await expect(card).toBeVisible()
+        await expect(card).toHaveAttribute('data-framer-appear-id', /svelte-motion-/)
+
+        const started = await page.evaluate(() => {
+            return (
+                (
+                    window as unknown as {
+                        __SvelteMotionAppear?: { started: Array<{ name: string }> }
+                    }
+                ).__SvelteMotionAppear?.started.map((entry) => entry.name) ?? []
+            )
+        })
+        expect(started).toContain('opacity')
+        expect(started).toContain('transform')
+
+        await expect
+            .poll(async () => card.evaluate((el) => getComputedStyle(el).opacity), {
+                timeout: 3000,
+                message: 'optimized appear card never settled to visible opacity'
+            })
+            .toBe('1')
+
+        const samples = await page.evaluate(() => {
+            return (
+                window as unknown as {
+                    __optimizedAppearOpacitySamples: number[]
+                }
+            ).__optimizedAppearOpacitySamples
+        })
+        const firstVisibleProgress = samples.findIndex((value) => value > 0.15)
+        expect(firstVisibleProgress).toBeGreaterThanOrEqual(0)
+        expect(Math.min(...samples.slice(firstVisibleProgress))).toBeGreaterThan(0.08)
+
+        const ids = await page.evaluate(() => {
+            return (
+                window as unknown as {
+                    __optimizedAppearIds: string[]
+                }
+            ).__optimizedAppearIds
+        })
+        expect(new Set(ids).size).toBe(1)
+    })
+})

--- a/e2e/motion/svg-path-length.test.ts
+++ b/e2e/motion/svg-path-length.test.ts
@@ -97,24 +97,25 @@ test.describe('SVG pathLength Animation', () => {
             .toBe(true)
 
         // After animation progresses, stroke-dasharray first value should increase
+        // while pathSpacing remains at upstream's default `1`.
         await expect
             .poll(
                 async () => {
                     const dasharray = await getStrokeDasharray()
                     if (dasharray === 'none') return false
                     const values = dasharray.split(/[\s,]+/).map((v) => parseFloat(v))
-                    // First value should be significantly larger than 0
-                    return values[0] > 0.3
+                    // First value should be significantly larger than 0 and the gap should remain 1.
+                    return values[0] > 0.3 && values[1] > 0.95
                 },
                 {
                     message:
-                        'strokeDasharray first value should increase during animation (line drawing)',
+                        'strokeDasharray should increase while preserving default pathSpacing=1',
                     timeout: 2500
                 }
             )
             .toBe(true)
 
-        // At the end, stroke-dasharray should be approximately "1px 0px" (fully drawn)
+        // At the end, stroke-dasharray should be approximately "1 1" (fully drawn)
         await expect
             .poll(
                 async () => {
@@ -122,11 +123,24 @@ test.describe('SVG pathLength Animation', () => {
                     if (dasharray === 'none') return false
                     const values = dasharray.split(/[\s,]+/).map((v) => parseFloat(v))
                     // First value should be close to 1 (fully drawn) in normalized units
-                    return values[0] > 0.9
+                    return values[0] > 0.9 && values[1] > 0.95
                 },
                 {
-                    message: 'stroke-dasharray should end near "1px 0px" for fully drawn path',
+                    message: 'stroke-dasharray should end near "1 1" for fully drawn path',
                     timeout: 3000
+                }
+            )
+            .toBe(true)
+
+        await expect
+            .poll(
+                async () =>
+                    await path.evaluate(
+                        (el) => !el.style.strokeDasharray && !el.style.strokeDashoffset
+                    ),
+                {
+                    message: 'SVG path drawing should be attribute-driven, not pinned as style',
+                    timeout: 1000
                 }
             )
             .toBe(true)

--- a/e2e/projection/nested-ancestor.spec.ts
+++ b/e2e/projection/nested-ancestor.spec.ts
@@ -39,6 +39,14 @@ const parseDelta = (text: string | null): Delta | null => {
     return { dx: Number(m[1]), dy: Number(m[2]), changed: m[3] === 'true' }
 }
 
+const isIdleDelta = (text: string | null): boolean => {
+    const delta = parseDelta(text)
+    return (
+        !!text?.includes('(no event yet)') ||
+        !!(delta && !delta.changed && Math.abs(delta.dx) < 0.5 && Math.abs(delta.dy) < 0.5)
+    )
+}
+
 const parseOffset = (text: string | null): Offset | null => {
     const m = text?.match(/x=(-?\d+)\s+y=(-?\d+)/)
     if (!m) return null
@@ -57,7 +65,7 @@ test.describe('projection/nested-ancestor', () => {
         const innerDelta = page.getByTestId('inner-delta')
         const offset = page.getByTestId('stripped-offset')
         await innerDelta.waitFor({ state: 'visible' })
-        await expect(innerDelta).toContainText('(no event yet)')
+        await expect.poll(async () => isIdleDelta(await innerDelta.textContent())).toBe(true)
 
         await page.getByTestId('toggle').click()
         await expect(innerDelta).toContainText('changed=true')

--- a/e2e/projection/nested-ancestor.spec.ts
+++ b/e2e/projection/nested-ancestor.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { isIdleDelta, parseProjectionDelta as parseDelta } from '../_helpers/projection'
 
 /**
  * Projection foundation (#379) — nested-ancestor measure semantics.
@@ -22,29 +23,9 @@ import { expect, test } from '@playwright/test'
  * transforms in would report a non-zero offset for the static case.
  */
 
-interface Delta {
-    dx: number
-    dy: number
-    changed: boolean
-}
-
 interface Offset {
     x: number
     y: number
-}
-
-const parseDelta = (text: string | null): Delta | null => {
-    const m = text?.match(/Δx=(-?[\d.]+)\s+Δy=(-?[\d.]+)\s+changed=(true|false)/)
-    if (!m) return null
-    return { dx: Number(m[1]), dy: Number(m[2]), changed: m[3] === 'true' }
-}
-
-const isIdleDelta = (text: string | null): boolean => {
-    const delta = parseDelta(text)
-    return (
-        !!text?.includes('(no event yet)') ||
-        !!(delta && !delta.changed && Math.abs(delta.dx) < 0.5 && Math.abs(delta.dy) < 0.5)
-    )
 }
 
 const parseOffset = (text: string | null): Offset | null => {

--- a/e2e/projection/sibling-swap.spec.ts
+++ b/e2e/projection/sibling-swap.spec.ts
@@ -27,6 +27,14 @@ const parseDelta = (text: string | null): Delta | null => {
     return { dx: Number(m[1]), dy: Number(m[2]), changed: m[3] === 'true' }
 }
 
+const isIdleDelta = (text: string | null): boolean => {
+    const delta = parseDelta(text)
+    return (
+        !!text?.includes('(no event yet)') ||
+        !!(delta && !delta.changed && Math.abs(delta.dx) < 0.5 && Math.abs(delta.dy) < 0.5)
+    )
+}
+
 const ROW_GAP_MIN = 88 // box height (80) + gap (16) leaves a comfortable lower bound
 const ROW_GAP_MAX = 104
 
@@ -38,9 +46,11 @@ test.describe('projection/sibling-swap', () => {
         const d1 = page.getByTestId('delta-1')
         await d0.waitFor({ state: 'visible' })
 
-        // No projection event has fired before the first swap.
-        await expect(d0).toContainText('(no event yet)')
-        await expect(d1).toContainText('(no event yet)')
+        // Before the first swap, layout is idle. Depending on scheduling,
+        // the page might still show "no event yet" or an initial unchanged
+        // zero-delta projection callback.
+        await expect.poll(async () => isIdleDelta(await d0.textContent())).toBe(true)
+        await expect.poll(async () => isIdleDelta(await d1.textContent())).toBe(true)
 
         await page.getByTestId('swap').click()
 

--- a/e2e/projection/sibling-swap.spec.ts
+++ b/e2e/projection/sibling-swap.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { isIdleDelta, parseProjectionDelta as parseDelta } from '../_helpers/projection'
 
 /**
  * Projection foundation (#379) — flat sibling-swap event stream.
@@ -14,26 +15,6 @@ import { expect, test } from '@playwright/test'
  * Expected: one box reports Δy ≈ +96, the other Δy ≈ -96, both with
  * `changed=true` and Δx ≈ 0. Swapping again flips the signs.
  */
-
-interface Delta {
-    dx: number
-    dy: number
-    changed: boolean
-}
-
-const parseDelta = (text: string | null): Delta | null => {
-    const m = text?.match(/Δx=(-?[\d.]+)\s+Δy=(-?[\d.]+)\s+changed=(true|false)/)
-    if (!m) return null
-    return { dx: Number(m[1]), dy: Number(m[2]), changed: m[3] === 'true' }
-}
-
-const isIdleDelta = (text: string | null): boolean => {
-    const delta = parseDelta(text)
-    return (
-        !!text?.includes('(no event yet)') ||
-        !!(delta && !delta.changed && Math.abs(delta.dx) < 0.5 && Math.abs(delta.dy) < 0.5)
-    )
-}
 
 const ROW_GAP_MIN = 88 // box height (80) + gap (16) leaves a comfortable lower bound
 const ROW_GAP_MAX = 104

--- a/src/lib/components/motionDomProjection.context.ts
+++ b/src/lib/components/motionDomProjection.context.ts
@@ -1,0 +1,22 @@
+import type { MotionDomProjectionAdapter } from '$lib/utils/motionDomProjection'
+import { getContext, setContext } from 'svelte'
+
+const MOTION_DOM_PROJECTION_CONTEXT_KEY = Symbol('svelte-motion:motion-dom-projection-parent')
+
+/**
+ * Publish the current upstream motion-dom projection adapter to descendants.
+ *
+ * @param node Current component projection adapter, or `null` to clear.
+ */
+export const setMotionDomProjectionParent = (node: MotionDomProjectionAdapter | null): void => {
+    setContext<MotionDomProjectionAdapter | null>(MOTION_DOM_PROJECTION_CONTEXT_KEY, node)
+}
+
+/**
+ * Read the nearest upstream motion-dom projection adapter.
+ *
+ * @returns Parent projection adapter, or `null` when no motion ancestor exists.
+ */
+export const getMotionDomProjectionParent = (): MotionDomProjectionAdapter | null => {
+    return getContext<MotionDomProjectionAdapter | null>(MOTION_DOM_PROJECTION_CONTEXT_KEY) ?? null
+}

--- a/src/lib/html/_MotionContainer.ssr.spec.ts
+++ b/src/lib/html/_MotionContainer.ssr.spec.ts
@@ -52,4 +52,19 @@ describe('_MotionContainer SSR styles', () => {
         expect(style).not.toMatch(/opacity:/)
         expect(style).not.toMatch(/border-radius:/)
     })
+
+    it('emits optimized appear handoff metadata for SSR enter animations', () => {
+        /* trunk-ignore(eslint/@typescript-eslint/no-explicit-any) */
+        const { container } = render(MotionContainer as unknown as any, {
+            props: {
+                tag: 'div',
+                initial: { opacity: 0, scale: 0.9 },
+                animate: { opacity: 1, scale: 1 },
+                transition: { duration: 0.5 }
+            }
+        })
+        const el = container.firstElementChild as HTMLElement
+        expect(el.getAttribute('data-framer-appear-id')).toMatch(/^svelte-motion-/)
+        expect(container.innerHTML).toContain('MotionHasOptimisedAnimation')
+    })
 })

--- a/src/lib/html/_MotionContainer.ssr.spec.ts
+++ b/src/lib/html/_MotionContainer.ssr.spec.ts
@@ -1,8 +1,17 @@
 import { render } from '@testing-library/svelte'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import MotionContainer from './_MotionContainer.svelte'
 
 describe('_MotionContainer SSR styles', () => {
+    beforeEach(() => {
+        window.MotionIsMounted = false
+        window.MotionHasOptimisedAnimation = undefined
+        window.MotionHandoffMarkAsComplete = undefined
+        window.MotionHandoffIsComplete = undefined
+        window.MotionCancelOptimisedAnimation = undefined
+        window.__SvelteMotionAppear = undefined
+    })
+
     it('reflects initial styles in SSR output (opacity/borderRadius)', () => {
         /* trunk-ignore(eslint/@typescript-eslint/no-explicit-any) */
         const { container } = render(MotionContainer as unknown as any, {

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -80,6 +80,14 @@
         isSVGTag,
         SVG_NAMESPACE
     } from '$lib/utils/svg'
+    import {
+        createOptimizedAppearData,
+        createOptimizedAppearScript,
+        finishOptimizedAppearAnimation,
+        hasOptimizedAppearAnimation,
+        markMotionMounted,
+        optimizedAppearDataAttribute
+    } from '$lib/utils/optimizedAppear'
     import { getLayoutIdRegistry } from '$lib/utils/layoutId'
     import {
         getLayoutScrollContainerRef,
@@ -92,6 +100,8 @@
         tag: keyof SvelteHTMLElements
         [key: string]: unknown
     }
+
+    const componentHydrationId = $props.id()
 
     let {
         children,
@@ -551,6 +561,23 @@
             reducedMotion
         )
     )
+    const optimizedAppearId = $derived(
+        effectiveInitialProp !== false &&
+            isNotEmpty(initialKeyframes) &&
+            isNotEmpty(animateKeyframes)
+            ? `svelte-motion-${componentHydrationId}`
+            : undefined
+    )
+    const optimizedAppearEntries = $derived(
+        createOptimizedAppearData(
+            initialKeyframes as Record<string, unknown> | undefined,
+            animateKeyframes as Record<string, unknown> | undefined,
+            mergedTransition
+        )
+    )
+    const optimizedAppearScript = $derived(
+        createOptimizedAppearScript(optimizedAppearId, optimizedAppearEntries)
+    )
 
     // Derived attributes to keep both branches in sync (focusability, data flags, style, class)
     const derivedAttrs = $derived<Record<string, unknown>>({
@@ -575,6 +602,7 @@
                   'data-path': dataPath
               }
             : {}),
+        ...(optimizedAppearScript ? { [optimizedAppearDataAttribute]: optimizedAppearId } : {}),
         // Apply normalized SVG path attributes synchronously on first render to avoid flash
         // Compute via svg utils (no dynamic import in SSR/derived expressions)
         ...(() => {
@@ -1423,6 +1451,7 @@
 
     $effect(() => {
         if (!(element && isLoaded === 'mounting')) return
+        markMotionMounted()
 
         pwLog('[motion] main effect running', {
             effectiveAnimate: !!effectiveAnimate,
@@ -1452,6 +1481,29 @@
                 dataPath = 5
                 isLoaded = 'ready'
             } else if (isNotEmpty(initialKeyframes)) {
+                const canHandoffOptimizedAppear = hasOptimizedAppearAnimation(optimizedAppearId)
+                if (canHandoffOptimizedAppear) {
+                    pwLog('[motion] path: optimized appear handoff')
+                    dataPath = 6
+                    isLoaded = 'initial'
+                    initialAnimationTriggered = true
+                    if (animateProp && typeof animateProp !== 'string') {
+                        objectAnimateRanOnMount = true
+                        lastAnimatePropJson = JSON.stringify(animateProp)
+                    }
+                    finishOptimizedAppearAnimation(optimizedAppearId)
+                        .then(() => {
+                            enterAnimationSettled = true
+                            isLoaded = 'ready'
+                            onAnimationCompleteProp?.(
+                                resolvedAnimate as DOMKeyframesDefinition | undefined
+                            )
+                        })
+                        .catch(() => {
+                            isLoaded = 'ready'
+                        })
+                    return
+                }
                 pwLog('[motion] path: has initialKeyframes, will animate to target')
                 // Apply initial instantly BEFORE exposing 'initial' state
                 const transformedInitial = transformSVGPathProperties(
@@ -1572,15 +1624,23 @@
 {#if isVoidTag}
     {#if isSVGTag(String(tag))}
         <svelte:element this={tag} bind:this={element} xmlns={SVG_NAMESPACE} {...derivedAttrs} />
+        <!-- trunk-ignore(eslint/svelte/no-at-html-tags): optimized appear emits a JSON-escaped SSR bootstrap script, not user-authored HTML. -->
+        {@html optimizedAppearScript}
     {:else}
         <svelte:element this={tag} bind:this={element} {...derivedAttrs} />
+        <!-- trunk-ignore(eslint/svelte/no-at-html-tags): optimized appear emits a JSON-escaped SSR bootstrap script, not user-authored HTML. -->
+        {@html optimizedAppearScript}
     {/if}
 {:else if isSVGTag(String(tag))}
     <svelte:element this={tag} bind:this={element} xmlns={SVG_NAMESPACE} {...derivedAttrs}>
         {@render children?.()}
     </svelte:element>
+    <!-- trunk-ignore(eslint/svelte/no-at-html-tags): optimized appear emits a JSON-escaped SSR bootstrap script, not user-authored HTML. -->
+    {@html optimizedAppearScript}
 {:else}
     <svelte:element this={tag} bind:this={element} {...derivedAttrs}>
         {@render children?.()}
     </svelte:element>
+    <!-- trunk-ignore(eslint/svelte/no-at-html-tags): optimized appear emits a JSON-escaped SSR bootstrap script, not user-authored HTML. -->
+    {@html optimizedAppearScript}
 {/if}

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -28,6 +28,7 @@
     import { isNotEmpty } from '$lib/utils/objects'
     import { sleep } from '$lib/utils/testing'
     import { animate, type AnimationOptions, type DOMKeyframesDefinition } from 'motion'
+    import { motionValue, svgEffect, type MotionValue } from 'motion-dom'
     import { isPlaywrightEnv, pwLog } from '$lib/utils/log'
     import { onDestroy, untrack, type Snippet } from 'svelte'
     import { VOID_TAGS } from '$lib/utils/constants'
@@ -82,6 +83,8 @@
     import {
         transformSVGPathProperties,
         computeNormalizedSVGInitialAttrs,
+        hasSVGPathProperties,
+        isSVGPathElement,
         isSVGTag,
         SVG_NAMESPACE
     } from '$lib/utils/svg'
@@ -629,6 +632,117 @@
         const delay = typeof transition?.delay === 'number' ? transition.delay : 0
         return Math.max(0, (duration + delay) * 1000)
     }
+    let cleanupSVGPathAttributeEffect: (() => void) | null = null
+
+    /**
+     * Reads the current normalized SVG path drawing state from DOM
+     * attributes. `motion-dom`'s svgEffect owns future writes; this only
+     * seeds its MotionValues from the currently rendered frame.
+     *
+     * @param {SVGPathElement} path The SVG path element to inspect.
+     * @returns {{ pathLength: number; pathSpacing: number; pathOffset: number }} The normalized drawing state.
+     */
+    const readSVGPathDrawingState = (
+        path: SVGPathElement
+    ): { pathLength: number; pathSpacing: number; pathOffset: number } => {
+        const dashArray =
+            path.getAttribute('stroke-dasharray') || path.style.strokeDasharray || '1 0'
+        const [rawLength, rawSpacing] = dashArray
+            .split(/[,\s]+/)
+            .filter(Boolean)
+            .map((part) => Number.parseFloat(part))
+        const rawOffset = Number.parseFloat(
+            path.getAttribute('stroke-dashoffset') || path.style.strokeDashoffset || '0'
+        )
+
+        return {
+            pathLength: Number.isFinite(rawLength) ? rawLength : 1,
+            pathSpacing: Number.isFinite(rawSpacing) ? rawSpacing : 1,
+            pathOffset: Number.isFinite(rawOffset) ? -rawOffset : 0
+        }
+    }
+
+    /**
+     * Removes custom SVG path props from keyframes after `svgEffect` has
+     * taken ownership of them.
+     *
+     * @param {Record<string, unknown>} keyframes Keyframes to copy.
+     * @returns {Record<string, unknown>} Keyframes without SVG path-only props.
+     */
+    const stripSVGPathKeyframes = (keyframes: Record<string, unknown>): Record<string, unknown> => {
+        const stripped = { ...keyframes }
+        delete stripped.pathLength
+        delete stripped.pathSpacing
+        delete stripped.pathOffset
+        return stripped
+    }
+
+    /**
+     * Extracts an animation completion promise from a Motion control when
+     * one is available.
+     *
+     * @param {unknown} control The return value from `animate`.
+     * @returns {Promise<unknown> | null} The finished promise, or null.
+     */
+    const getFinishedPromise = (control: unknown): Promise<unknown> | null => {
+        if (!control || typeof control !== 'object') return null
+        const finished = (control as { finished?: unknown }).finished
+        return finished && typeof (finished as Promise<unknown>).then === 'function'
+            ? (finished as Promise<unknown>)
+            : null
+    }
+
+    /**
+     * Animates SVG path drawing props via motion-dom's `svgEffect`, matching
+     * upstream's attribute-based pathLength/pathSpacing/pathOffset behavior.
+     *
+     * @param {SVGPathElement} path The path element to animate.
+     * @param {Record<string, unknown>} keyframes Keyframes containing SVG path props.
+     * @param {MotionTransition} transition The transition to apply to generated MotionValues.
+     * @returns {Promise<unknown>[]} Promises for generated path animations.
+     */
+    const animateSVGPathAttributes = (
+        path: SVGPathElement,
+        keyframes: Record<string, unknown>,
+        transition: MotionTransition
+    ): Promise<unknown>[] => {
+        if (!hasSVGPathProperties(keyframes)) return []
+
+        cleanupSVGPathAttributeEffect?.()
+        const current = readSVGPathDrawingState(path)
+        const values: Record<string, MotionValue<number>> = {}
+
+        if ('pathLength' in keyframes) {
+            values.pathLength = motionValue(current.pathLength)
+        }
+        if ('pathLength' in keyframes || 'pathSpacing' in keyframes) {
+            values.pathSpacing = motionValue(current.pathSpacing)
+        }
+        if ('pathOffset' in keyframes) {
+            values.pathOffset = motionValue(current.pathOffset)
+        }
+
+        cleanupSVGPathAttributeEffect = svgEffect(path, values)
+
+        return Object.entries(values)
+            .map(([key, value]) => {
+                const control = animate(
+                    value as never,
+                    (key === 'pathSpacing' && !('pathSpacing' in keyframes)
+                        ? 1
+                        : keyframes[key]) as never,
+                    transition as unknown as AnimationOptions
+                )
+                return getFinishedPromise(control)
+            })
+            .filter((promise): promise is Promise<unknown> => promise !== null)
+    }
+
+    onDestroy(() => {
+        cleanupSVGPathAttributeEffect?.()
+        cleanupSVGPathAttributeEffect = null
+    })
+
     // Wait-mode enter coordination needs to affect the first rendered attrs,
     // before the blocked entrant can participate in layout.
     let waitCallbackRegistered = $state(false)
@@ -971,19 +1085,22 @@
         }
 
         const transitionAnimate: MotionTransition = mergedTransition ?? {}
-        let payload = $state.snapshot(resolvedAnimate)
+        const rawPayload = filterReducedMotionKeyframes(
+            $state.snapshot(resolvedAnimate) as Record<string, unknown>,
+            reducedMotion
+        ) as Record<string, unknown>
+        const svgPathFinished =
+            isSVGPathElement(element) && hasSVGPathProperties(rawPayload)
+                ? animateSVGPathAttributes(element, rawPayload, transitionAnimate)
+                : []
+        let payload = (
+            svgPathFinished.length > 0 ? stripSVGPathKeyframes(rawPayload) : rawPayload
+        ) as typeof rawPayload
 
         // Transform SVG path properties (pathLength, pathOffset) to their CSS equivalents
         payload = transformSVGPathProperties(
             element,
             payload as Record<string, unknown>
-        ) as typeof payload
-
-        // Strip transform keys when reduced-motion is active so the element
-        // stays in place while opacity / color etc. still animate.
-        payload = filterReducedMotionKeyframes(
-            payload as Record<string, unknown>,
-            reducedMotion
         ) as typeof payload
 
         // Ensure dash properties aren't pinned as inline styles
@@ -1010,13 +1127,24 @@
             enterAnimationSettled = true
             onAnimationCompleteProp?.(def)
         }
-        animateWithLifecycle(
-            element,
-            payload as unknown as DOMKeyframesDefinition,
-            transitionAnimate as unknown as AnimationOptions,
-            (def) => onAnimationStartProp?.(def as unknown as DOMKeyframesDefinition | undefined),
-            (def) => completeEnterAnimation(def as unknown as DOMKeyframesDefinition | undefined)
-        )
+        if (isNotEmpty(payload)) {
+            animateWithLifecycle(
+                element,
+                payload as unknown as DOMKeyframesDefinition,
+                transitionAnimate as unknown as AnimationOptions,
+                (def) =>
+                    onAnimationStartProp?.(def as unknown as DOMKeyframesDefinition | undefined),
+                (def) =>
+                    completeEnterAnimation(def as unknown as DOMKeyframesDefinition | undefined)
+            )
+        } else if (svgPathFinished.length > 0) {
+            onAnimationStartProp?.(rawPayload as unknown as DOMKeyframesDefinition)
+            Promise.all(svgPathFinished)
+                .then(() => completeEnterAnimation(rawPayload as unknown as DOMKeyframesDefinition))
+                .catch(() =>
+                    completeEnterAnimation(rawPayload as unknown as DOMKeyframesDefinition)
+                )
+        }
         if (isJsdomRuntime()) {
             window.setTimeout(
                 () => completeEnterAnimation(),

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -279,6 +279,11 @@
         width: rect.width,
         height: rect.height
     })
+    const isViewportOffscreen = (rect: DOMRect): boolean =>
+        rect.bottom <= 0 ||
+        rect.right <= 0 ||
+        rect.top >= window.innerHeight ||
+        rect.left >= window.innerWidth
 
     // Ancestor-transform-invariant layout measurement for seeding the
     // fallback FLIP effect's first rect.
@@ -615,6 +620,8 @@
     let waitLayoutParent: HTMLElement | null = null
     let waitLayoutParentWidth = ''
     let waitLayoutParentHeight = ''
+    let waitLayoutViewportScrollX = 0
+    let waitLayoutViewportScrollY = 0
     const presenceLayoutHoldAttribute = 'data-presence-layout-hold'
     const presenceLayoutReleaseEvent = 'svelte-motion:presence-layout-release'
     const waitEnterBlockedBeforeMount = $derived(
@@ -1025,6 +1032,8 @@
         waitLayoutParent = parent
         waitLayoutParentWidth = parent.style.width
         waitLayoutParentHeight = parent.style.height
+        waitLayoutViewportScrollX = typeof window !== 'undefined' ? window.scrollX : 0
+        waitLayoutViewportScrollY = typeof window !== 'undefined' ? window.scrollY : 0
         parent.setAttribute(presenceLayoutHoldAttribute, 'true')
         parent.style.width = `${rect.width}px`
         parent.style.height = `${rect.height}px`
@@ -1045,14 +1054,23 @@
         } else {
             parent.style.removeProperty('height')
         }
+        const viewportScrolledDuringHold =
+            typeof window !== 'undefined' &&
+            (window.scrollX !== waitLayoutViewportScrollX ||
+                window.scrollY !== waitLayoutViewportScrollY)
         parent.dispatchEvent(
             new CustomEvent(presenceLayoutReleaseEvent, {
-                detail: { previousRect: domRectToRectLike(previousRect) }
+                detail: {
+                    previousRect: domRectToRectLike(previousRect),
+                    viewportScrolledDuringHold
+                }
             })
         )
         waitLayoutParent = null
         waitLayoutParentWidth = ''
         waitLayoutParentHeight = ''
+        waitLayoutViewportScrollX = 0
+        waitLayoutViewportScrollY = 0
     }
 
     const revealWaitHiddenElement = () => {
@@ -1293,10 +1311,17 @@
         if (!(element && layoutProp && isLoaded === 'ready' && hasLayoutFeatures)) return
 
         let rafId: number | null = null
+        let wasViewportOffscreenSinceLastLayout = false
         const flipLayoutMode = layoutProp === 'position' ? 'position' : true
         motionDomProjection?.seedLayout()
         lastRect = measureLayoutRect()
         setCompositorHints(element!, true)
+
+        const rememberOffscreenScroll = () => {
+            if (isViewportOffscreen(element!.getBoundingClientRect())) {
+                wasViewportOffscreenSinceLastLayout = true
+            }
+        }
 
         const commitObservedLayout = () => {
             if (element!.hasAttribute('data-layout-size-animation')) {
@@ -1327,21 +1352,36 @@
                 const transforms = computeFlipTransforms(lastRect, next, flipLayoutMode)
                 runFlipAnimation(element!, transforms, (mergedTransition ?? {}) as AnimationOptions)
                 lastRect = next
+                wasViewportOffscreenSinceLastLayout = false
             } else if (nextBox) {
                 lastRect = boxToRectLike(nextBox)
+                wasViewportOffscreenSinceLastLayout = false
             }
             motionDomProjection?.commitObservedLayoutChange()
         }
 
         const commitPresenceLayoutRelease = (event: Event) => {
-            const previous = (event as CustomEvent<{ previousRect?: RectLike }>).detail
-                ?.previousRect
+            const detail = (
+                event as CustomEvent<{
+                    previousRect?: RectLike
+                    viewportScrolledDuringHold?: boolean
+                }>
+            ).detail
+            const previous = detail?.previousRect
+            const viewportRect = element!.getBoundingClientRect()
             const next = measureLayoutRect()
             if (!(previous && next)) return
 
-            const transforms = computeFlipTransforms(previous, next, flipLayoutMode)
-            runFlipAnimation(element!, transforms, (mergedTransition ?? {}) as AnimationOptions)
             lastRect = next
+            const shouldSkipLayoutAnimation =
+                detail?.viewportScrolledDuringHold ||
+                wasViewportOffscreenSinceLastLayout ||
+                isViewportOffscreen(viewportRect)
+            if (!shouldSkipLayoutAnimation) {
+                const transforms = computeFlipTransforms(previous, next, flipLayoutMode)
+                runFlipAnimation(element!, transforms, (mergedTransition ?? {}) as AnimationOptions)
+            }
+            wasViewportOffscreenSinceLastLayout = false
             motionDomProjection?.commitObservedLayoutChange()
         }
 
@@ -1353,10 +1393,12 @@
             })
         }
         const disconnectObservers = observeLayoutChanges(element!, () => scheduleProjectionCommit())
+        window.addEventListener('scroll', rememberOffscreenScroll, { passive: true })
         element!.addEventListener(presenceLayoutReleaseEvent, commitPresenceLayoutRelease)
 
         return () => {
             disconnectObservers()
+            window.removeEventListener('scroll', rememberOffscreenScroll)
             element?.removeEventListener(presenceLayoutReleaseEvent, commitPresenceLayoutRelease)
             lastRect = null
             if (element) {

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -58,6 +58,11 @@
     import { attachPan, type AttachPanCleanup } from '$lib/utils/pan'
     import { ProjectionNode } from '$lib/utils/projection'
     import { getProjectionParent, setProjectionParent } from '$lib/components/projection.context'
+    import { MotionDomProjectionAdapter } from '$lib/utils/motionDomProjection'
+    import {
+        getMotionDomProjectionParent,
+        setMotionDomProjectionParent
+    } from '$lib/components/motionDomProjection.context'
     import {
         resolveInitial,
         resolveAnimate,
@@ -244,6 +249,18 @@
     })
     setProjectionParent(projection)
 
+    const motionDomProjectionParent =
+        typeof window !== 'undefined' ? getMotionDomProjectionParent() : null
+    const motionDomProjection =
+        typeof window !== 'undefined'
+            ? new MotionDomProjectionAdapter({
+                  parent: motionDomProjectionParent
+              })
+            : null
+    if (motionDomProjection) {
+        setMotionDomProjectionParent(motionDomProjection)
+    }
+
     // Convert a projection `Box` (ancestor chain reset to base, self
     // transform stripped, scroll containers compensated) to the
     // `RectLike` shape `computeFlipTransforms` consumes.
@@ -256,9 +273,15 @@
         width: box.x.max - box.x.min,
         height: box.y.max - box.y.min
     })
+    const domRectToRectLike = (rect: DOMRect): RectLike => ({
+        left: rect.left,
+        top: rect.top,
+        width: rect.width,
+        height: rect.height
+    })
 
     // Ancestor-transform-invariant layout measurement for seeding the
-    // FLIP effect's first rect.
+    // fallback FLIP effect's first rect.
     const measureLayoutRect = (): RectLike | null => {
         const box = projection.measure()
         return box ? boxToRectLike(box) : null
@@ -578,6 +601,25 @@
     const optimizedAppearScript = $derived(
         createOptimizedAppearScript(optimizedAppearId, optimizedAppearEntries)
     )
+    const renderedOptimizedAppearScript = $derived(
+        optimizedAppearScript && (typeof window === 'undefined' || !window.MotionIsMounted)
+            ? optimizedAppearScript
+            : ''
+    )
+    // Wait-mode enter coordination needs to affect the first rendered attrs,
+    // before the blocked entrant can participate in layout.
+    let waitCallbackRegistered = $state(false)
+    let waitUnsubscribe: (() => void) | null = null
+    let waitHiddenDisplay: string | null = null
+    let waitEnterReleased = $state(false)
+    let waitLayoutParent: HTMLElement | null = null
+    let waitLayoutParentWidth = ''
+    let waitLayoutParentHeight = ''
+    const presenceLayoutHoldAttribute = 'data-presence-layout-hold'
+    const presenceLayoutReleaseEvent = 'svelte-motion:presence-layout-release'
+    const waitEnterBlockedBeforeMount = $derived(
+        context?.mode === 'wait' && !waitEnterReleased && context.isEnterBlocked(presenceKey)
+    )
 
     // Derived attributes to keep both branches in sync (focusability, data flags, style, class)
     const derivedAttrs = $derived<Record<string, unknown>>({
@@ -602,7 +644,16 @@
                   'data-path': dataPath
               }
             : {}),
-        ...(optimizedAppearScript ? { [optimizedAppearDataAttribute]: optimizedAppearId } : {}),
+        ...(renderedOptimizedAppearScript
+            ? { [optimizedAppearDataAttribute]: optimizedAppearId }
+            : {}),
+        ...(layoutProp
+            ? { 'data-layout': String(layoutProp), 'data-svelte-motion-layout': '' }
+            : {}),
+        ...(scopedLayoutId ? { 'data-layout-id': scopedLayoutId } : {}),
+        ...(waitEnterBlockedBeforeMount || waitHiddenDisplay !== null
+            ? { 'data-presence-wait-hidden': 'true' }
+            : {}),
         // Apply normalized SVG path attributes synchronously on first render to avoid flash
         // Compute via svg utils (no dynamic import in SSR/derived expressions)
         ...(() => {
@@ -616,9 +667,7 @@
             return {}
         })(),
         style: mergeInlineStyles(
-            initialKeyframes && 'pathLength' in initialKeyframes && isLoaded === 'mounting'
-                ? `${styleProp || ''};visibility:hidden`
-                : styleProp,
+            `${initialKeyframes && 'pathLength' in initialKeyframes && isLoaded === 'mounting' ? `${styleProp || ''};visibility:hidden` : (styleProp ?? '')}${waitEnterBlockedBeforeMount || waitHiddenDisplay !== null ? ';display:none' : ''}`,
             // The "from" slot: apply initialKeyframes as inline styles during
             // the mounting/initial phases (before the WAAPI animation locks
             // its from-value and we promote to 'ready' — see the lifecycle
@@ -940,17 +989,85 @@
         )
     }
 
-    // Track if we've already registered a wait callback to prevent duplicates
-    let waitCallbackRegistered = $state(false)
-    let waitUnsubscribe: (() => void) | null = null
-
     // Cleanup wait callback on component unmount to prevent memory leaks
     $effect(() => {
         return () => {
+            if (element && waitHiddenDisplay !== null) {
+                element.style.display = waitHiddenDisplay
+                element.removeAttribute('data-presence-wait-hidden')
+                waitHiddenDisplay = null
+            }
+            releaseWaitLayoutHold()
             waitUnsubscribe?.()
             waitUnsubscribe = null
         }
     })
+
+    const getPresenceLayoutParent = (): HTMLElement | null => {
+        let parent = element?.parentElement ?? null
+        const layoutParent = element?.parentElement?.closest<HTMLElement>(
+            '[data-svelte-motion-layout]'
+        )
+        if (layoutParent) return layoutParent
+
+        while (parent && getComputedStyle(parent).display === 'contents') {
+            parent = parent.parentElement
+        }
+        return parent
+    }
+
+    const holdWaitLayout = () => {
+        if (!element || waitLayoutParent) return
+        const parent = getPresenceLayoutParent()
+        if (!parent) return
+
+        const rect = parent.getBoundingClientRect()
+        waitLayoutParent = parent
+        waitLayoutParentWidth = parent.style.width
+        waitLayoutParentHeight = parent.style.height
+        parent.setAttribute(presenceLayoutHoldAttribute, 'true')
+        parent.style.width = `${rect.width}px`
+        parent.style.height = `${rect.height}px`
+    }
+
+    function releaseWaitLayoutHold() {
+        if (!waitLayoutParent) return
+        const parent = waitLayoutParent
+        const previousRect = parent.getBoundingClientRect()
+        parent.removeAttribute(presenceLayoutHoldAttribute)
+        if (waitLayoutParentWidth) {
+            parent.style.width = waitLayoutParentWidth
+        } else {
+            parent.style.removeProperty('width')
+        }
+        if (waitLayoutParentHeight) {
+            parent.style.height = waitLayoutParentHeight
+        } else {
+            parent.style.removeProperty('height')
+        }
+        parent.dispatchEvent(
+            new CustomEvent(presenceLayoutReleaseEvent, {
+                detail: { previousRect: domRectToRectLike(previousRect) }
+            })
+        )
+        waitLayoutParent = null
+        waitLayoutParentWidth = ''
+        waitLayoutParentHeight = ''
+    }
+
+    const revealWaitHiddenElement = () => {
+        waitEnterReleased = true
+        if (waitHiddenDisplay !== null && element) {
+            if (waitHiddenDisplay) {
+                element.style.display = waitHiddenDisplay
+            } else {
+                element.style.removeProperty('display')
+            }
+            element.removeAttribute('data-presence-wait-hidden')
+            waitHiddenDisplay = null
+        }
+        releaseWaitLayoutHold()
+    }
 
     /**
      * Run the enter animation, respecting wait mode if inside AnimatePresence.
@@ -977,11 +1094,20 @@
                 return true // Still deferred
             }
 
-            const blocked = context.isEnterBlocked?.()
+            const blocked = context.isEnterBlocked?.(presenceKey)
             pwLog('[motion] runAnimation: wait mode', { blocked })
 
             if (blocked) {
                 pwLog('[motion] runAnimation: enters blocked, deferring')
+
+                waitEnterReleased = false
+                if (waitHiddenDisplay === null) {
+                    waitHiddenDisplay =
+                        element.style.display === 'none' ? '' : element.style.display
+                    element.style.display = 'none'
+                    element.setAttribute('data-presence-wait-hidden', 'true')
+                    holdWaitLayout()
+                }
 
                 waitCallbackRegistered = true
 
@@ -991,6 +1117,12 @@
                     waitUnsubscribe?.()
                     waitUnsubscribe = null
                     waitCallbackRegistered = false
+
+                    // Reveal synchronously after the exiting placeholder has
+                    // been removed. The parent is fixed-size until the next
+                    // frame, so it measures the final entrant instead of an
+                    // overlap between exiting and entering content.
+                    revealWaitHiddenElement()
 
                     // Snap to initial state first (in case inline styles were removed)
                     if (initialKeyframes && element) {
@@ -1023,6 +1155,11 @@
                 })
                 return true // Animation was deferred
             }
+
+            if (waitHiddenDisplay !== null || waitEnterBlockedBeforeMount) {
+                pwLog('[motion] runAnimation: wait mode no longer blocked, revealing')
+                revealWaitHiddenElement()
+            }
         }
 
         // Not blocked - run animation immediately
@@ -1046,6 +1183,7 @@
     let objectAnimateRanOnMount = $state(false)
     // Track the serialized animateProp to detect changes for object animate props
     let lastAnimatePropJson = $state<string | undefined>(undefined)
+    let motionDomProjectionUpdatePending = false
     const currentAnimateKey = $derived(
         typeof animateProp === 'string'
             ? animateProp
@@ -1053,6 +1191,72 @@
               ? effectiveAnimate
               : undefined
     )
+
+    $effect(() => {
+        if (!motionDomProjection) return
+        motionDomProjection.updateOptions({
+            layout: layoutProp,
+            layoutId: scopedLayoutId,
+            transition: mergedTransition as never,
+            style: styleProp
+        })
+    })
+
+    $effect(() => {
+        if (!motionDomProjection) return
+        if (!element) return
+        motionDomProjection.mount(element)
+        return () => {
+            motionDomProjection.unmount()
+        }
+    })
+
+    let explicitLayoutSnapshot: RectLike | null = null
+    let lastRect: RectLike | null = null
+    const trackLayoutProjectionDependencies = () => [
+        classProp,
+        styleProp,
+        scopedLayoutId,
+        mergedTransition
+    ]
+
+    $effect.pre(() => {
+        const shouldProject = element && layoutProp && isLoaded === 'ready' && hasLayoutFeatures
+        // Track common layout-affecting props so Svelte-owned updates can
+        // snapshot before the DOM patch, matching upstream MeasureLayout.
+        trackLayoutProjectionDependencies()
+
+        if (!shouldProject) {
+            explicitLayoutSnapshot = null
+            return
+        }
+
+        explicitLayoutSnapshot = measureLayoutRect()
+        projection.willUpdate()
+        motionDomProjection?.willUpdate()
+        motionDomProjectionUpdatePending = true
+    })
+
+    $effect(() => {
+        const shouldProject = element && layoutProp && isLoaded === 'ready' && hasLayoutFeatures
+        trackLayoutProjectionDependencies()
+
+        if (!shouldProject || !motionDomProjectionUpdatePending) return
+        motionDomProjectionUpdatePending = false
+        const previous = explicitLayoutSnapshot
+        explicitLayoutSnapshot = null
+        if (previous) {
+            const next = measureLayoutRect()
+            if (next) {
+                const flipLayoutMode = layoutProp === 'position' ? 'position' : true
+                const transforms = computeFlipTransforms(previous, next, flipLayoutMode)
+                runFlipAnimation(element!, transforms, (mergedTransition ?? {}) as AnimationOptions)
+                lastRect = next
+            }
+        }
+        projection.didUpdate()
+        motionDomProjection?.didUpdate()
+    })
 
     // Projection node lifecycle + the `onProjectionUpdate` listener.
     // Mount once the element binds; seed the baseline layout; unmount on
@@ -1081,56 +1285,80 @@
         }
     })
 
-    // Minimal layout animation using FLIP when `layout` is enabled.
-    // When layout === 'position' we only translate.
-    // When layout === true we also scale to smoothly interpolate size changes.
-    let lastRect: RectLike | null = null
+    // Upstream layout projection via motion-dom. Svelte runes mode doesn't
+    // expose the React-style pre/post render hook pair used upstream, so the
+    // component snapshots committed layout changes through DOM observers while
+    // keeping the existing local ProjectionNode event fan-out alive.
     $effect(() => {
         if (!(element && layoutProp && isLoaded === 'ready' && hasLayoutFeatures)) return
 
-        // Initialize last rect on first ready frame. We measure through the
-        // projection node rather than `measureRect` directly so the rect is
-        // ancestor-transform-invariant: the node resets the whole ancestor
-        // chain to its mount-time base while reading, which strips any
-        // motion-applied (FLIP/drag) transform up the tree. Without this a
-        // child re-measures and FLIPs whenever an ancestor's transform
-        // animates, even though the child's own layout never moved. (#379)
+        let rafId: number | null = null
+        const flipLayoutMode = layoutProp === 'position' ? 'position' : true
+        motionDomProjection?.seedLayout()
         lastRect = measureLayoutRect()
-        // Hint compositor for smoother FLIP transforms
         setCompositorHints(element!, true)
 
-        let rafId: number | null = null
-        const runFlip = () => {
-            // commitLayoutChange does the ancestor-stripped measure, fans
-            // the delta out to `onProjectionUpdate` listeners, AND returns
-            // the freshly-measured box — so the FLIP reuses that single
-            // measurement as `next` instead of walking + transform-resetting
-            // the ancestor chain a second time per frame. (#379)
-            const nextBox = projection.commitLayoutChange()
-            if (!nextBox) return
-            const next = boxToRectLike(nextBox)
-            if (!lastRect) {
-                lastRect = next
+        const commitObservedLayout = () => {
+            if (element!.hasAttribute('data-layout-size-animation')) {
                 return
             }
-            const transforms = computeFlipTransforms(lastRect, next, layoutProp ?? false)
-            runFlipAnimation(element!, transforms, (mergedTransition ?? {}) as AnimationOptions)
-            lastRect = next
+
+            const hasPresenceHold = element!.hasAttribute(presenceLayoutHoldAttribute)
+            const hasHiddenWaitEnter = !!element!.querySelector(
+                '[data-presence-wait-hidden="true"]'
+            )
+            const hasPresencePlaceholder = !!element!.querySelector(
+                '[data-presence-placeholder="true"]'
+            )
+
+            if (hasPresenceHold || hasHiddenWaitEnter) {
+                return
+            }
+
+            if (hasPresencePlaceholder) {
+                lastRect = measureLayoutRect()
+                motionDomProjection?.seedLayout()
+                return
+            }
+
+            const nextBox = projection.commitLayoutChange()
+            if (nextBox && lastRect) {
+                const next = boxToRectLike(nextBox)
+                const transforms = computeFlipTransforms(lastRect, next, flipLayoutMode)
+                runFlipAnimation(element!, transforms, (mergedTransition ?? {}) as AnimationOptions)
+                lastRect = next
+            } else if (nextBox) {
+                lastRect = boxToRectLike(nextBox)
+            }
+            motionDomProjection?.commitObservedLayoutChange()
         }
 
-        const scheduleFlip = () => {
-            if (rafId) cancelAnimationFrame(rafId)
+        const commitPresenceLayoutRelease = (event: Event) => {
+            const previous = (event as CustomEvent<{ previousRect?: RectLike }>).detail
+                ?.previousRect
+            const next = measureLayoutRect()
+            if (!(previous && next)) return
+
+            const transforms = computeFlipTransforms(previous, next, flipLayoutMode)
+            runFlipAnimation(element!, transforms, (mergedTransition ?? {}) as AnimationOptions)
+            lastRect = next
+            motionDomProjection?.commitObservedLayoutChange()
+        }
+
+        const scheduleProjectionCommit = () => {
+            if (rafId) return
+            commitObservedLayout()
             rafId = requestAnimationFrame(() => {
                 rafId = null
-                runFlip()
             })
         }
-        const disconnectObservers = observeLayoutChanges(element!, () => scheduleFlip())
+        const disconnectObservers = observeLayoutChanges(element!, () => scheduleProjectionCommit())
+        element!.addEventListener(presenceLayoutReleaseEvent, commitPresenceLayoutRelease)
 
         return () => {
             disconnectObservers()
+            element?.removeEventListener(presenceLayoutReleaseEvent, commitPresenceLayoutRelease)
             lastRect = null
-            // Reset compositor hints on teardown
             if (element) {
                 setCompositorHints(element, false)
             }
@@ -1625,22 +1853,22 @@
     {#if isSVGTag(String(tag))}
         <svelte:element this={tag} bind:this={element} xmlns={SVG_NAMESPACE} {...derivedAttrs} />
         <!-- trunk-ignore(eslint/svelte/no-at-html-tags): optimized appear emits a JSON-escaped SSR bootstrap script, not user-authored HTML. -->
-        {@html optimizedAppearScript}
+        {@html renderedOptimizedAppearScript}
     {:else}
         <svelte:element this={tag} bind:this={element} {...derivedAttrs} />
         <!-- trunk-ignore(eslint/svelte/no-at-html-tags): optimized appear emits a JSON-escaped SSR bootstrap script, not user-authored HTML. -->
-        {@html optimizedAppearScript}
+        {@html renderedOptimizedAppearScript}
     {/if}
 {:else if isSVGTag(String(tag))}
     <svelte:element this={tag} bind:this={element} xmlns={SVG_NAMESPACE} {...derivedAttrs}>
         {@render children?.()}
     </svelte:element>
     <!-- trunk-ignore(eslint/svelte/no-at-html-tags): optimized appear emits a JSON-escaped SSR bootstrap script, not user-authored HTML. -->
-    {@html optimizedAppearScript}
+    {@html renderedOptimizedAppearScript}
 {:else}
     <svelte:element this={tag} bind:this={element} {...derivedAttrs}>
         {@render children?.()}
     </svelte:element>
     <!-- trunk-ignore(eslint/svelte/no-at-html-tags): optimized appear emits a JSON-escaped SSR bootstrap script, not user-authored HTML. -->
-    {@html optimizedAppearScript}
+    {@html renderedOptimizedAppearScript}
 {/if}

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -611,6 +611,24 @@
             ? optimizedAppearScript
             : ''
     )
+    const applyAnimateRestingStyle = () => {
+        if (!element) return
+        const restingValues = resolveRestingValues(
+            animateKeyframes as DOMKeyframesDefinition | undefined
+        ) as Record<string, unknown> | undefined
+        if (!restingValues) return
+        element.setAttribute(
+            'style',
+            mergeInlineStyles(element.getAttribute('style') ?? '', undefined, restingValues)
+        )
+    }
+    const isJsdomRuntime = (): boolean =>
+        typeof navigator !== 'undefined' && /jsdom/i.test(navigator.userAgent)
+    const getTransitionFallbackMs = (transition: AnimationOptions | undefined): number => {
+        const duration = typeof transition?.duration === 'number' ? transition.duration : 0
+        const delay = typeof transition?.delay === 'number' ? transition.delay : 0
+        return Math.max(0, (duration + delay) * 1000)
+    }
     // Wait-mode enter coordination needs to affect the first rendered attrs,
     // before the blocked entrant can participate in layout.
     let waitCallbackRegistered = $state(false)
@@ -981,19 +999,30 @@
 
         // A fresh run owns the transform again until it completes.
         enterAnimationSettled = false
+        const completeEnterAnimation = (
+            def: DOMKeyframesDefinition | undefined = payload as unknown as DOMKeyframesDefinition
+        ) => {
+            if (enterAnimationSettled) return
+            // Now the target is the resting state — promote it to the
+            // inline baseline so it persists after WAAPI surrenders the
+            // property (default fill:'none'). (#377)
+            applyAnimateRestingStyle()
+            enterAnimationSettled = true
+            onAnimationCompleteProp?.(def)
+        }
         animateWithLifecycle(
             element,
             payload as unknown as DOMKeyframesDefinition,
             transitionAnimate as unknown as AnimationOptions,
             (def) => onAnimationStartProp?.(def as unknown as DOMKeyframesDefinition | undefined),
-            (def) => {
-                // Now the target is the resting state — promote it to the
-                // inline baseline so it persists after WAAPI surrenders the
-                // property (default fill:'none'). (#377)
-                enterAnimationSettled = true
-                onAnimationCompleteProp?.(def as unknown as DOMKeyframesDefinition | undefined)
-            }
+            (def) => completeEnterAnimation(def as unknown as DOMKeyframesDefinition | undefined)
         )
+        if (isJsdomRuntime()) {
+            window.setTimeout(
+                () => completeEnterAnimation(),
+                getTransitionFallbackMs(transitionAnimate as AnimationOptions)
+            )
+        }
     }
 
     // Cleanup wait callback on component unmount to prevent memory leaks
@@ -1763,6 +1792,7 @@
                     }
                     finishOptimizedAppearAnimation(optimizedAppearId)
                         .then(() => {
+                            applyAnimateRestingStyle()
                             enterAnimationSettled = true
                             isLoaded = 'ready'
                             onAnimationCompleteProp?.(

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -72,6 +72,10 @@ export type { MotionTemplateInput } from '$lib/utils/motionTemplate.svelte'
 export { useMotionValue } from '$lib/utils/motionValue.svelte'
 export type { MotionValue, RawMotionValue } from '$lib/utils/motionValue.svelte'
 export { useMotionValueEvent } from '$lib/utils/motionValueEvent'
+export {
+    optimizedAppearDataAttribute,
+    startOptimizedAppearAnimation
+} from '$lib/utils/optimizedAppear'
 export { useReducedMotion } from '$lib/utils/reducedMotion.svelte'
 export type { ReducedMotionState } from '$lib/utils/reducedMotion.svelte'
 export { useReducedMotionConfig } from '$lib/utils/reducedMotionConfig.svelte'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -451,8 +451,8 @@ export type MotionProps = {
     style?: string
     /** CSS classes */
     class?: string
-    /** Enable FLIP layout animations; "position" limits to translation only */
-    layout?: boolean | 'position'
+    /** Enable FLIP layout animations; string values select the upstream projection animation type. */
+    layout?: boolean | 'position' | 'size' | 'preserve-aspect'
     /**
      * Fires after each `layout`-driven change with the FLIP delta from
      * the element's internal projection node. Mirrors framer-motion's

--- a/src/lib/utils/layout.spec.ts
+++ b/src/lib/utils/layout.spec.ts
@@ -337,9 +337,21 @@ describe('utils/layout', () => {
                     target: el,
                     options: expect.objectContaining({
                         attributes: true,
-                        attributeFilter: ['class', 'style', 'data-presence-layout-hold'],
+                        attributeFilter: ['class', 'style', 'data-presence-layout-hold']
+                    })
+                }),
+                expect.objectContaining({
+                    target: el,
+                    options: expect.objectContaining({
                         childList: true,
                         subtree: true
+                    })
+                }),
+                expect.objectContaining({
+                    target: parent,
+                    options: expect.objectContaining({
+                        childList: true,
+                        subtree: false
                     })
                 })
             ])

--- a/src/lib/utils/layout.spec.ts
+++ b/src/lib/utils/layout.spec.ts
@@ -228,6 +228,39 @@ describe('utils/layout', () => {
         expect('y' in (keyframes as Record<string, unknown>)).toBe(false)
     })
 
+    it('runFlipAnimation: animates box size when scaling would distort layout descendants', async () => {
+        const el = document.createElement('button')
+        const child = document.createElement('span')
+        child.setAttribute('data-svelte-motion-layout', '')
+        el.appendChild(child)
+
+        let measureCount = 0
+        vi.spyOn(el, 'getBoundingClientRect').mockImplementation(() => {
+            measureCount += 1
+            return measureCount === 1 ? new DOMRect(100, 20, 80, 30) : new DOMRect(100, 20, 60, 30)
+        })
+
+        animateMock.mockClear()
+        runFlipAnimation(
+            el,
+            { dx: 0, dy: 0, sx: 0.75, sy: 1, shouldTranslate: false, shouldScale: true },
+            {}
+        )
+
+        expect(el.getAttribute('data-layout-size-animation')).toBe('true')
+        expect(el.style.width).toBe('60px')
+
+        const call = animateMock.mock.calls[0]
+        expect(call?.[0]).toBe(el)
+        const keyframes = call?.[1] as Record<string, unknown>
+        expect(keyframes).toMatchObject({ width: ['60px', '80px'], height: ['30px', '30px'] })
+        expect('scaleX' in keyframes).toBe(false)
+        expect(child.style.transform).toBe('')
+
+        await Promise.resolve()
+        expect(el.hasAttribute('data-layout-size-animation')).toBe(false)
+    })
+
     it('setCompositorHints: toggles styles', () => {
         const el = document.createElement('div')
         setCompositorHints(el, true)
@@ -285,7 +318,7 @@ describe('utils/layout', () => {
                     target: el,
                     options: expect.objectContaining({
                         attributes: true,
-                        attributeFilter: ['class', 'style']
+                        attributeFilter: ['class', 'style', 'data-presence-layout-hold']
                     })
                 })
             ])
@@ -374,6 +407,53 @@ describe('utils/layout', () => {
         // Teardown
         rafSpy.mockRestore()
         cafSpy.mockRestore()
+        vi.unstubAllGlobals()
+    })
+
+    it('observeLayoutChanges: ignores layout changes while an ancestor is box-size animating', () => {
+        const parent = document.createElement('div')
+        const el = document.createElement('div')
+        parent.setAttribute('data-layout-size-animation', 'true')
+        parent.appendChild(el)
+        el.style.transform = 'translateX(12px)'
+        el.style.transformOrigin = '0 0'
+        el.style.willChange = 'transform'
+        const cb = vi.fn()
+
+        class FakeResizeObserver {
+            private _cb: ResizeObserverCallback
+            constructor(cb2: ResizeObserverCallback) {
+                this._cb = cb2
+            }
+            observe() {
+                this._cb([], this as unknown as ResizeObserver)
+            }
+            disconnect() {}
+        }
+        class FakeMutationObserver {
+            private _cb: MutationCallback
+            constructor(cb2: MutationCallback) {
+                this._cb = cb2
+            }
+            observe() {
+                this._cb([], this as unknown as MutationObserver)
+            }
+            disconnect() {}
+        }
+        vi.stubGlobal('ResizeObserver', FakeResizeObserver as unknown as typeof ResizeObserver)
+        vi.stubGlobal(
+            'MutationObserver',
+            FakeMutationObserver as unknown as typeof MutationObserver
+        )
+
+        const cleanup = observeLayoutChanges(el, cb)
+
+        expect(cb).not.toHaveBeenCalled()
+        expect(el.style.transform).toBe('')
+        expect(el.style.transformOrigin).toBe('')
+        expect(el.style.willChange).toBe('')
+
+        cleanup()
         vi.unstubAllGlobals()
     })
 

--- a/src/lib/utils/layout.spec.ts
+++ b/src/lib/utils/layout.spec.ts
@@ -318,7 +318,9 @@ describe('utils/layout', () => {
                     target: el,
                     options: expect.objectContaining({
                         attributes: true,
-                        attributeFilter: ['class', 'style', 'data-presence-layout-hold']
+                        attributeFilter: ['class', 'style', 'data-presence-layout-hold'],
+                        childList: true,
+                        subtree: true
                     })
                 })
             ])

--- a/src/lib/utils/layout.spec.ts
+++ b/src/lib/utils/layout.spec.ts
@@ -52,6 +52,25 @@ describe('utils/layout', () => {
         spy.mockRestore()
     })
 
+    it('measureRect: adds viewport scroll when requested', () => {
+        const el = document.createElement('div')
+        const scrollX = vi.spyOn(window, 'scrollX', 'get').mockReturnValue(15)
+        const scrollY = vi.spyOn(window, 'scrollY', 'get').mockReturnValue(40)
+        const spy = vi
+            .spyOn(el, 'getBoundingClientRect')
+            .mockReturnValue(new DOMRect(10, 20, 100, 50))
+
+        const rect = measureRect(el, [], 'none', true)
+        expect(rect.left).toBe(25)
+        expect(rect.top).toBe(60)
+        expect(rect.width).toBe(100)
+        expect(rect.height).toBe(50)
+
+        spy.mockRestore()
+        scrollX.mockRestore()
+        scrollY.mockRestore()
+    })
+
     it('measureRect: adds a single scroll container offset to the returned rect', () => {
         const el = document.createElement('div')
         const scroller = document.createElement('div')

--- a/src/lib/utils/layout.ts
+++ b/src/lib/utils/layout.ts
@@ -1,5 +1,66 @@
 import { animate, type AnimationOptions, type DOMKeyframesDefinition } from 'motion'
 
+const layoutSizeAnimationAttribute = 'data-layout-size-animation'
+
+const px = (value: number): string => `${Math.max(0, value)}px`
+
+const runBoxSizeAnimation = (
+    el: HTMLElement,
+    transforms: {
+        dx: number
+        dy: number
+        sx: number
+        sy: number
+    },
+    transition: AnimationOptions
+) => {
+    const { dx, dy, sx, sy } = transforms
+    const originalWidth = el.style.width
+    const originalHeight = el.style.height
+    const originalTransform = el.style.transform
+    const originalTransformOrigin = el.style.transformOrigin
+
+    const nextRect = el.getBoundingClientRect()
+    const prevWidth = nextRect.width * sx
+    const prevHeight = nextRect.height * sy
+
+    el.setAttribute(layoutSizeAnimationAttribute, 'true')
+    for (const child of el.querySelectorAll<HTMLElement>('[data-svelte-motion-layout]')) {
+        child.style.transform = ''
+        child.style.transformOrigin = ''
+        if (child.style.willChange === 'transform') child.style.willChange = ''
+    }
+    el.style.width = px(prevWidth)
+    el.style.height = px(prevHeight)
+
+    const sizedRect = el.getBoundingClientRect()
+    const residualDx = nextRect.left + dx - sizedRect.left
+    const residualDy = nextRect.top + dy - sizedRect.top
+    const shouldTranslate = Math.abs(residualDx) > 0.5 || Math.abs(residualDy) > 0.5
+
+    const keyframes: Record<string, unknown> = {
+        width: [px(prevWidth), px(nextRect.width)],
+        height: [px(prevHeight), px(nextRect.height)]
+    }
+
+    if (shouldTranslate) {
+        keyframes.x = [residualDx, 0]
+        keyframes.y = [residualDy, 0]
+        el.style.transformOrigin = '0 0'
+        el.style.transform = `translate(${residualDx}px, ${residualDy}px)`
+    }
+
+    const animation = animate(el, keyframes as unknown as DOMKeyframesDefinition, transition)
+
+    animation.finished?.finally(() => {
+        el.style.width = originalWidth
+        el.style.height = originalHeight
+        el.style.transformOrigin = originalTransformOrigin
+        el.style.transform = originalTransform
+        el.removeAttribute(layoutSizeAnimationAttribute)
+    })
+}
+
 /**
  * Measure an element's bounding client rect without current transform.
  *
@@ -137,6 +198,15 @@ export const runFlipAnimation = (
     const { dx, dy, sx, sy, shouldTranslate, shouldScale } = transforms
     if (!(shouldTranslate || shouldScale)) return
 
+    const correctionTargets = shouldScale
+        ? Array.from(el.querySelectorAll<HTMLElement>('[data-svelte-motion-layout]'))
+        : []
+
+    if (shouldScale && correctionTargets.length > 0) {
+        runBoxSizeAnimation(el, { dx, dy, sx, sy }, transition)
+        return
+    }
+
     const keyframes: Record<string, unknown> = {}
     if (shouldTranslate) {
         keyframes.x = [dx, 0]
@@ -184,6 +254,12 @@ export const observeLayoutChanges = (el: HTMLElement, onChange: () => void): (()
     let releaseTimeout: ReturnType<typeof setTimeout> | null = null
 
     const schedule = () => {
+        if (el.closest(`[${layoutSizeAnimationAttribute}]`)) {
+            el.style.transform = ''
+            el.style.transformOrigin = ''
+            if (el.style.willChange === 'transform') el.style.willChange = ''
+            return
+        }
         if (pendingRaf !== null || releaseTimeout !== null) return
         // Leading-edge: call immediately, then throttle further calls until next frame (or 50ms)
         onChange()
@@ -200,7 +276,10 @@ export const observeLayoutChanges = (el: HTMLElement, onChange: () => void): (()
     const ro = new ResizeObserver(() => schedule())
     ro.observe(el)
     const mo = new MutationObserver(() => schedule())
-    mo.observe(el, { attributes: true, attributeFilter: ['class', 'style'] })
+    mo.observe(el, {
+        attributes: true,
+        attributeFilter: ['class', 'style', 'data-presence-layout-hold']
+    })
     if (el.parentElement) {
         mo.observe(el.parentElement, { childList: true, subtree: false, attributes: true })
     }

--- a/src/lib/utils/layout.ts
+++ b/src/lib/utils/layout.ts
@@ -346,19 +346,23 @@ export const observeLayoutChanges = (el: HTMLElement, onChange: () => void): (()
     }
     const ro = new ResizeObserver(() => schedule())
     ro.observe(el)
-    const mo = new MutationObserver(() => schedule())
-    mo.observe(el, {
+    const attributeObserver = new MutationObserver(() => schedule())
+    attributeObserver.observe(el, {
         attributes: true,
-        attributeFilter: ['class', 'style', 'data-presence-layout-hold'],
+        attributeFilter: ['class', 'style', 'data-presence-layout-hold']
+    })
+    const childListObserver = new MutationObserver(() => schedule())
+    childListObserver.observe(el, {
         childList: true,
         subtree: true
     })
     if (el.parentElement) {
-        mo.observe(el.parentElement, { childList: true, subtree: false, attributes: true })
+        childListObserver.observe(el.parentElement, { childList: true, subtree: false })
     }
     return () => {
         ro.disconnect()
-        mo.disconnect()
+        attributeObserver.disconnect()
+        childListObserver.disconnect()
         if (pendingRaf !== null && typeof cancelAnimationFrame === 'function') {
             cancelAnimationFrame(pendingRaf)
             pendingRaf = null

--- a/src/lib/utils/layout.ts
+++ b/src/lib/utils/layout.ts
@@ -4,6 +4,18 @@ const layoutSizeAnimationAttribute = 'data-layout-size-animation'
 
 const px = (value: number): string => `${Math.max(0, value)}px`
 
+const isViewportOffscreen = (el: HTMLElement): boolean => {
+    if (typeof window === 'undefined') return false
+
+    const rect = el.getBoundingClientRect()
+    return (
+        rect.bottom <= 0 ||
+        rect.right <= 0 ||
+        rect.top >= window.innerHeight ||
+        rect.left >= window.innerWidth
+    )
+}
+
 const runBoxSizeAnimation = (
     el: HTMLElement,
     transforms: {
@@ -52,13 +64,60 @@ const runBoxSizeAnimation = (
 
     const animation = animate(el, keyframes as unknown as DOMKeyframesDefinition, transition)
 
-    animation.finished?.finally(() => {
+    let removeScrollListener: (() => void) | undefined
+    let offscreenRaf: number | null = null
+    let cleanupRan = false
+    const cleanup = () => {
+        if (cleanupRan) return
+        cleanupRan = true
+        removeScrollListener?.()
+        if (
+            offscreenRaf !== null &&
+            typeof window !== 'undefined' &&
+            typeof window.cancelAnimationFrame === 'function'
+        ) {
+            window.cancelAnimationFrame(offscreenRaf)
+            offscreenRaf = null
+        }
         el.style.width = originalWidth
         el.style.height = originalHeight
         el.style.transformOrigin = originalTransformOrigin
         el.style.transform = originalTransform
         el.removeAttribute(layoutSizeAnimationAttribute)
-    })
+    }
+
+    if (typeof window !== 'undefined') {
+        const completeIfOffscreen = () => {
+            if (cleanupRan) return
+            if (isViewportOffscreen(el)) {
+                animation.complete()
+                cleanup()
+            }
+        }
+        const scheduleCompleteIfOffscreen = () => {
+            if (typeof window.requestAnimationFrame !== 'function') {
+                completeIfOffscreen()
+                return
+            }
+            if (offscreenRaf !== null) return
+            offscreenRaf = window.requestAnimationFrame(() => {
+                offscreenRaf = null
+                completeIfOffscreen()
+            })
+        }
+        const handleScroll = () => {
+            completeIfOffscreen()
+            scheduleCompleteIfOffscreen()
+        }
+        window.addEventListener('scroll', handleScroll, { passive: true })
+        removeScrollListener = () => {
+            window.removeEventListener('scroll', handleScroll)
+        }
+        completeIfOffscreen()
+        scheduleCompleteIfOffscreen()
+    }
+
+    animation.finished?.finally(cleanup)
 }
 
 /**
@@ -68,11 +127,13 @@ const runBoxSizeAnimation = (
  * immediately after reading the rect.
  *
  * When `scrollContainers` are provided, the returned rect is shifted by the
- * **sum** of each container's `scrollLeft` / `scrollTop`. FLIP deltas
- * computed from two such measures stay correct even when the user scrolls
- * any of the containers between measurements — including a nested
- * `layoutScroll` inside another `layoutScroll`. Mirrors framer-motion's
- * `removeElementScroll`, which walks every ancestor in the path.
+ * **sum** of each container's `scrollLeft` / `scrollTop`. When
+ * `includeViewportScroll` is true, the viewport's `window.scrollX` /
+ * `window.scrollY` is included too. FLIP deltas computed from two such
+ * measures stay correct even when the user scrolls between measurements —
+ * including a nested `layoutScroll` inside another `layoutScroll`. Mirrors
+ * framer-motion's `removeElementScroll`, which walks every ancestor in the
+ * path, plus root scroll compensation from the projection tree.
  *
  * Pass an empty array (or omit) for viewport-relative behaviour.
  *
@@ -89,6 +150,7 @@ const runBoxSizeAnimation = (
  * @param el Element to measure.
  * @param scrollContainers Optional ancestor chain with `layoutScroll` enabled.
  * @param baseTransform Transform string applied during measurement. Defaults to `'none'`.
+ * @param includeViewportScroll Whether to include `window.scrollX/Y` in the returned rect.
  * @returns DOMRect snapshot of the element.
  *
  * @example
@@ -106,19 +168,28 @@ const runBoxSizeAnimation = (
 export const measureRect = (
     el: HTMLElement,
     scrollContainers?: HTMLElement[],
-    baseTransform = 'none'
+    baseTransform = 'none',
+    includeViewportScroll = false
 ): DOMRect => {
     const prev = el.style.transform
     try {
         el.style.transform = baseTransform
         const rect = el.getBoundingClientRect()
-        if (!scrollContainers || scrollContainers.length === 0) return rect
+        let offsetLeft = includeViewportScroll && typeof window !== 'undefined' ? window.scrollX : 0
+        let offsetTop = includeViewportScroll && typeof window !== 'undefined' ? window.scrollY : 0
+        if (!scrollContainers || scrollContainers.length === 0) {
+            if (offsetLeft === 0 && offsetTop === 0) return rect
+            return new DOMRect(
+                rect.left + offsetLeft,
+                rect.top + offsetTop,
+                rect.width,
+                rect.height
+            )
+        }
         // Re-express the rect in the *combined* scroll-container coordinate
         // space so a subsequent scroll on any of them doesn't show up as
         // movement. DOMRect's left/top are read-only, so allocate a fresh
         // one with the summed offsets applied.
-        let offsetLeft = 0
-        let offsetTop = 0
         for (const container of scrollContainers) {
             offsetLeft += container.scrollLeft
             offsetTop += container.scrollTop

--- a/src/lib/utils/layout.ts
+++ b/src/lib/utils/layout.ts
@@ -278,7 +278,9 @@ export const observeLayoutChanges = (el: HTMLElement, onChange: () => void): (()
     const mo = new MutationObserver(() => schedule())
     mo.observe(el, {
         attributes: true,
-        attributeFilter: ['class', 'style', 'data-presence-layout-hold']
+        attributeFilter: ['class', 'style', 'data-presence-layout-hold'],
+        childList: true,
+        subtree: true
     })
     if (el.parentElement) {
         mo.observe(el.parentElement, { childList: true, subtree: false, attributes: true })

--- a/src/lib/utils/motionDomProjection.ts
+++ b/src/lib/utils/motionDomProjection.ts
@@ -118,6 +118,12 @@ export class MotionDomProjectionAdapter {
      * Update projection options from current Svelte props.
      *
      * @param options Current layout-related motion props.
+     * @returns Nothing.
+     *
+     * @example
+     * ```ts
+     * adapter.updateOptions({ layout, layoutId, transition, style })
+     * ```
      */
     updateOptions(options: MotionDomProjectionUpdateOptions): void {
         this.layout = options.layout
@@ -144,6 +150,12 @@ export class MotionDomProjectionAdapter {
      * Mount the upstream projection node to an element and seed its layout.
      *
      * @param element Element represented by the current motion component.
+     * @returns Nothing.
+     *
+     * @example
+     * ```ts
+     * adapter.mount(element)
+     * ```
      */
     mount(element: HTMLElement): void {
         if (this.element === element) return
@@ -156,6 +168,13 @@ export class MotionDomProjectionAdapter {
 
     /**
      * Unmount the upstream projection node and clear its visual-element store.
+     *
+     * @returns Nothing.
+     *
+     * @example
+     * ```ts
+     * adapter.unmount()
+     * ```
      */
     unmount(): void {
         if (!this.element) return
@@ -169,6 +188,13 @@ export class MotionDomProjectionAdapter {
 
     /**
      * Capture the upstream "before" snapshot.
+     *
+     * @returns Nothing.
+     *
+     * @example
+     * ```ts
+     * adapter.willUpdate()
+     * ```
      */
     willUpdate(): void {
         if (!this.element || !this.layoutId) return
@@ -177,6 +203,13 @@ export class MotionDomProjectionAdapter {
 
     /**
      * Commit an upstream layout update after Svelte has patched the DOM.
+     *
+     * @returns Nothing.
+     *
+     * @example
+     * ```ts
+     * adapter.didUpdate()
+     * ```
      */
     didUpdate(): void {
         if (!this.element || !this.layoutId) return
@@ -186,6 +219,13 @@ export class MotionDomProjectionAdapter {
 
     /**
      * Seed the current layout without animating.
+     *
+     * @returns Nothing.
+     *
+     * @example
+     * ```ts
+     * adapter.seedLayout()
+     * ```
      */
     seedLayout(): void {
         if (!this.element) return
@@ -201,6 +241,13 @@ export class MotionDomProjectionAdapter {
      * Svelte runes mode doesn't expose the same component pre/post-update
      * hooks Framer Motion uses in React, so this adapter reuses upstream
      * projection while the Svelte component controls the snapshot timing.
+     *
+     * @returns Nothing.
+     *
+     * @example
+     * ```ts
+     * adapter.commitObservedLayoutChange()
+     * ```
      */
     commitObservedLayoutChange(): void {
         if (!this.element || !this.layoutId) return

--- a/src/lib/utils/motionDomProjection.ts
+++ b/src/lib/utils/motionDomProjection.ts
@@ -1,0 +1,225 @@
+import {
+    HTMLProjectionNode,
+    HTMLVisualElement,
+    copyBoxInto,
+    createBox,
+    visualElementStore,
+    type IProjectionNode,
+    type Measurements,
+    type ResolvedValues,
+    type Transition,
+    type VisualElement
+} from 'motion-dom'
+
+type ProjectionVisualElement = VisualElement & {
+    latestValues: ResolvedValues
+    projection?: IProjectionNode<HTMLElement>
+}
+
+type LayoutOption = boolean | string | undefined
+type AnimationType = 'position' | 'x' | 'y' | 'size' | 'both' | 'preserve-aspect'
+
+export interface MotionDomProjectionOptions {
+    /** Parent adapter used to connect this node into the upstream projection tree. */
+    parent?: MotionDomProjectionAdapter | null
+}
+
+/**
+ * Latest layout-related motion props applied to an upstream projection node.
+ */
+export interface MotionDomProjectionUpdateOptions {
+    /** Enables layout projection and selects the upstream animation type. */
+    layout?: LayoutOption
+    /** Shared layout id used by upstream projection matching. */
+    layoutId?: string
+    /** Transition passed to the upstream layout animation builder. */
+    transition?: Transition
+    /** Inline style props passed through to the visual element. */
+    style?: unknown
+}
+
+const createVisualState = () => ({
+    latestValues: {},
+    renderState: {
+        transform: {},
+        transformOrigin: {},
+        style: {},
+        vars: {}
+    }
+})
+
+const cloneMeasurements = (measurements: Measurements | undefined): Measurements | undefined => {
+    if (!measurements) return undefined
+
+    const measuredBox = createBox()
+    const layoutBox = createBox()
+    copyBoxInto(measuredBox, measurements.measuredBox)
+    copyBoxInto(layoutBox, measurements.layoutBox)
+
+    return {
+        animationId: measurements.animationId,
+        measuredBox,
+        layoutBox,
+        latestValues: { ...measurements.latestValues },
+        source: measurements.source
+    }
+}
+
+const animationTypes = new Set<AnimationType>([
+    'position',
+    'x',
+    'y',
+    'size',
+    'both',
+    'preserve-aspect'
+])
+
+const animationTypeForLayout = (layout: LayoutOption): AnimationType =>
+    typeof layout === 'string' && animationTypes.has(layout as AnimationType)
+        ? (layout as AnimationType)
+        : 'both'
+
+/**
+ * Svelte lifecycle adapter for motion-dom's upstream projection node system.
+ *
+ * The public Svelte API stays unchanged (`layout`, `layoutId`, `transition`).
+ * This adapter only translates those props into the same `HTMLProjectionNode`
+ * and `HTMLVisualElement` internals Framer Motion uses.
+ */
+export class MotionDomProjectionAdapter {
+    readonly visualElement: ProjectionVisualElement
+    readonly projection: IProjectionNode<HTMLElement>
+
+    private element: HTMLElement | null = null
+    private layout: LayoutOption
+    private layoutId: string | undefined
+    private transition: Transition | undefined
+    private lastLayout: Measurements | undefined
+
+    constructor(options: MotionDomProjectionOptions = {}) {
+        const parent = options.parent ?? null
+        this.visualElement = new HTMLVisualElement(
+            {
+                parent: parent?.visualElement,
+                props: {},
+                presenceContext: null,
+                visualState: createVisualState()
+            } as never,
+            { allowProjection: true } as never
+        ) as ProjectionVisualElement
+        this.projection = new HTMLProjectionNode(
+            this.visualElement.latestValues,
+            parent?.projection as unknown as IProjectionNode | undefined
+        )
+        this.visualElement.projection = this.projection
+    }
+
+    /**
+     * Update projection options from current Svelte props.
+     *
+     * @param options Current layout-related motion props.
+     */
+    updateOptions(options: MotionDomProjectionUpdateOptions): void {
+        this.layout = options.layout
+        this.layoutId = options.layoutId
+        this.transition = options.transition
+
+        this.visualElement.update(
+            {
+                transition: options.transition,
+                style: options.style
+            } as never,
+            null
+        )
+        this.projection.setOptions({
+            layout: options.layout,
+            layoutId: options.layoutId,
+            animationType: animationTypeForLayout(options.layout),
+            transition: options.transition,
+            visualElement: this.visualElement
+        })
+    }
+
+    /**
+     * Mount the upstream projection node to an element and seed its layout.
+     *
+     * @param element Element represented by the current motion component.
+     */
+    mount(element: HTMLElement): void {
+        if (this.element === element) return
+        if (this.element) this.unmount()
+
+        this.element = element
+        this.visualElement.mount(element)
+        this.seedLayout()
+    }
+
+    /**
+     * Unmount the upstream projection node and clear its visual-element store.
+     */
+    unmount(): void {
+        if (!this.element) return
+        const element = this.element
+        this.projection.scheduleCheckAfterUnmount()
+        this.visualElement.unmount()
+        visualElementStore.delete(element)
+        this.element = null
+        this.lastLayout = undefined
+    }
+
+    /**
+     * Capture the upstream "before" snapshot.
+     */
+    willUpdate(): void {
+        if (!this.element || !this.layoutId) return
+        this.projection.willUpdate()
+    }
+
+    /**
+     * Commit an upstream layout update after Svelte has patched the DOM.
+     */
+    didUpdate(): void {
+        if (!this.element || !this.layoutId) return
+        this.projection.root?.didUpdate()
+        this.refreshCachedLayout()
+    }
+
+    /**
+     * Seed the current layout without animating.
+     */
+    seedLayout(): void {
+        if (!this.element) return
+        this.projection.isLayoutDirty = true
+        this.projection.updateLayout()
+        this.lastLayout = cloneMeasurements(this.projection.layout)
+    }
+
+    /**
+     * Animate from the last cached layout to the current observed layout.
+     *
+     * This covers layout changes discovered after the mutation by observers.
+     * Svelte runes mode doesn't expose the same component pre/post-update
+     * hooks Framer Motion uses in React, so this adapter reuses upstream
+     * projection while the Svelte component controls the snapshot timing.
+     */
+    commitObservedLayoutChange(): void {
+        if (!this.element || !this.layoutId) return
+        const snapshot = cloneMeasurements(this.lastLayout)
+        if (!snapshot) {
+            this.seedLayout()
+            return
+        }
+
+        this.projection.root?.startUpdate()
+        this.projection.snapshot = snapshot
+        this.projection.isLayoutDirty = true
+        this.projection.root?.didUpdate()
+        this.refreshCachedLayout()
+    }
+
+    private refreshCachedLayout(): void {
+        requestAnimationFrame(() => {
+            this.lastLayout = cloneMeasurements(this.projection.layout)
+        })
+    }
+}

--- a/src/lib/utils/optimizedAppear.spec.ts
+++ b/src/lib/utils/optimizedAppear.spec.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+    createOptimizedAppearData,
+    createOptimizedAppearScript,
+    handoffOptimizedAppearAnimation,
+    optimizedAppearDataAttribute,
+    startOptimizedAppearAnimation
+} from './optimizedAppear'
+
+afterEach(() => {
+    vi.restoreAllMocks()
+    window.MotionIsMounted = undefined
+    window.MotionHasOptimisedAnimation = undefined
+    window.MotionHandoffMarkAsComplete = undefined
+    window.MotionHandoffIsComplete = undefined
+    window.MotionCancelOptimisedAnimation = undefined
+    window.__SvelteMotionAppear = undefined
+})
+
+describe('optimizedAppear', () => {
+    it('builds opacity and transform appear entries from initial and animate values', () => {
+        const entries = createOptimizedAppearData(
+            { opacity: 0, scale: 0.8, y: 16 },
+            { opacity: 1, scale: 1, y: 0 },
+            { duration: 0.6, ease: [0.16, 1, 0.3, 1] }
+        )
+
+        expect(entries).toEqual([
+            {
+                name: 'opacity',
+                keyframes: [0, 1],
+                options: {
+                    duration: 600,
+                    delay: 0,
+                    fill: 'both',
+                    easing: 'cubic-bezier(0.16, 1, 0.3, 1)'
+                }
+            },
+            {
+                name: 'transform',
+                keyframes: ['scale(0.8) translateY(16px)', 'scale(1) translateY(0px)'],
+                options: {
+                    duration: 600,
+                    delay: 0,
+                    fill: 'both',
+                    easing: 'cubic-bezier(0.16, 1, 0.3, 1)'
+                }
+            }
+        ])
+    })
+
+    it('creates an SSR bootstrap script with the upstream data attribute', () => {
+        const script = createOptimizedAppearScript('appear-1', [
+            {
+                name: 'opacity',
+                keyframes: [0, 1],
+                options: { duration: 300, fill: 'both' }
+            }
+        ])
+
+        expect(script).toContain('<script>')
+        expect(script).toContain(optimizedAppearDataAttribute)
+        expect(script).toContain('appear-1')
+        expect(script).toContain('MotionHasOptimisedAnimation')
+    })
+
+    it('starts and hands off imperative optimized appear animations', () => {
+        const element = document.createElement('div')
+        element.dataset.framerAppearId = 'appear-2'
+        const commitStyles = vi.fn()
+        const cancel = vi.fn()
+        const animation = { commitStyles, cancel, startTime: null } as unknown as Animation
+        const animateSpy = vi.spyOn(element, 'animate').mockReturnValue(animation)
+
+        startOptimizedAppearAnimation(element, 'opacity', [0, 1], { duration: 0.3 })
+
+        expect(animateSpy).toHaveBeenCalled()
+        expect(window.MotionHasOptimisedAnimation?.('appear-2')).toBe(true)
+        expect(handoffOptimizedAppearAnimation('appear-2')).toBe(true)
+        expect(commitStyles).toHaveBeenCalled()
+        expect(cancel).toHaveBeenCalled()
+        expect(window.MotionHandoffIsComplete?.('appear-2')).toBe(true)
+    })
+})

--- a/src/lib/utils/optimizedAppear.spec.ts
+++ b/src/lib/utils/optimizedAppear.spec.ts
@@ -64,6 +64,16 @@ describe('optimizedAppear', () => {
         expect(script).toContain('MotionHasOptimisedAnimation')
     })
 
+    it('maps Motion easing names to native WAAPI easing strings', () => {
+        const entries = createOptimizedAppearData(
+            { opacity: 0 },
+            { opacity: 1 },
+            { duration: 0.4, ease: 'easeInOut' }
+        )
+
+        expect(entries[0]?.options.easing).toBe('ease-in-out')
+    })
+
     it('starts and hands off imperative optimized appear animations', () => {
         const element = document.createElement('div')
         element.dataset.framerAppearId = 'appear-2'

--- a/src/lib/utils/optimizedAppear.spec.ts
+++ b/src/lib/utils/optimizedAppear.spec.ts
@@ -91,4 +91,23 @@ describe('optimizedAppear', () => {
         expect(cancel).toHaveBeenCalled()
         expect(window.MotionHandoffIsComplete?.('appear-2')).toBe(true)
     })
+
+    it('creates an SSR bootstrap script with one shared ready animation gate', () => {
+        const script = createOptimizedAppearScript('appear-3', [
+            {
+                name: 'opacity',
+                keyframes: [0, 1],
+                options: { duration: 300, fill: 'both' }
+            },
+            {
+                name: 'transform',
+                keyframes: ['scale(0)', 'scale(1)'],
+                options: { duration: 300, fill: 'both' }
+            }
+        ])
+
+        expect(script).toContain('if(!s.readyAnimation)')
+        expect(script).toContain('const r=s.readyAnimation')
+        expect(script).not.toContain('const key=k(p.id,a.name),ready=')
+    })
 })

--- a/src/lib/utils/optimizedAppear.ts
+++ b/src/lib/utils/optimizedAppear.ts
@@ -1,6 +1,12 @@
 import { mergeInlineStyles } from '$lib/utils/style'
 import { resolveRestingValues } from '$lib/utils/variants'
 import { startWaapiAnimation, type AnimationOptions } from 'motion'
+import {
+    mapEasingToNativeEasing,
+    optimizedAppearDataAttribute,
+    optimizedAppearDataId,
+    transformProps
+} from 'motion-dom'
 
 type AppearValueName = 'opacity' | 'transform'
 
@@ -21,31 +27,13 @@ type SvelteMotionAppearStore = {
     started: Array<{ id: string; name: string }>
 }
 
-const optimizedAppearDataId = 'framerAppearId'
-const optimizedAppearDataAttribute = 'data-framer-appear-id'
+type NativeEasing = Parameters<typeof mapEasingToNativeEasing>[0]
 
 declare global {
     interface Window {
         __SvelteMotionAppear?: SvelteMotionAppearStore
     }
 }
-
-const transformProps = new Set([
-    'x',
-    'y',
-    'z',
-    'scale',
-    'scaleX',
-    'scaleY',
-    'rotate',
-    'rotateX',
-    'rotateY',
-    'rotateZ',
-    'skew',
-    'skewX',
-    'skewY',
-    'transform'
-])
 
 const appearStoreId = (elementId: string, valueName: string): string => {
     const key = transformProps.has(valueName) ? 'transform' : valueName
@@ -108,16 +96,18 @@ const readStyleProp = (style: string, prop: string): string | undefined => {
 const toNativeOptions = (transition: AnimationOptions | undefined): KeyframeAnimationOptions => {
     const duration = typeof transition?.duration === 'number' ? transition.duration : 0.3
     const delay = typeof transition?.delay === 'number' ? transition.delay : 0
+    const durationMs = duration * 1000
     const options: KeyframeAnimationOptions = {
-        duration: duration * 1000,
+        duration: durationMs,
         delay: delay * 1000,
         fill: 'both'
     }
 
-    if (typeof transition?.ease === 'string') {
-        options.easing = transition.ease
-    } else if (Array.isArray(transition?.ease) && transition.ease.length === 4) {
-        options.easing = `cubic-bezier(${transition.ease.join(', ')})`
+    const easing = mapEasingToNativeEasing(transition?.ease as NativeEasing, durationMs)
+    if (Array.isArray(easing)) {
+        options.easing = easing[0] ?? 'linear'
+    } else if (easing) {
+        options.easing = easing
     }
 
     return options

--- a/src/lib/utils/optimizedAppear.ts
+++ b/src/lib/utils/optimizedAppear.ts
@@ -25,6 +25,8 @@ type SvelteMotionAppearStore = {
     animations: Map<string, AppearStoreEntry>
     complete: Map<string, boolean>
     started: Array<{ id: string; name: string }>
+    readyAnimation?: Animation
+    startFrameTime?: number
 }
 
 type NativeEasing = Parameters<typeof mapEasingToNativeEasing>[0]
@@ -172,7 +174,7 @@ export const createOptimizedAppearScript = (
 ): string => {
     if (!appearId || entries.length === 0) return ''
     const payload = JSON.stringify({ id: appearId, entries }).replace(/</g, '\\u003c')
-    return `<script>(()=>{const p=${payload},w=window;if(w.MotionIsMounted)return;const q=String(p.id).replace(/["\\\\]/g,"\\\\$&");const e=document.querySelector('[${optimizedAppearDataAttribute}="'+q+'"]');if(!e||!e.animate)return;const s=w.__SvelteMotionAppear||(w.__SvelteMotionAppear={animations:new Map,complete:new Map,started:[]});const k=(id,n)=>id+": "+(n==="transform"?"transform":n);w.MotionHasOptimisedAnimation=w.MotionHasOptimisedAnimation||((id,n)=>id?n?s.animations.has(k(id,n)):s.complete.has(id):false);w.MotionHandoffMarkAsComplete=w.MotionHandoffMarkAsComplete||((id)=>{if(s.complete.has(id))s.complete.set(id,true)});w.MotionHandoffIsComplete=w.MotionHandoffIsComplete||((id)=>s.complete.get(id)===true);w.MotionCancelOptimisedAnimation=w.MotionCancelOptimisedAnimation||((id,n)=>{const key=k(id,n),d=s.animations.get(key);if(!d)return;d.animation.cancel();s.animations.delete(key);if(!s.animations.size)w.MotionCancelOptimisedAnimation=undefined});s.complete.set(p.id,false);const t=performance.now();for(const a of p.entries){const anim=e.animate({[a.name]:a.keyframes},a.options);anim.startTime=t;s.animations.set(k(p.id,a.name),{animation:anim,startTime:t});s.started.push({id:p.id,name:a.name})}})();</script>`
+    return `<script>(()=>{const p=${payload},w=window;if(w.MotionIsMounted)return;const q=String(p.id).replace(/["\\\\]/g,"\\\\$&");const e=document.querySelector('[${optimizedAppearDataAttribute}="'+q+'"]');if(!e||!e.animate)return;const s=w.__SvelteMotionAppear||(w.__SvelteMotionAppear={animations:new Map,complete:new Map,started:[]});const k=(id,n)=>id+": "+(n==="transform"?"transform":n);w.MotionHasOptimisedAnimation=w.MotionHasOptimisedAnimation||((id,n)=>id?n?s.animations.has(k(id,n)):s.complete.has(id):false);w.MotionHandoffMarkAsComplete=w.MotionHandoffMarkAsComplete||((id)=>{if(s.complete.has(id))s.complete.set(id,true)});w.MotionHandoffIsComplete=w.MotionHandoffIsComplete||((id)=>s.complete.get(id)===true);w.MotionCancelOptimisedAnimation=w.MotionCancelOptimisedAnimation||((id,n)=>{const key=k(id,n),d=s.animations.get(key);if(!d)return;d.animation.cancel();s.animations.delete(key);if(!s.animations.size)w.MotionCancelOptimisedAnimation=undefined});s.complete.set(p.id,false);for(const a of p.entries){const key=k(p.id,a.name);if(!s.readyAnimation){s.readyAnimation=e.animate({[a.name]:[a.keyframes[0],a.keyframes[0]]},{duration:1e4,easing:"linear",fill:"both"});s.animations.set(key,{animation:s.readyAnimation,startTime:null})}const start=()=>{s.readyAnimation.cancel();let t=s.startFrameTime;if(t===undefined){t=performance.now();s.startFrameTime=t}const anim=e.animate({[a.name]:a.keyframes},a.options);anim.startTime=t;s.animations.set(key,{animation:anim,startTime:t});s.started.push({id:p.id,name:a.name})};const r=s.readyAnimation;r.ready?r.ready.then(start).catch(()=>{}):start()}})();</script>`
 }
 
 /**
@@ -202,13 +204,32 @@ export const startOptimizedAppearAnimation = (
     const store = getAppearStore()
     if (!store) return
 
-    const animation = startWaapiAnimation(element, name, keyframes, options as never)
-    const startTime = performance.now()
-    animation.startTime = startTime
+    const storeId = appearStoreId(id, name)
+    if (!store.readyAnimation) {
+        store.readyAnimation = startWaapiAnimation(element, name, [keyframes[0], keyframes[0]], {
+            duration: 10000,
+            ease: 'linear'
+        } as never)
+        store.animations.set(storeId, { animation: store.readyAnimation, startTime: null })
+    }
+
+    const startAnimation = () => {
+        store.readyAnimation?.cancel()
+        store.startFrameTime ??= performance.now()
+        const animation = startWaapiAnimation(element, name, keyframes, options as never)
+        animation.startTime = store.startFrameTime
+        store.animations.set(storeId, { animation, startTime: store.startFrameTime })
+        store.started.push({ id, name })
+        onReady?.(animation)
+    }
+
     store.complete.set(id, false)
-    store.animations.set(appearStoreId(id, name), { animation, startTime })
-    store.started.push({ id, name })
-    onReady?.(animation)
+    const readyAnimation = store.readyAnimation
+    if (readyAnimation.ready) {
+        readyAnimation.ready.then(startAnimation).catch(() => {})
+    } else {
+        startAnimation()
+    }
 }
 
 /**
@@ -252,14 +273,17 @@ export const finishOptimizedAppearAnimation = async (
     const store = getAppearStore()
     if (!store) return false
 
-    const entries = [...store.animations].filter(([key]) => key.startsWith(`${elementId}: `))
+    let entries = [...store.animations].filter(([key]) => key.startsWith(`${elementId}: `))
     if (!entries.length) return false
 
     await Promise.all(
-        entries.map(([, data]) => {
-            return data.animation.finished.catch(() => undefined)
-        })
+        entries.map(([, data]) =>
+            data.startTime === null ? data.animation.ready?.catch(() => undefined) : undefined
+        )
     )
+
+    entries = [...store.animations].filter(([key]) => key.startsWith(`${elementId}: `))
+    await Promise.all(entries.map(([, data]) => data.animation.finished.catch(() => undefined)))
 
     for (const [key, data] of entries) {
         if (!store.animations.has(key)) continue

--- a/src/lib/utils/optimizedAppear.ts
+++ b/src/lib/utils/optimizedAppear.ts
@@ -123,6 +123,15 @@ const toNativeOptions = (transition: AnimationOptions | undefined): KeyframeAnim
  * @param animate Target keyframes for the enter animation.
  * @param transition Motion transition options.
  * @returns Appear entries for WAAPI-supported opacity and transform values.
+ *
+ * @example
+ * ```ts
+ * const entries = createOptimizedAppearData(
+ *     { opacity: 0, scale: 0.8 },
+ *     { opacity: 1, scale: 1 },
+ *     { duration: 0.6, ease: [0.16, 1, 0.3, 1] }
+ * )
+ * ```
  */
 export const createOptimizedAppearData = (
     initial: Record<string, unknown> | null | undefined,
@@ -167,6 +176,13 @@ export const createOptimizedAppearData = (
  * @param appearId Stable optimized-appear id attached to the motion element.
  * @param entries WAAPI animation entries to start.
  * @returns A script tag string, or an empty string when no entries exist.
+ *
+ * @example
+ * ```ts
+ * const script = createOptimizedAppearScript('appear-1', [
+ *     { name: 'opacity', keyframes: [0, 1], options: { duration: 300, fill: 'both' } }
+ * ])
+ * ```
  */
 export const createOptimizedAppearScript = (
     appearId: string | undefined,
@@ -188,6 +204,15 @@ export const createOptimizedAppearScript = (
  * @param keyframes WAAPI keyframes for the property.
  * @param options Motion animation options.
  * @param onReady Optional callback receiving the started animation.
+ * @returns Nothing.
+ *
+ * @example
+ * ```ts
+ * const element = document.querySelector('[data-framer-appear-id]')
+ * if (element instanceof HTMLElement) {
+ *     startOptimizedAppearAnimation(element, 'opacity', [0, 1], { duration: 0.3 })
+ * }
+ * ```
  */
 export const startOptimizedAppearAnimation = (
     element: HTMLElement,
@@ -237,6 +262,14 @@ export const startOptimizedAppearAnimation = (
  *
  * @param elementId Optimized appear id.
  * @returns `true` when at least one optimized animation was handed off.
+ *
+ * @example
+ * ```ts
+ * const wasHandedOff = handoffOptimizedAppearAnimation('appear-1')
+ * if (wasHandedOff) {
+ *     console.log('Animation handed off to runtime')
+ * }
+ * ```
  */
 export const handoffOptimizedAppearAnimation = (elementId: string | undefined): boolean => {
     if (!elementId || typeof window === 'undefined') return false
@@ -265,6 +298,14 @@ export const handoffOptimizedAppearAnimation = (elementId: string | undefined): 
  *
  * @param elementId Optimized appear id.
  * @returns Whether at least one optimized animation was adopted.
+ *
+ * @example
+ * ```ts
+ * const wasAdopted = await finishOptimizedAppearAnimation('appear-1')
+ * if (wasAdopted) {
+ *     console.log('Animation finished and adopted')
+ * }
+ * ```
  */
 export const finishOptimizedAppearAnimation = async (
     elementId: string | undefined
@@ -304,6 +345,13 @@ export const finishOptimizedAppearAnimation = async (
  *
  * @param elementId Optimized appear id.
  * @returns Whether any optimized appear animation is currently registered.
+ *
+ * @example
+ * ```ts
+ * if (hasOptimizedAppearAnimation('appear-1')) {
+ *     console.log('Animation is active')
+ * }
+ * ```
  */
 export const hasOptimizedAppearAnimation = (elementId: string | undefined): boolean => {
     if (!elementId || typeof window === 'undefined') return false
@@ -312,6 +360,13 @@ export const hasOptimizedAppearAnimation = (elementId: string | undefined): bool
 
 /**
  * Mark Motion as mounted so late optimized-appear starters no-op.
+ *
+ * @returns Nothing.
+ *
+ * @example
+ * ```ts
+ * markMotionMounted()
+ * ```
  */
 export const markMotionMounted = (): void => {
     if (typeof window !== 'undefined') {

--- a/src/lib/utils/optimizedAppear.ts
+++ b/src/lib/utils/optimizedAppear.ts
@@ -1,0 +1,308 @@
+import { mergeInlineStyles } from '$lib/utils/style'
+import { resolveRestingValues } from '$lib/utils/variants'
+import { startWaapiAnimation, type AnimationOptions } from 'motion'
+
+type AppearValueName = 'opacity' | 'transform'
+
+type OptimizedAppearEntry = {
+    name: AppearValueName
+    keyframes: [string | number, string | number]
+    options: KeyframeAnimationOptions
+}
+
+type AppearStoreEntry = {
+    animation: Animation
+    startTime: number | null
+}
+
+type SvelteMotionAppearStore = {
+    animations: Map<string, AppearStoreEntry>
+    complete: Map<string, boolean>
+    started: Array<{ id: string; name: string }>
+}
+
+const optimizedAppearDataId = 'framerAppearId'
+const optimizedAppearDataAttribute = 'data-framer-appear-id'
+
+declare global {
+    interface Window {
+        __SvelteMotionAppear?: SvelteMotionAppearStore
+    }
+}
+
+const transformProps = new Set([
+    'x',
+    'y',
+    'z',
+    'scale',
+    'scaleX',
+    'scaleY',
+    'rotate',
+    'rotateX',
+    'rotateY',
+    'rotateZ',
+    'skew',
+    'skewX',
+    'skewY',
+    'transform'
+])
+
+const appearStoreId = (elementId: string, valueName: string): string => {
+    const key = transformProps.has(valueName) ? 'transform' : valueName
+    return `${elementId}: ${key}`
+}
+
+const getAppearStore = (): SvelteMotionAppearStore | undefined => {
+    if (typeof window === 'undefined') return undefined
+    window.__SvelteMotionAppear ??= {
+        animations: new Map(),
+        complete: new Map(),
+        started: []
+    }
+    return window.__SvelteMotionAppear
+}
+
+const installAppearGlobals = (): void => {
+    if (typeof window === 'undefined') return
+    const store = getAppearStore()
+    if (!store) return
+
+    window.MotionHasOptimisedAnimation ??= (elementId?: string, valueName?: string) => {
+        if (!elementId) return false
+        if (!valueName) return store.complete.has(elementId)
+        return store.animations.has(appearStoreId(elementId, valueName))
+    }
+
+    window.MotionHandoffMarkAsComplete ??= (elementId: string) => {
+        if (store.complete.has(elementId)) {
+            store.complete.set(elementId, true)
+        }
+    }
+
+    window.MotionHandoffIsComplete ??= (elementId: string) => {
+        return store.complete.get(elementId) === true
+    }
+
+    window.MotionCancelOptimisedAnimation ??= (elementId?: string, valueName?: string) => {
+        if (!elementId || !valueName) return
+        const animationId = appearStoreId(elementId, valueName)
+        const data = store.animations.get(animationId)
+        if (!data) return
+        data.animation.cancel()
+        store.animations.delete(animationId)
+        if (!store.animations.size) {
+            window.MotionCancelOptimisedAnimation = undefined
+        }
+    }
+}
+
+const readStyleProp = (style: string, prop: string): string | undefined => {
+    return style
+        .split(';')
+        .map((part) => part.trim())
+        .find((part) => part.startsWith(`${prop}:`))
+        ?.slice(prop.length + 1)
+        .trim()
+}
+
+const toNativeOptions = (transition: AnimationOptions | undefined): KeyframeAnimationOptions => {
+    const duration = typeof transition?.duration === 'number' ? transition.duration : 0.3
+    const delay = typeof transition?.delay === 'number' ? transition.delay : 0
+    const options: KeyframeAnimationOptions = {
+        duration: duration * 1000,
+        delay: delay * 1000,
+        fill: 'both'
+    }
+
+    if (typeof transition?.ease === 'string') {
+        options.easing = transition.ease
+    } else if (Array.isArray(transition?.ease) && transition.ease.length === 4) {
+        options.easing = `cubic-bezier(${transition.ease.join(', ')})`
+    }
+
+    return options
+}
+
+/**
+ * Build serialisable optimized-appear animation entries from an initial and
+ * animate pair.
+ *
+ * @param initial Initial keyframes reflected into SSR markup.
+ * @param animate Target keyframes for the enter animation.
+ * @param transition Motion transition options.
+ * @returns Appear entries for WAAPI-supported opacity and transform values.
+ */
+export const createOptimizedAppearData = (
+    initial: Record<string, unknown> | null | undefined,
+    animate: Record<string, unknown> | null | undefined,
+    transition?: AnimationOptions
+): OptimizedAppearEntry[] => {
+    if (!initial || !animate) return []
+
+    const target = resolveRestingValues(animate as never) as Record<string, unknown> | undefined
+    if (!target) return []
+    const options = toNativeOptions(transition)
+    const entries: OptimizedAppearEntry[] = []
+
+    if (initial.opacity != null && target.opacity != null) {
+        entries.push({
+            name: 'opacity',
+            keyframes: [
+                Array.isArray(initial.opacity) ? initial.opacity[0] : initial.opacity,
+                Array.isArray(target.opacity) ? target.opacity[0] : target.opacity
+            ] as [string | number, string | number],
+            options
+        })
+    }
+
+    const initialTransform = readStyleProp(mergeInlineStyles('', initial), 'transform')
+    const targetTransform = readStyleProp(mergeInlineStyles('', target), 'transform')
+    if (initialTransform && targetTransform && initialTransform !== targetTransform) {
+        entries.push({
+            name: 'transform',
+            keyframes: [initialTransform, targetTransform],
+            options
+        })
+    }
+
+    return entries
+}
+
+/**
+ * Create the inline SSR bootstrap that starts appear animations before Svelte
+ * hydrates the component tree.
+ *
+ * @param appearId Stable optimized-appear id attached to the motion element.
+ * @param entries WAAPI animation entries to start.
+ * @returns A script tag string, or an empty string when no entries exist.
+ */
+export const createOptimizedAppearScript = (
+    appearId: string | undefined,
+    entries: OptimizedAppearEntry[]
+): string => {
+    if (!appearId || entries.length === 0) return ''
+    const payload = JSON.stringify({ id: appearId, entries }).replace(/</g, '\\u003c')
+    return `<script>(()=>{const p=${payload},w=window;if(w.MotionIsMounted)return;const q=String(p.id).replace(/["\\\\]/g,"\\\\$&");const e=document.querySelector('[${optimizedAppearDataAttribute}="'+q+'"]');if(!e||!e.animate)return;const s=w.__SvelteMotionAppear||(w.__SvelteMotionAppear={animations:new Map,complete:new Map,started:[]});const k=(id,n)=>id+": "+(n==="transform"?"transform":n);w.MotionHasOptimisedAnimation=w.MotionHasOptimisedAnimation||((id,n)=>id?n?s.animations.has(k(id,n)):s.complete.has(id):false);w.MotionHandoffMarkAsComplete=w.MotionHandoffMarkAsComplete||((id)=>{if(s.complete.has(id))s.complete.set(id,true)});w.MotionHandoffIsComplete=w.MotionHandoffIsComplete||((id)=>s.complete.get(id)===true);w.MotionCancelOptimisedAnimation=w.MotionCancelOptimisedAnimation||((id,n)=>{const key=k(id,n),d=s.animations.get(key);if(!d)return;d.animation.cancel();s.animations.delete(key);if(!s.animations.size)w.MotionCancelOptimisedAnimation=undefined});s.complete.set(p.id,false);const t=performance.now();for(const a of p.entries){const anim=e.animate({[a.name]:a.keyframes},a.options);anim.startTime=t;s.animations.set(k(p.id,a.name),{animation:anim,startTime:t});s.started.push({id:p.id,name:a.name})}})();</script>`
+}
+
+/**
+ * Start an optimized appear animation imperatively.
+ *
+ * Mirrors Framer Motion's `startOptimizedAppearAnimation`: if Motion has
+ * already mounted, this intentionally does nothing.
+ *
+ * @param element Element carrying `data-framer-appear-id`.
+ * @param name CSS property to animate.
+ * @param keyframes WAAPI keyframes for the property.
+ * @param options Motion animation options.
+ * @param onReady Optional callback receiving the started animation.
+ */
+export const startOptimizedAppearAnimation = (
+    element: HTMLElement,
+    name: AppearValueName,
+    keyframes: string[] | number[],
+    options: AnimationOptions,
+    onReady?: (animation: Animation) => void
+): void => {
+    if (typeof window === 'undefined' || window.MotionIsMounted) return
+    const id = element.dataset[optimizedAppearDataId]
+    if (!id) return
+
+    installAppearGlobals()
+    const store = getAppearStore()
+    if (!store) return
+
+    const animation = startWaapiAnimation(element, name, keyframes, options as never)
+    const startTime = performance.now()
+    animation.startTime = startTime
+    store.complete.set(id, false)
+    store.animations.set(appearStoreId(id, name), { animation, startTime })
+    store.started.push({ id, name })
+    onReady?.(animation)
+}
+
+/**
+ * Commit and cancel optimized appear animations for an element.
+ *
+ * @param elementId Optimized appear id.
+ * @returns `true` when at least one optimized animation was handed off.
+ */
+export const handoffOptimizedAppearAnimation = (elementId: string | undefined): boolean => {
+    if (!elementId || typeof window === 'undefined') return false
+    const store = getAppearStore()
+    if (!store) return false
+
+    let handedOff = false
+    for (const [key, data] of [...store.animations]) {
+        if (!key.startsWith(`${elementId}: `)) continue
+        data.animation.commitStyles?.()
+        data.animation.cancel()
+        store.animations.delete(key)
+        handedOff = true
+    }
+
+    if (store.complete.has(elementId)) {
+        store.complete.set(elementId, true)
+    }
+
+    return handedOff
+}
+
+/**
+ * Let active optimized appear animations finish before handing their final
+ * styles back to Svelte Motion.
+ *
+ * @param elementId Optimized appear id.
+ * @returns Whether at least one optimized animation was adopted.
+ */
+export const finishOptimizedAppearAnimation = async (
+    elementId: string | undefined
+): Promise<boolean> => {
+    if (!elementId || typeof window === 'undefined') return false
+    const store = getAppearStore()
+    if (!store) return false
+
+    const entries = [...store.animations].filter(([key]) => key.startsWith(`${elementId}: `))
+    if (!entries.length) return false
+
+    await Promise.all(
+        entries.map(([, data]) => {
+            return data.animation.finished.catch(() => undefined)
+        })
+    )
+
+    for (const [key, data] of entries) {
+        if (!store.animations.has(key)) continue
+        data.animation.commitStyles?.()
+        data.animation.cancel()
+        store.animations.delete(key)
+    }
+
+    if (store.complete.has(elementId)) {
+        store.complete.set(elementId, true)
+    }
+
+    return true
+}
+
+/**
+ * Check whether an optimized appear animation is active for an element.
+ *
+ * @param elementId Optimized appear id.
+ * @returns Whether any optimized appear animation is currently registered.
+ */
+export const hasOptimizedAppearAnimation = (elementId: string | undefined): boolean => {
+    if (!elementId || typeof window === 'undefined') return false
+    return window.MotionHasOptimisedAnimation?.(elementId) ?? false
+}
+
+/**
+ * Mark Motion as mounted so late optimized-appear starters no-op.
+ */
+export const markMotionMounted = (): void => {
+    if (typeof window !== 'undefined') {
+        window.MotionIsMounted = true
+    }
+}
+
+export { optimizedAppearDataAttribute }

--- a/src/lib/utils/presence.spec.ts
+++ b/src/lib/utils/presence.spec.ts
@@ -416,6 +416,53 @@ describe('AnimatePresence modes', () => {
             placeholder = document.querySelector('[data-presence-placeholder="true"]')
             expect(placeholder).toBeFalsy()
         })
+
+        it('preserves grid placement on sync placeholders', () => {
+            vi.spyOn(window, 'getComputedStyle').mockImplementation((target: Element) => {
+                if (target === el) {
+                    return mockComputedStyle({
+                        borderRadius: '8px',
+                        boxSizing: 'border-box',
+                        display: 'flex',
+                        gridColumnStart: '1',
+                        gridColumnEnd: '2',
+                        gridRowStart: '1',
+                        gridRowEnd: '2'
+                    })
+                }
+
+                return mockComputedStyle({
+                    borderRadius: '8px',
+                    boxSizing: 'border-box',
+                    position: 'relative'
+                })
+            })
+
+            const ctx = createAnimatePresenceContext({ mode: 'sync' })
+            ctx.registerChild('k1', el, { opacity: 0 })
+            ctx.unregisterChild('k1')
+
+            const placeholder = document.querySelector(
+                '[data-presence-placeholder="true"]'
+            ) as HTMLElement | null
+
+            expect(placeholder).toBeTruthy()
+            expect(placeholder?.style.gridColumnStart).toBe('1')
+            expect(placeholder?.style.gridColumnEnd).toBe('2')
+            expect(placeholder?.style.gridRowStart).toBe('1')
+            expect(placeholder?.style.gridRowEnd).toBe('2')
+        })
+
+        it('uses the registered insertion parent when a child is detached before unregister', () => {
+            const ctx = createAnimatePresenceContext({ mode: 'wait' })
+            ctx.registerChild('k1', el, { opacity: 0 })
+
+            el.remove()
+            ctx.unregisterChild('k1')
+
+            const placeholder = parent.querySelector('[data-presence-placeholder="true"]')
+            expect(placeholder).toBeTruthy()
+        })
     })
 })
 

--- a/src/lib/utils/presence.spec.ts
+++ b/src/lib/utils/presence.spec.ts
@@ -402,22 +402,19 @@ describe('AnimatePresence modes', () => {
             await Promise.resolve()
         })
 
-        it('inserts and removes a placeholder for sync mode', async () => {
+        it('does not insert a placeholder for sync mode', async () => {
             const ctx = createAnimatePresenceContext({ mode: 'sync' })
             ctx.registerChild('k1', el, { opacity: 0 })
             ctx.unregisterChild('k1')
 
-            let placeholder = document.querySelector('[data-presence-placeholder="true"]')
-            expect(placeholder).toBeTruthy()
-
-            await Promise.resolve()
-            await Promise.resolve()
-
-            placeholder = document.querySelector('[data-presence-placeholder="true"]')
+            const placeholder = document.querySelector('[data-presence-placeholder="true"]')
             expect(placeholder).toBeFalsy()
+
+            await Promise.resolve()
+            await Promise.resolve()
         })
 
-        it('preserves grid placement on sync placeholders', () => {
+        it('preserves grid placement on wait placeholders', () => {
             vi.spyOn(window, 'getComputedStyle').mockImplementation((target: Element) => {
                 if (target === el) {
                     return mockComputedStyle({
@@ -438,7 +435,7 @@ describe('AnimatePresence modes', () => {
                 })
             })
 
-            const ctx = createAnimatePresenceContext({ mode: 'sync' })
+            const ctx = createAnimatePresenceContext({ mode: 'wait' })
             ctx.registerChild('k1', el, { opacity: 0 })
             ctx.unregisterChild('k1')
 

--- a/src/lib/utils/presence.ts
+++ b/src/lib/utils/presence.ts
@@ -491,9 +491,9 @@ export const createAnimatePresenceContext = (context: {
         const rect = child.lastRect
         const computed = child.lastComputedStyle
 
-        // For sync/wait, preserve layout by inserting a hidden placeholder.
-        // For popLayout, we remove from layout immediately (no placeholder).
-        const shouldPreserveLayout = mode !== 'popLayout'
+        // Wait mode holds the exiting layout slot while the entering child is hidden.
+        // Sync and popLayout must not add an extra layout participant.
+        const shouldPreserveLayout = mode === 'wait'
         let placeholder: HTMLElement | null = null
         const liveLayoutInsertion = findLayoutInsertionParent(child.element)
         const layoutInsertion =

--- a/src/lib/utils/presence.ts
+++ b/src/lib/utils/presence.ts
@@ -31,6 +31,7 @@ type PresenceChild = {
     mergedTransition?: MotionTransition
     lastRect: DOMRect
     lastComputedStyle: CSSStyleDeclaration
+    layoutInsertion?: { parent: HTMLElement; before?: HTMLElement }
     /** Last captured mid-animation opacity (from rAF polling). */
     lastAnimatedOpacity?: string
     /** Last captured mid-animation transform (from rAF polling). */
@@ -59,6 +60,20 @@ const resetTransforms = (element: HTMLElement): void => {
     ;(s as any).OTransform = 'none'
 }
 
+const findLayoutInsertionParent = (
+    element: HTMLElement
+): { parent: HTMLElement; before?: HTMLElement } | null => {
+    let before = element
+    let parent = element.parentElement
+
+    while (parent && getComputedStyle(parent).display === 'contents') {
+        before = parent
+        parent = parent.parentElement
+    }
+
+    return parent ? { parent, before } : null
+}
+
 /**
  * Presence context API used by `AnimatePresence` and motion elements.
  * Consumers register/unregister children and provide size/style snapshots
@@ -76,10 +91,11 @@ export type AnimatePresenceContext = {
      */
     shouldAnimateEnter: (key: string) => boolean
     /**
-     * For mode='wait': Returns true if enters should be blocked (exits in progress).
+     * For mode='wait': Returns true if enters should be blocked by an exiting
+     * or currently-present sibling.
      * Motion elements should delay their enter animation until this returns false.
      */
-    isEnterBlocked: () => boolean
+    isEnterBlocked: (key?: string) => boolean
     /**
      * For mode='wait': Register a callback to be invoked when enters are unblocked.
      * Returns an unsubscribe function.
@@ -231,10 +247,22 @@ export const createAnimatePresenceContext = (context: {
      * }
      * ```
      */
-    const isEnterBlocked = (): boolean => {
-        // For wait mode, block enters only when there are actual in-flight exits
-        const blocked = mode === 'wait' && inFlightExits > 0
-        pwLog('[presence] isEnterBlocked', { blocked, mode, inFlightExits })
+    const isEnterBlocked = (key?: string): boolean => {
+        if (mode !== 'wait') {
+            pwLog('[presence] isEnterBlocked', { blocked: false, mode, inFlightExits, key })
+            return false
+        }
+
+        const hasBlockingSibling =
+            key !== undefined && Array.from(children.keys()).some((childKey) => childKey !== key)
+        const blocked = inFlightExits > 0 || hasBlockingSibling
+        pwLog('[presence] isEnterBlocked', {
+            blocked,
+            mode,
+            inFlightExits,
+            key,
+            hasBlockingSibling
+        })
         return blocked
     }
 
@@ -403,7 +431,8 @@ export const createAnimatePresenceContext = (context: {
             exit,
             mergedTransition,
             lastRect: initialRect,
-            lastComputedStyle: initialStyle
+            lastComputedStyle: initialStyle,
+            layoutInsertion: findLayoutInsertionParent(element) ?? undefined
         })
     }
 
@@ -466,8 +495,11 @@ export const createAnimatePresenceContext = (context: {
         // For popLayout, we remove from layout immediately (no placeholder).
         const shouldPreserveLayout = mode !== 'popLayout'
         let placeholder: HTMLElement | null = null
-        const layoutParent = child.element.parentElement
-        if (shouldPreserveLayout && layoutParent) {
+        const liveLayoutInsertion = findLayoutInsertionParent(child.element)
+        const layoutInsertion =
+            liveLayoutInsertion ??
+            (child.layoutInsertion?.parent.isConnected ? child.layoutInsertion : null)
+        if (shouldPreserveLayout && layoutInsertion) {
             placeholder = document.createElement(child.element.tagName.toLowerCase())
             placeholder.setAttribute('data-presence-placeholder', 'true')
             placeholder.style.display = computed.display === 'contents' ? 'block' : computed.display
@@ -484,7 +516,23 @@ export const createAnimatePresenceContext = (context: {
             if (computed.alignSelf) {
                 placeholder.style.alignSelf = computed.alignSelf
             }
-            layoutParent.insertBefore(placeholder, child.element)
+            if (computed.gridColumnStart) {
+                placeholder.style.gridColumnStart = computed.gridColumnStart
+            }
+            if (computed.gridColumnEnd) {
+                placeholder.style.gridColumnEnd = computed.gridColumnEnd
+            }
+            if (computed.gridRowStart) {
+                placeholder.style.gridRowStart = computed.gridRowStart
+            }
+            if (computed.gridRowEnd) {
+                placeholder.style.gridRowEnd = computed.gridRowEnd
+            }
+            const before =
+                layoutInsertion.before?.parentElement === layoutInsertion.parent
+                    ? layoutInsertion.before
+                    : null
+            layoutInsertion.parent.insertBefore(placeholder, before)
         }
 
         // Clone original node to preserve structure/classes, then inline computed styles to freeze look
@@ -624,7 +672,6 @@ export const createAnimatePresenceContext = (context: {
                         // ignore
                     }
                     clone.remove()
-                    placeholder?.remove()
 
                     // Log clone removal and element counts for debugging rapid toggle
                     pwLog('[presence] clone REMOVED from DOM', {
@@ -656,6 +703,7 @@ export const createAnimatePresenceContext = (context: {
                         clonesInDOM: document.querySelectorAll('[data-clone="true"]').length
                     })
 
+                    placeholder?.remove()
                     finishExit()
                 })
         })

--- a/src/lib/utils/projection.ts
+++ b/src/lib/utils/projection.ts
@@ -137,9 +137,9 @@ export interface ProjectionNodeOptions {
     /**
      * Thunk returning the `layoutScroll` ancestor chain at measure
      * time. Used as the second argument to `measureRect`, which
-     * shifts the returned rect by the sum of ancestor
-     * `scrollLeft`/`scrollTop` so FLIP deltas stay correct when
-     * scrollable ancestors scroll between two measurements.
+     * shifts the returned rect by the viewport scroll plus the sum of
+     * ancestor `scrollLeft`/`scrollTop` so FLIP deltas stay correct
+     * when the page or scrollable ancestors scroll between two measurements.
      *
      * Returning `[]` (or omitting the option entirely) gives
      * viewport-relative measurements — fine for the common case.
@@ -360,7 +360,8 @@ export class ProjectionNode {
             const rect = measureRect(
                 this.element,
                 this.getScrollContainers?.() ?? [],
-                this.resolveBaseTransform()
+                this.resolveBaseTransform(),
+                true
             )
             const box = rectToBox(rect)
             this.latestLayout = box

--- a/src/lib/utils/svg.spec.ts
+++ b/src/lib/utils/svg.spec.ts
@@ -69,45 +69,45 @@ describe('svg utilities', () => {
     })
 
     describe('transformSVGPathProperties', () => {
-        it('should transform pathLength to normalized px dash attributes and set pathLength="1"', () => {
+        it('should transform pathLength to normalized unitless dash attributes and set pathLength="1"', () => {
             const keyframes = { pathLength: 1 }
             const result = transformSVGPathProperties(mockPathElement, keyframes)
 
             expect(result).not.toHaveProperty('pathLength')
-            expect(result).toHaveProperty('stroke-dasharray', '1px 0px')
-            expect(result).toHaveProperty('stroke-dashoffset', '0px')
+            expect(result).toHaveProperty('stroke-dasharray', '1 1')
+            expect(result).toHaveProperty('stroke-dashoffset', '0')
             expect(mockPathElement.setAttribute).toHaveBeenCalledWith('pathLength', '1')
         })
 
-        it('should transform pathLength array to normalized px dasharray array', () => {
+        it('should transform pathLength array to normalized unitless dasharray array', () => {
             const keyframes = { pathLength: [0, 0.5, 1] }
             const result = transformSVGPathProperties(mockPathElement, keyframes)
 
-            expect(result).toHaveProperty('stroke-dasharray', ['0px 1px', '0.5px 0.5px', '1px 0px'])
+            expect(result).toHaveProperty('stroke-dasharray', ['0 1', '0.5 1', '1 1'])
             expect(result).not.toHaveProperty('pathLength')
         })
 
-        it('should transform pathOffset to negative px strokeDashoffset', () => {
+        it('should transform pathOffset to negative unitless strokeDashoffset', () => {
             const keyframes = { pathOffset: 0.5 }
             const result = transformSVGPathProperties(mockPathElement, keyframes)
 
-            expect(result).toHaveProperty('stroke-dashoffset', '-0.5px')
+            expect(result).toHaveProperty('stroke-dashoffset', '-0.5')
             expect(result).not.toHaveProperty('pathOffset')
         })
 
-        it('should transform pathOffset array to negative px strokeDashoffset array', () => {
+        it('should transform pathOffset array to negative unitless strokeDashoffset array', () => {
             const keyframes = { pathOffset: [0, 0.5, 1] }
             const result = transformSVGPathProperties(mockPathElement, keyframes)
 
-            expect(result).toHaveProperty('stroke-dashoffset', ['0px', '-0.5px', '-1px'])
+            expect(result).toHaveProperty('stroke-dashoffset', ['0', '-0.5', '-1'])
         })
 
-        it('should handle both pathLength and pathOffset together (normalized px, pathLength="1")', () => {
+        it('should handle both pathLength and pathOffset together (normalized unitless, pathLength="1")', () => {
             const keyframes = { pathLength: 1, pathOffset: 0.5 }
             const result = transformSVGPathProperties(mockPathElement, keyframes)
 
-            expect(result).toHaveProperty('stroke-dasharray', '1px 0px')
-            expect(result).toHaveProperty('stroke-dashoffset', '-0.5px')
+            expect(result).toHaveProperty('stroke-dasharray', '1 1')
+            expect(result).toHaveProperty('stroke-dashoffset', '-0.5')
             expect(mockPathElement.setAttribute).toHaveBeenCalledWith('pathLength', '1')
         })
 
@@ -116,8 +116,8 @@ describe('svg utilities', () => {
             const result = transformSVGPathProperties(mockPathElement, keyframes)
 
             expect(result).toMatchObject({
-                'stroke-dasharray': '1px 0px',
-                'stroke-dashoffset': '0px',
+                'stroke-dasharray': '1 1',
+                'stroke-dashoffset': '0',
                 opacity: 0.5,
                 x: 100
             })
@@ -131,23 +131,23 @@ describe('svg utilities', () => {
             expect(result).toEqual(keyframes)
         })
 
-        it('should handle pathSpacing by transforming to normalized px dasharray and removing pathSpacing', () => {
+        it('should handle pathSpacing by transforming to normalized unitless dasharray and removing pathSpacing', () => {
             const keyframes = { pathLength: 1, pathSpacing: 0.5 }
             const result = transformSVGPathProperties(mockPathElement, keyframes)
 
             expect(result).not.toHaveProperty('pathSpacing')
-            expect(result).toHaveProperty('stroke-dasharray', '1px 0.5px')
+            expect(result).toHaveProperty('stroke-dasharray', '1 0.5')
         })
     })
 
     describe('transformInitialSVGPathProperties', () => {
-        it('should transform initial properties (normalized px)', () => {
+        it('should transform initial properties (normalized unitless)', () => {
             const initial = { pathLength: 0, opacity: 1 }
             const result = transformInitialSVGPathProperties(mockPathElement, initial)
 
             expect(result).toMatchObject({
-                'stroke-dasharray': '0px 1px',
-                'stroke-dashoffset': '0px',
+                'stroke-dasharray': '0 1',
+                'stroke-dashoffset': '0',
                 opacity: 1
             })
         })
@@ -175,17 +175,17 @@ describe('svg utilities', () => {
             const res = computeNormalizedSVGInitialAttrs({ pathLength: 0.25 })
             expect(res).toEqual({
                 pathLength: '1',
-                'stroke-dasharray': '0.25px 0.75px',
-                'stroke-dashoffset': '0px'
+                'stroke-dasharray': '0.25 1',
+                'stroke-dashoffset': '0'
             })
         })
 
-        it('should compute dashoffset from negative pathOffset in px', () => {
+        it('should compute dashoffset from negative pathOffset', () => {
             const res = computeNormalizedSVGInitialAttrs({ pathLength: 1, pathOffset: 0.5 })
             expect(res).toEqual({
                 pathLength: '1',
-                'stroke-dasharray': '1px 0px',
-                'stroke-dashoffset': '-0.5px'
+                'stroke-dasharray': '1 1',
+                'stroke-dashoffset': '-0.5'
             })
         })
 
@@ -193,8 +193,8 @@ describe('svg utilities', () => {
             const res = computeNormalizedSVGInitialAttrs({ pathLength: 0.5, pathSpacing: 0.25 })
             expect(res).toEqual({
                 pathLength: '1',
-                'stroke-dasharray': '0.5px 0.25px',
-                'stroke-dashoffset': '0px'
+                'stroke-dasharray': '0.5 0.25',
+                'stroke-dashoffset': '0'
             })
         })
     })

--- a/src/lib/utils/svg.ts
+++ b/src/lib/utils/svg.ts
@@ -1,3 +1,5 @@
+import { buildSVGPath } from 'motion-dom'
+
 /**
  * SVG-specific properties that need special handling during animation.
  * These properties are not standard CSS properties and need to be transformed.
@@ -151,8 +153,8 @@ export const isSVGElement = (element: Element): element is SVGElement => {
  *
  * Normalized behavior (React/Framer Motion parity):
  * - Ensures `pathLength="1"` is set when any path prop is present
- * - Maps `pathLength`/`pathSpacing` → `stroke-dasharray` (px)
- * - Maps `pathOffset` → `stroke-dashoffset` (negative px)
+ * - Maps `pathLength`/`pathSpacing` → unitless `stroke-dasharray`
+ * - Maps `pathOffset` → unitless negative `stroke-dashoffset`
  *
  * @param {Element} element The element being animated (must be an SVG path).
  * @param {Record<string, unknown>} keyframes The input keyframes possibly containing path props.
@@ -205,47 +207,66 @@ export const transformSVGPathProperties = (
             return n ?? v
         })()
 
-        const toPx = (v: unknown): string => (typeof v === 'number' ? `${v}px` : String(v))
+        const toUnitless = (v: unknown): string => (typeof v === 'number' ? `${v}` : String(v))
 
-        const buildDashArray = (len: unknown, spa: unknown): string => `${toPx(len)} ${toPx(spa)}`
+        const buildDashArray = (len: unknown, spa: unknown): string =>
+            `${toUnitless(len)} ${toUnitless(spa)}`
 
-        // stroke-dasharray from pathLength/pathSpacing with default spacing = 1 - length
+        // stroke-dasharray from pathLength/pathSpacing with upstream's default spacing = 1
         if (Array.isArray(length)) {
             const lenArr = length as unknown[]
             const spaArr = Array.isArray(spacing)
                 ? (spacing as unknown[])
-                : lenArr.map((lv) =>
-                      typeof lv === 'number' ? 1 - (lv as number) : (spacing as unknown)
-                  )
+                : lenArr.map(() => (spacing !== undefined ? (spacing as unknown) : 1))
             const dashArray = lenArr.map((lv, i) => buildDashArray(lv, spaArr[i]))
             ;(transformed as Record<string, unknown>).strokeDasharray = dashArray
             ;(transformed as Record<string, unknown>)['stroke-dasharray'] = dashArray
         } else if (length !== undefined) {
-            const len = length
-            const lenNum = toNum(len) ?? 0
-            const spa = spacing !== undefined ? spacing : 1 - lenNum
-            const dashArray = buildDashArray(len, spa)
+            const lenNum = toNum(length)
+            const spaNum = spacing === undefined ? undefined : toNum(spacing)
+            const offsetNum = offset === undefined ? undefined : toNum(offset)
+            let dashArray: string
+            let dashOffset: string | undefined
+
+            if (
+                lenNum !== undefined &&
+                (spacing === undefined || spaNum !== undefined) &&
+                (offset === undefined || offsetNum !== undefined)
+            ) {
+                const attrs: Record<string, string | number> = {}
+                buildSVGPath(attrs, lenNum, spacing === undefined ? 1 : spaNum, offsetNum, true)
+                dashArray = String(attrs['stroke-dasharray'])
+                dashOffset = String(attrs['stroke-dashoffset'])
+            } else {
+                const spa = spacing !== undefined ? spacing : 1
+                dashArray = buildDashArray(length, spa)
+            }
+
             ;(transformed as Record<string, unknown>).strokeDasharray = dashArray
             ;(transformed as Record<string, unknown>)['stroke-dasharray'] = dashArray
+            if (dashOffset !== undefined) {
+                ;(transformed as Record<string, unknown>).strokeDashoffset = dashOffset
+                ;(transformed as Record<string, unknown>)['stroke-dashoffset'] = dashOffset
+            }
         }
 
         // stroke-dashoffset from -pathOffset
         if (Array.isArray(offset)) {
             const offs = (offset as unknown[]).map((ov) => {
                 const n = toNum(ov)
-                return n !== undefined ? `${-n}px` : String(ov)
+                return n !== undefined ? `${-n}` : String(ov)
             })
             ;(transformed as Record<string, unknown>).strokeDashoffset = offs
             ;(transformed as Record<string, unknown>)['stroke-dashoffset'] = offs
         } else if (offset !== undefined) {
             const n = toNum(offset)
-            const off = n !== undefined ? `${-n}px` : String(offset)
+            const off = n !== undefined ? `${-n}` : String(offset)
             ;(transformed as Record<string, unknown>).strokeDashoffset = off
             ;(transformed as Record<string, unknown>)['stroke-dashoffset'] = off
-        } else {
+        } else if (!('stroke-dashoffset' in transformed)) {
             // default 0
-            ;(transformed as Record<string, unknown>).strokeDashoffset = '0px'
-            ;(transformed as Record<string, unknown>)['stroke-dashoffset'] = '0px'
+            ;(transformed as Record<string, unknown>).strokeDashoffset = '0'
+            ;(transformed as Record<string, unknown>)['stroke-dashoffset'] = '0'
         }
 
         delete (transformed as Record<string, unknown>).pathLength
@@ -299,8 +320,8 @@ export const transformInitialSVGPathProperties = (
  *
  * Behavior matches React/Framer Motion parity:
  * - Always sets pathLength="1" whenever any of path props are present
- * - stroke-dasharray = px(pathLength) + ' ' + px(pathSpacing ?? 1 - Number(pathLength))
- * - stroke-dashoffset = px(-(pathOffset ?? 0))
+ * - stroke-dasharray = pathLength + ' ' + (pathSpacing ?? 1)
+ * - stroke-dashoffset = -(pathOffset ?? 0)
  *
  * The returned object is suitable for direct DOM attribute assignment (dash-cased keys).
  *
@@ -314,21 +335,19 @@ export const computeNormalizedSVGInitialAttrs = (
     const hasAny = 'pathLength' in initial || 'pathSpacing' in initial || 'pathOffset' in initial
     if (!hasAny) return null
 
-    const toPx = (v: unknown): string => (typeof v === 'number' ? `${v}px` : String(v))
-    const negatePx = (v: unknown): string => {
-        if (typeof v === 'number') return `${-v}px`
+    const toUnitless = (v: unknown): string => (typeof v === 'number' ? `${v}` : String(v))
+    const negate = (v: unknown): string => {
+        if (typeof v === 'number') return `${-v}`
         const s = String(v)
-        return s.startsWith('-') ? s : /^[\d.]+(px)?$/i.test(s) ? `-${s}` : s
+        return s.startsWith('-') ? s : /^[\d.]+(px)?$/i.test(s) ? `-${s.replace(/px$/i, '')}` : s
     }
 
     const len = (initial as Record<string, unknown>).pathLength ?? 0
-    const spa =
-        (initial as Record<string, unknown>).pathSpacing ??
-        (typeof len === 'number' ? 1 - (len as number) : 1)
+    const spa = (initial as Record<string, unknown>).pathSpacing ?? 1
     const off = (initial as Record<string, unknown>).pathOffset ?? 0
 
-    const dashArray = `${toPx(len)} ${toPx(spa)}`
-    const dashOffset = negatePx(off)
+    const dashArray = `${toUnitless(len)} ${toUnitless(spa)}`
+    const dashOffset = negate(off)
 
     // logging removed
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -133,6 +133,14 @@
                         Transform persistence (#377)
                     </a>
                 </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/optimized-appear') + searchParams}
+                    >
+                        Optimized appear animations
+                    </a>
+                </li>
             </ul>
         </div>
         <div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -255,6 +255,14 @@
                         Modes (sync/wait/popLayout)
                     </a>
                 </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/animate-presence/layout-button') + searchParams}
+                    >
+                        Layout button content swap
+                    </a>
+                </li>
             </ul>
         </div>
         <div>

--- a/src/routes/tests/animate-presence/layout-button/+page.svelte
+++ b/src/routes/tests/animate-presence/layout-button/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import ModeButton from './ModeButton.svelte'
+    import RollingCopyButton from './RollingCopyButton.svelte'
 </script>
 
 <svelte:head>
@@ -19,6 +20,7 @@
         </div>
 
         <div class="demos">
+            <RollingCopyButton />
             <ModeButton mode="wait" title="Wait" testIdPrefix="wait" />
             <ModeButton mode="sync" title="Sync" testIdPrefix="sync" />
             <ModeButton mode="popLayout" title="Pop layout" testIdPrefix="pop-layout" />
@@ -207,8 +209,66 @@
         color: inherit;
         background: transparent;
     }
+    :global(.featured-demo) {
+        background: #0c1519;
+    }
+    :global(.featured-copy) {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 28px;
+        min-height: 132px;
+    }
+    :global(.featured-copy > div) {
+        max-width: 560px;
+    }
+    :global(.rolling-button-slot) {
+        display: grid;
+        flex: none;
+        place-items: center;
+        width: 180px;
+    }
+    :global(.rolling-copy-button) {
+        padding: 12px 18px;
+        min-width: 112px;
+        border-color: #52626d;
+        background: #111b21;
+        font-size: 15px;
+        line-height: 18px;
+        box-shadow: 0 0 0 0 rgba(125, 211, 252, 0);
+    }
+    :global(.rolling-copy-button:hover) {
+        border-color: #7dd3fc;
+        box-shadow: 0 0 0 1px rgba(125, 211, 252, 0.28);
+    }
+    :global(.rolling-copy-button[data-stage='copied']) {
+        border-color: #7dd3fc;
+        background: #10232b;
+        color: #7dd3fc;
+    }
+    :global(.rolling-button-content) {
+        display: inline-grid;
+        place-items: center;
+        pointer-events: none;
+        transform-origin: center center;
+    }
+    :global(.rolling-state-stack) {
+        overflow: visible;
+    }
+    :global(.rolling-state) {
+        gap: 8px;
+        line-height: 18px;
+    }
+    :global(.rolling-state svg) {
+        width: 16px;
+        height: 16px;
+    }
     @media (max-width: 640px) {
         :global(.demo-head) {
+            align-items: flex-start;
+            flex-direction: column;
+        }
+        :global(.featured-copy) {
             align-items: flex-start;
             flex-direction: column;
         }

--- a/src/routes/tests/animate-presence/layout-button/+page.svelte
+++ b/src/routes/tests/animate-presence/layout-button/+page.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+    import ModeButton from './ModeButton.svelte'
+</script>
+
+<svelte:head>
+    <title>AnimatePresence + layout button · regression test</title>
+</svelte:head>
+
+<main class="page" data-testid="layout-button-page">
+    <section class="panel">
+        <div class="intro">
+            <p class="eyebrow">AnimatePresence / layout</p>
+            <h1>Button content swap</h1>
+            <p class="lede">
+                The button should spring between <code>copy</code> and <code>copied</code> without clipping
+                or visually scaling the label. Each row exercises a different presence mode against layout
+                projection attributes.
+            </p>
+        </div>
+
+        <div class="demos">
+            <ModeButton mode="wait" title="Wait" testIdPrefix="wait" />
+            <ModeButton mode="sync" title="Sync" testIdPrefix="sync" />
+            <ModeButton mode="popLayout" title="Pop layout" testIdPrefix="pop-layout" />
+        </div>
+    </section>
+</main>
+
+<style>
+    :global(body) {
+        margin: 0;
+        background: #0b0d10;
+        color: #ecfdf5;
+        font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+        min-height: 100%;
+        height: auto;
+        overflow-y: auto;
+    }
+    :global(html) {
+        min-height: 100%;
+        height: auto;
+        overflow-y: auto;
+    }
+    :global(body > .h-full),
+    :global(body > .h-full > .h-full),
+    :global(.container),
+    :global(#sandbox) {
+        min-height: 100vh;
+        height: auto;
+    }
+    :global(.container),
+    :global(#sandbox) {
+        align-items: flex-start;
+        justify-content: center;
+    }
+    .page {
+        min-height: 100vh;
+        display: grid;
+        align-items: start;
+        justify-items: center;
+        padding: 32px;
+    }
+    .panel {
+        width: min(980px, 100%);
+        display: grid;
+        gap: 28px;
+        padding: 28px;
+        border: 1px solid #263238;
+        background: #101418;
+    }
+    .intro {
+        max-width: 680px;
+    }
+    .eyebrow {
+        margin: 0 0 8px;
+        color: #7dd3fc;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+    }
+    h1 {
+        margin: 0;
+        font-size: 28px;
+        line-height: 1.1;
+    }
+    .lede {
+        max-width: 560px;
+        margin: 12px 0 0;
+        color: #a7b5bd;
+        line-height: 1.55;
+    }
+    code {
+        color: #c4b5fd;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+    .demos {
+        display: grid;
+        gap: 18px;
+        border-top: 1px solid #263238;
+        padding-top: 28px;
+    }
+    :global(.demo) {
+        display: grid;
+        gap: 14px;
+        padding: 16px;
+        border: 1px solid #263238;
+        background: #0d1216;
+    }
+    :global(.demo-head) {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 20px;
+        min-height: 86px;
+    }
+    :global(.demo h2) {
+        margin: 0;
+        font-size: 16px;
+        line-height: 1.2;
+    }
+    :global(.demo p) {
+        margin: 6px 0 0;
+        color: #7dd3fc;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 12px;
+        line-height: 1.2;
+    }
+    :global(.copy-button) {
+        appearance: none;
+        -webkit-appearance: none;
+        display: inline-grid;
+        place-items: center;
+        align-content: center;
+        justify-content: center;
+        padding: 7px 12px;
+        border: 1px solid #43515a;
+        background: #11171c;
+        color: #cbd5e1;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 13px;
+        line-height: 16px;
+        cursor: pointer;
+    }
+    :global(.copy-button:has(.copied-state:not([data-presence-wait-hidden='true']))) {
+        border-color: #7dd3fc;
+        background: #10232b;
+        color: #7dd3fc;
+    }
+    :global(.copy-button:focus) {
+        outline: none;
+    }
+    :global(.copy-button:focus-visible) {
+        outline: 2px solid #7dd3fc;
+        outline-offset: 3px;
+    }
+    :global(.state-stack) {
+        display: inline-grid;
+        align-items: center;
+        justify-items: center;
+    }
+    :global(.state) {
+        grid-area: 1 / 1;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        white-space: nowrap;
+        line-height: 16px;
+    }
+    :global(.state svg) {
+        width: 14px;
+        height: 14px;
+        flex: none;
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 2;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+    }
+    :global(.copy-state) {
+        color: #cbd5e1;
+    }
+    :global(.copied-state) {
+        color: #7dd3fc;
+    }
+    :global(.debug-log) {
+        display: grid;
+        gap: 4px;
+        height: 150px;
+        overflow: auto;
+        border-top: 1px solid #263238;
+        padding-top: 12px;
+        color: #a7f3d0;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 11px;
+        line-height: 1.45;
+    }
+    :global(.debug-head) {
+        color: #7dd3fc;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+    }
+    :global(.debug-log code) {
+        display: block;
+        overflow-wrap: anywhere;
+        color: inherit;
+        background: transparent;
+    }
+    @media (max-width: 640px) {
+        :global(.demo-head) {
+            align-items: flex-start;
+            flex-direction: column;
+        }
+    }
+</style>

--- a/src/routes/tests/animate-presence/layout-button/ModeButton.svelte
+++ b/src/routes/tests/animate-presence/layout-button/ModeButton.svelte
@@ -3,11 +3,15 @@
     import { onDestroy, onMount } from 'svelte'
     import type { AnimatePresenceMode } from '$lib/types'
 
-    const { mode, title, testIdPrefix } = $props<{
+    let {
+        mode,
+        title,
+        testIdPrefix
+    }: {
         mode: AnimatePresenceMode
         title: string
         testIdPrefix: string
-    }>()
+    } = $props()
 
     let copied = $state(false)
     let resetTimer: ReturnType<typeof setTimeout> | null = null

--- a/src/routes/tests/animate-presence/layout-button/ModeButton.svelte
+++ b/src/routes/tests/animate-presence/layout-button/ModeButton.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+    import { AnimatePresence, motion } from '$lib'
+    import { onDestroy, onMount } from 'svelte'
+    import type { AnimatePresenceMode } from '$lib/types'
+
+    const { mode, title, testIdPrefix } = $props<{
+        mode: AnimatePresenceMode
+        title: string
+        testIdPrefix: string
+    }>()
+
+    let copied = $state(false)
+    let resetTimer: ReturnType<typeof setTimeout> | null = null
+    let buttonElement: HTMLButtonElement | null = $state(null)
+    let observerLog = $state<string[]>([])
+
+    const layoutTransition = { duration: 2.4, ease: 'linear' as const }
+    const visibleExit = { opacity: 0, transition: { duration: 0.001 } }
+    const labelTransition = { duration: 0.08, ease: 'linear' as const }
+    const resetDelay = () => (mode === 'wait' ? 5200 : 3200)
+
+    function pushLog(entry: Record<string, unknown>) {
+        const line = JSON.stringify(entry)
+        observerLog = [...observerLog.slice(-18), line]
+        console.log(`[layout-button:${mode}]`, line)
+    }
+
+    function visibleStateElement(): HTMLElement | null {
+        if (!buttonElement) return null
+
+        const states = Array.from(buttonElement.querySelectorAll<HTMLElement>('.state'))
+        return (
+            states.find((state) => {
+                const style = getComputedStyle(state)
+                const rect = state.getBoundingClientRect()
+                return (
+                    style.display !== 'none' &&
+                    state.getAttribute('data-presence-wait-hidden') !== 'true' &&
+                    !state.closest('[data-clone="true"]') &&
+                    rect.width > 0 &&
+                    rect.height > 0
+                )
+            }) ??
+            states[0] ??
+            null
+        )
+    }
+
+    function snapshot(label: string) {
+        if (!buttonElement) return undefined
+
+        const stateElement = visibleStateElement()
+        const buttonStyle = getComputedStyle(buttonElement)
+        const stateStyle = stateElement ? getComputedStyle(stateElement) : undefined
+        const buttonRect = buttonElement.getBoundingClientRect()
+        const stateRect = stateElement?.getBoundingClientRect()
+
+        const entry = {
+            label,
+            mode,
+            buttonText: buttonElement.textContent?.trim(),
+            buttonClass: buttonElement.className,
+            buttonInlineTransform: buttonElement.style.transform || '(none)',
+            buttonComputedTransform: buttonStyle.transform,
+            buttonFontSize: buttonStyle.fontSize,
+            buttonLineHeight: buttonStyle.lineHeight,
+            buttonWidth: buttonRect.width.toFixed(3),
+            buttonHeight: buttonRect.height.toFixed(3),
+            stateClass: stateElement?.className ?? '(missing)',
+            stateInlineTransform: stateElement?.style.transform || '(none)',
+            stateComputedTransform: stateStyle?.transform ?? '(missing)',
+            stateDisplay: stateStyle?.display ?? '(missing)',
+            stateFontSize: stateStyle?.fontSize ?? '(missing)',
+            stateLineHeight: stateStyle?.lineHeight ?? '(missing)',
+            stateWidth: stateRect ? stateRect.width.toFixed(3) : '(missing)',
+            stateHeight: stateRect ? stateRect.height.toFixed(3) : '(missing)',
+            hiddenWaitStates: buttonElement.querySelectorAll('[data-presence-wait-hidden="true"]')
+                .length,
+            animationCount: buttonElement.getAnimations({ subtree: true }).length
+        }
+
+        pushLog(entry)
+        return entry
+    }
+
+    function traceFrames(reason: string) {
+        let frame = 0
+        const started = performance.now()
+
+        const readFrame = () => {
+            frame += 1
+            snapshot(`${reason} frame ${frame} +${Math.round(performance.now() - started)}ms`)
+            if (performance.now() - started < 520) {
+                requestAnimationFrame(readFrame)
+            }
+        }
+
+        requestAnimationFrame(readFrame)
+    }
+
+    function showCopied() {
+        snapshot('before click')
+        copied = true
+        if (resetTimer) clearTimeout(resetTimer)
+        resetTimer = setTimeout(() => {
+            snapshot('before reset')
+            copied = false
+            resetTimer = null
+            traceFrames('reset')
+        }, resetDelay())
+        traceFrames('click')
+    }
+
+    onMount(() => {
+        if (!buttonElement) return
+
+        snapshot('mounted')
+
+        const resizeObserver = new ResizeObserver(() => {
+            snapshot('ResizeObserver')
+        })
+        resizeObserver.observe(buttonElement)
+
+        const mutationObserver = new MutationObserver((mutations) => {
+            pushLog({
+                label: 'MutationObserver',
+                mode,
+                mutations: mutations.map((mutation) => ({
+                    type: mutation.type,
+                    target:
+                        mutation.target instanceof HTMLElement
+                            ? {
+                                  tag: mutation.target.tagName.toLowerCase(),
+                                  className: mutation.target.className,
+                                  style: mutation.target.getAttribute('style'),
+                                  hidden:
+                                      mutation.target.getAttribute('data-presence-wait-hidden') ===
+                                      'true'
+                              }
+                            : mutation.target.nodeName,
+                    attributeName: mutation.attributeName
+                }))
+            })
+            snapshot('MutationObserver')
+        })
+        mutationObserver.observe(buttonElement, {
+            attributes: true,
+            attributeFilter: ['class', 'style', 'data-presence-wait-hidden'],
+            childList: true,
+            subtree: true
+        })
+
+        return () => {
+            resizeObserver.disconnect()
+            mutationObserver.disconnect()
+        }
+    })
+
+    onDestroy(() => {
+        if (resetTimer) clearTimeout(resetTimer)
+    })
+</script>
+
+<article class="demo" data-testid="{testIdPrefix}-demo">
+    <div class="demo-head">
+        <div>
+            <h2>{title}</h2>
+            <p>{mode}</p>
+        </div>
+        <motion.button
+            type="button"
+            class="copy-button"
+            data-testid="{testIdPrefix}-button"
+            data-mode={mode}
+            aria-label="Copy snippet"
+            bind:ref={buttonElement}
+            layout
+            transition={layoutTransition}
+            onclick={showCopied}
+        >
+            <span class="state-stack">
+                <AnimatePresence initial={false} {mode}>
+                    {#if copied}
+                        <motion.span
+                            key="copied"
+                            class="state copied-state"
+                            data-testid="{testIdPrefix}-copied-state"
+                            layout="position"
+                            initial={{ opacity: 1 }}
+                            animate={{ opacity: 1 }}
+                            exit={visibleExit}
+                            transition={labelTransition}
+                        >
+                            <svg
+                                aria-hidden="true"
+                                data-testid="{testIdPrefix}-copied-icon"
+                                viewBox="0 0 24 24"
+                            >
+                                <path d="M20 6 9 17l-5-5" />
+                            </svg>
+                            <span>copied</span>
+                        </motion.span>
+                    {:else}
+                        <motion.span
+                            key="copy"
+                            class="state copy-state"
+                            data-testid="{testIdPrefix}-copy-state"
+                            layout="position"
+                            initial={{ opacity: 1 }}
+                            animate={{ opacity: 1 }}
+                            exit={visibleExit}
+                            transition={labelTransition}
+                        >
+                            <svg
+                                aria-hidden="true"
+                                data-testid="{testIdPrefix}-copy-icon"
+                                viewBox="0 0 24 24"
+                            >
+                                <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+                                <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+                            </svg>
+                            <span>copy</span>
+                        </motion.span>
+                    {/if}
+                </AnimatePresence>
+            </span>
+        </motion.button>
+    </div>
+
+    <div class="debug-log" data-testid="{testIdPrefix}-observer-log">
+        <div class="debug-head">observer log</div>
+        {#each observerLog as line, index (index)}
+            <code>{index + 1}: {line}</code>
+        {/each}
+    </div>
+</article>

--- a/src/routes/tests/animate-presence/layout-button/RollingCopyButton.svelte
+++ b/src/routes/tests/animate-presence/layout-button/RollingCopyButton.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+    import { AnimatePresence, motion } from '$lib'
+    import { onDestroy } from 'svelte'
+
+    type CopyStage = 'copy' | 'copied'
+
+    const copyStages: Record<
+        CopyStage,
+        {
+            className: string
+            label: string
+        }
+    > = {
+        copy: {
+            className: 'copy-state',
+            label: 'copy'
+        },
+        copied: {
+            className: 'copied-state',
+            label: 'copied'
+        }
+    }
+
+    let stage = $state<CopyStage>('copy')
+    let hasActivated = $state(false)
+    let hovered = $state(false)
+    let pressed = $state(false)
+    let resetTimer: ReturnType<typeof setTimeout> | null = null
+
+    const layoutTransition = { type: 'spring' as const, stiffness: 440, damping: 34 }
+    const rollTransition = { duration: 0.22, ease: [0.22, 1, 0.36, 1] as const }
+    const settledState = { opacity: 1, y: 0, filter: 'blur(0px)' }
+    const rollEnterState = { opacity: 0, y: 14, filter: 'blur(5px)' }
+    const contentRestState = { y: 0, scale: 1 }
+    const contentHoverState = { y: -1, scale: 1.025 }
+    const contentPressedState = { y: 0, scale: 0.94 }
+    const contentTransition = { type: 'spring' as const, stiffness: 500, damping: 30 }
+
+    function clearTimers() {
+        if (resetTimer) clearTimeout(resetTimer)
+        resetTimer = null
+    }
+
+    function copySnippet() {
+        clearTimers()
+        hasActivated = true
+        stage = 'copied'
+        resetTimer = setTimeout(() => {
+            stage = 'copy'
+            resetTimer = null
+        }, 1800)
+    }
+
+    function leaveButton() {
+        hovered = false
+        pressed = false
+    }
+
+    function releasePress() {
+        pressed = false
+    }
+
+    onDestroy(clearTimers)
+</script>
+
+<article class="demo featured-demo" data-testid="rolling-demo">
+    <div class="featured-copy">
+        <div>
+            <p class="eyebrow">dogfood control</p>
+            <h2>Hover, tap, and rolling copy label</h2>
+            <p>
+                This mirrors the docs copy interaction: the shell responds to hover/tap while
+                AnimatePresence rolls the icon and label between copy and copied states.
+            </p>
+        </div>
+
+        <div class="rolling-button-slot">
+            <motion.button
+                type="button"
+                class="copy-button rolling-copy-button"
+                data-testid="rolling-button"
+                data-stage={stage}
+                aria-label="Copy snippet"
+                layout
+                transition={layoutTransition}
+                onpointerenter={() => (hovered = true)}
+                onpointerleave={leaveButton}
+                onpointerdown={() => (pressed = true)}
+                onpointerup={releasePress}
+                onpointercancel={releasePress}
+                onblur={leaveButton}
+                onclick={copySnippet}
+            >
+                <motion.span
+                    class="rolling-button-content"
+                    data-testid="rolling-button-content"
+                    animate={pressed
+                        ? contentPressedState
+                        : hovered
+                          ? contentHoverState
+                          : contentRestState}
+                    transition={contentTransition}
+                >
+                    <span class="state-stack rolling-state-stack">
+                        <AnimatePresence mode="wait" initial={false}>
+                            <motion.span
+                                key={stage}
+                                class={`state rolling-state ${copyStages[stage].className}`}
+                                data-testid={`rolling-${stage}-state`}
+                                layout="position"
+                                initial={hasActivated ? rollEnterState : settledState}
+                                animate={settledState}
+                                exit={{ opacity: 0, y: -14, filter: 'blur(5px)' }}
+                                transition={rollTransition}
+                            >
+                                {#if stage === 'copied'}
+                                    <svg
+                                        aria-hidden="true"
+                                        data-testid="rolling-copied-icon"
+                                        viewBox="0 0 24 24"
+                                    >
+                                        <path d="M20 6 9 17l-5-5" />
+                                    </svg>
+                                {:else}
+                                    <svg
+                                        aria-hidden="true"
+                                        data-testid="rolling-copy-icon"
+                                        viewBox="0 0 24 24"
+                                    >
+                                        <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+                                        <path
+                                            d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+                                        />
+                                    </svg>
+                                {/if}
+                                <span>{copyStages[stage].label}</span>
+                            </motion.span>
+                        </AnimatePresence>
+                    </span>
+                </motion.span>
+            </motion.button>
+        </div>
+    </div>
+</article>

--- a/src/routes/tests/motion/animate-transform-persist/+page.svelte
+++ b/src/routes/tests/motion/animate-transform-persist/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import { motion } from '$lib'
 
+    let { data }: { data: { slow: boolean } } = $props()
+
     // Regression route for #377 — transform shortcuts must persist as inline
     // style after the WAAPI animation completes (default fill:'none' otherwise
     // surrenders the property, leaving transform:none).
@@ -13,13 +15,9 @@
     //   • x [0,120,60]    (keyframe array — rests at the LAST element, 60)
     //
     // A slower transition gives e2e room to sample a mid-animation frame and
-    // confirm it actually animates (no snap-to-target). `?slow` stretches it
-    // to 4s for frame-by-frame debugging of transient glitches.
-    // `?slow` stretches the animation to 4s so the enter motion can be
-    // watched (and frame-sampled by e2e) instead of completing in 0.6s.
-    const slow =
-        typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('slow')
-    const transition = { duration: slow ? 4 : 0.6, ease: 'linear' } as const
+    // confirm it actually animates (no snap-to-target). Read via load() so SSR
+    // optimized-appear scripts and hydrated state use the same duration.
+    const transition = $derived({ duration: data.slow ? 4 : 0.6, ease: 'linear' } as const)
 </script>
 
 <svelte:head>

--- a/src/routes/tests/motion/animate-transform-persist/+page.ts
+++ b/src/routes/tests/motion/animate-transform-persist/+page.ts
@@ -1,0 +1,5 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = ({ url }) => ({
+    slow: url.searchParams.has('slow')
+})

--- a/src/routes/tests/motion/enter-animation/+page.svelte
+++ b/src/routes/tests/motion/enter-animation/+page.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
     import { motion, MotionConfig } from '$lib'
+
+    let { data }: { data: { slow: boolean } } = $props()
+
+    const duration = $derived(data.slow ? 3.2 : 1.6)
+    const transition = $derived({
+        duration,
+        scale: { type: 'spring', visualDuration: duration, bounce: 0.5 }
+    })
 </script>
 
-<MotionConfig
-    transition={{ duration: 0.4, scale: { type: 'spring', visualDuration: 0.4, bounce: 0.5 } }}
->
+<MotionConfig {transition}>
     <motion.div
         initial={{ opacity: 0, scale: 0 }}
         animate={{ opacity: 1, scale: 1 }}

--- a/src/routes/tests/motion/enter-animation/+page.ts
+++ b/src/routes/tests/motion/enter-animation/+page.ts
@@ -1,0 +1,5 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = ({ url }) => ({
+    slow: url.searchParams.has('slow')
+})

--- a/src/routes/tests/optimized-appear/+page.svelte
+++ b/src/routes/tests/optimized-appear/+page.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+    import { motion } from '$lib'
+</script>
+
+<main class="min-h-screen bg-slate-950 px-6 py-12 text-white">
+    <section class="mx-auto grid max-w-4xl gap-8 md:grid-cols-[1fr_1.2fr] md:items-center">
+        <div>
+            <p class="text-sm font-medium uppercase tracking-wide text-cyan-300">
+                Optimized appear
+            </p>
+            <h1 class="mt-3 text-3xl font-semibold">SSR handoff without the cold-start flash</h1>
+            <p class="mt-4 text-sm leading-6 text-slate-300">
+                This page renders an initial state in SSR, starts an appear animation from inline
+                server HTML, then hydrates into the normal motion runtime.
+            </p>
+        </div>
+
+        <motion.div
+            data-testid="optimized-appear-card"
+            class="rounded-lg border border-cyan-300/30 bg-cyan-300/10 p-8 shadow-2xl shadow-cyan-950/50"
+            initial={{ opacity: 0, y: 28, scale: 0.92 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{ duration: 1, ease: [0.16, 1, 0.3, 1] }}
+        >
+            <div class="h-2 w-24 rounded-full bg-cyan-300"></div>
+            <h2 class="mt-6 text-xl font-semibold">Compositor-first entry</h2>
+            <p class="mt-3 text-sm leading-6 text-slate-200">
+                The browser starts opacity and transform before Svelte Motion takes ownership.
+            </p>
+        </motion.div>
+    </section>
+</main>


### PR DESCRIPTION
## Summary

Adds optimized appear animation handoff support so SSR entrance animations can begin before Svelte hydration and continue cleanly once the runtime mounts. The branch also tightens parity with upstream Motion internals by reusing `motion-dom` projection/SVG helpers where possible and adds dogfood coverage for the layout/presence interactions we validated visually.

## Changes

✨ New features
- Add optimized appear handoff data generation, inline bootstrap support, hydration gating, and exported low-level appear helpers.
- Add docs and examples for optimized appear, including a public example page and test page linked from the component web root.

🐛 Bug fixes
- Reuse upstream-style `motion-dom` SVG path drawing behavior for `pathLength`, `pathSpacing`, and `pathOffset` so path drawing uses normalized dash attributes.
- Stabilize optimized appear readiness so hydration does not flash, blank, or replay the first visible frame incorrectly.
- Improve AnimatePresence/layout projection behavior for sync layout swaps, scroll during layout animation, and wait-mode entry handling.

🔧 Refactoring/improvements
- Add a `MotionDomProjectionAdapter` and projection context to bridge layout measurement behavior toward upstream internals.
- Add projection/layout measurement improvements for static ancestor transforms and scroll-aware layout animation.
- Record the failed e2e review workflow in `CLAUDE.md` so future failures are reviewed visually one page at a time.

🧪 Testing
- Add optimized appear unit/e2e coverage and visual test pages.
- Add extensive AnimatePresence layout-button dogfood coverage for sync, wait, popLayout, scrolling, and rolling copy interactions.
- Stabilize timing-sensitive e2e assertions by measuring after the relevant animation/re-grab frame and accepting valid zero-delta idle projection callbacks.
- Verified locally with `pnpm exec playwright test --project=chromium --reporter=line` (`156 passed`, `2 skipped`) and `pnpm test` (`583 passed`).

📚 Documentation
- Add optimized appear docs and examples pages.
- Add navigation entries for the optimized appear docs/example surface.

## Commits

- [`7cc2c12`](https://github.com/humanspeak/svelte-motion/commit/7cc2c12eee9f4dcaa47941059768bf58fbe29170) test(e2e): stabilize animation timing assertions
- [`8b49f1a`](https://github.com/humanspeak/svelte-motion/commit/8b49f1a9d89549eb02a19aadb362ea4e5a2b4a15) fix(motion): align SVG path drawing with motion-dom
- [`859df8a`](https://github.com/humanspeak/svelte-motion/commit/859df8ab575075e7381b11ccc30a5fd6f54da397) fix(motion): gate optimized appear until ready
- [`1cdca11`](https://github.com/humanspeak/svelte-motion/commit/1cdca11faedd2b41d8698e1783126c5c5cfe5356) fix(motion): stabilize optimized appear test timing
- [`e9b26fe`](https://github.com/humanspeak/svelte-motion/commit/e9b26fe0b0c350bee5d48e08cd7e042648d5160a) docs: document failed e2e review workflow
- [`92a2cce`](https://github.com/humanspeak/svelte-motion/commit/92a2cceab4ad5ace7eb56e20317fdf0c693b539f) fix(animate-presence): stabilize layout swaps during scroll
- [`58e01ae`](https://github.com/humanspeak/svelte-motion/commit/58e01ae84af9ab16f7ad880908c964aadc005f2e) fix(animate-presence): anchor sync layout swaps
- [`a972edf`](https://github.com/humanspeak/svelte-motion/commit/a972edf6cb5eb86808b59c9cbf6ff1fd532e1035) fix(animate-presence): stabilize layout button dogfood
- [`f1ac4bb`](https://github.com/humanspeak/svelte-motion/commit/f1ac4bb078a5a1026b8083ade85202e68114ee0fc) fix: reuse motion-dom optimized appear internals
- [`282bd51`](https://github.com/humanspeak/svelte-motion/commit/282bd5160f690cdae4b61dd7a0e195fafda8363b) feat: add optimized appear animation handoff
