### PR TITLE
feat: document usePresenceData parity

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -24,7 +24,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.6.2",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.6.5",
         "@humanspeak/svelte-markdown": "^1.5.3",
         "@humanspeak/svelte-motion": "workspace:*",
         "@inlang/paraglide-js": "^2.18.1",

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -92,6 +92,7 @@ export const docsSections: NavSection[] = [
             { title: 'useCycle', href: '/docs/use-cycle', icon: RefreshCw },
             { title: 'useInView', href: '/docs/use-in-view', icon: Eye },
             { title: 'usePresence', href: '/docs/use-presence', icon: Ghost },
+            { title: 'usePresenceData', href: '/docs/use-presence-data', icon: ArrowUpDown },
             {
                 title: 'useReducedMotion',
                 href: '/docs/use-reduced-motion',

--- a/docs/src/lib/examples/use-presence-data/demos/Default.svelte
+++ b/docs/src/lib/examples/use-presence-data/demos/Default.svelte
@@ -1,0 +1,120 @@
+<script lang="ts" module>
+    const iconsProps = {
+        xmlns: 'http://www.w3.org/2000/svg',
+        width: '24',
+        height: '24',
+        viewBox: '0 0 24 24',
+        fill: 'none',
+        stroke: 'currentColor',
+        strokeWidth: '2',
+        strokeLinecap: 'round',
+        strokeLinejoin: 'round'
+    }
+</script>
+
+<script lang="ts">
+    import { AnimatePresence, motion, wrap } from '@humanspeak/svelte-motion'
+    import PresenceDataSlide from './PresenceDataSlide.svelte'
+
+    const items = [1, 2, 3, 4, 5, 6]
+
+    let selectedItem = $state(items[0])
+    let direction: 1 | -1 = $state(1)
+
+    const color = $derived(`var(--presence-hue-${selectedItem})`)
+
+    function setSlide(newDirection: 1 | -1) {
+        selectedItem = wrap(1, items.length, selectedItem + newDirection)
+        direction = newDirection
+    }
+</script>
+
+<!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
+<div class="dk-demo-shell">
+    <div class="container">
+        <motion.button
+            initial={false}
+            animate={{ backgroundColor: color }}
+            aria-label="Previous"
+            class="button"
+            onclick={() => setSlide(-1)}
+            whileFocus={{ outline: `2px solid ${color}` }}
+            whileTap={{ scale: 0.9 }}
+        >
+            <svg {...iconsProps}>
+                <path d="m12 19-7-7 7-7" />
+                <path d="M19 12H5" />
+            </svg>
+        </motion.button>
+
+        <AnimatePresence custom={direction} initial={false} mode="popLayout">
+            {#key selectedItem}
+                <PresenceDataSlide slideKey={selectedItem} {color} />
+            {/key}
+        </AnimatePresence>
+
+        <motion.button
+            initial={false}
+            animate={{ backgroundColor: color }}
+            aria-label="Next"
+            class="button"
+            onclick={() => setSlide(1)}
+            whileFocus={{ outline: `2px solid ${color}` }}
+            whileTap={{ scale: 0.9 }}
+        >
+            <svg {...iconsProps}>
+                <path d="M5 12h14" />
+                <path d="m12 5 7 7-7 7" />
+            </svg>
+        </motion.button>
+    </div>
+</div>
+
+<style>
+    .dk-demo-shell {
+        --presence-hue-1: #ff0088;
+        --presence-hue-2: #dd00ee;
+        --presence-hue-3: #9911ff;
+        --presence-hue-4: #0d63f8;
+        --presence-hue-5: #0cdcf7;
+        --presence-hue-6: #4ff0b7;
+
+        min-height: 360px;
+        display: grid;
+        place-items: center;
+        padding: 2rem;
+        background:
+            linear-gradient(90deg, rgba(114, 217, 247, 0.1) 1px, transparent 1px),
+            linear-gradient(0deg, rgba(114, 217, 247, 0.1) 1px, transparent 1px), #0e161c;
+        background-size: 44px 44px;
+        color: white;
+    }
+
+    .container {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+    }
+
+    .dk-demo-shell :global(.button) {
+        position: relative;
+        z-index: 1;
+        width: 42px;
+        height: 42px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: 0;
+        border-radius: 50%;
+        outline-offset: 2px;
+        color: white;
+        cursor: pointer;
+    }
+
+    .dk-demo-shell :global(.button svg) {
+        width: 24px;
+        height: 24px;
+    }
+</style>

--- a/docs/src/lib/examples/use-presence-data/demos/PresenceDataSlide.svelte
+++ b/docs/src/lib/examples/use-presence-data/demos/PresenceDataSlide.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+    /**
+     * Slide that reads AnimatePresence custom data with usePresenceData.
+     *
+     * @component
+     * @param color CSS color used as the slide background.
+     * @param slideKey Numeric slide id displayed by the example.
+     */
+    import { motion, usePresenceData, type Variants } from '@humanspeak/svelte-motion'
+
+    const { color, slideKey }: { color: string; slideKey: number } = $props()
+
+    const direction = $derived(usePresenceData<1 | -1>() ?? 1)
+    const variants: Variants = {
+        enter: (custom) => ({
+            opacity: 0,
+            x: (custom as number) > 0 ? 56 : -56
+        }),
+        center: {
+            opacity: 1,
+            x: 0,
+            transition: {
+                delay: 0.16,
+                type: 'spring',
+                visualDuration: 0.34,
+                bounce: 0.36
+            }
+        },
+        exit: (custom) => ({
+            opacity: 0,
+            x: (custom as number) > 0 ? -56 : 56
+        })
+    }
+</script>
+
+<motion.div
+    key={String(slideKey)}
+    class="slide"
+    data-presence-direction={direction}
+    {variants}
+    initial="enter"
+    animate="center"
+    exit="exit"
+    style={`background-color: ${color};`}
+>
+    <span>{slideKey}</span>
+</motion.div>
+
+<style>
+    :global(.slide) {
+        width: 150px;
+        height: 150px;
+        display: grid;
+        place-items: center;
+        border-radius: 10px;
+        color: rgba(255, 255, 255, 0.86);
+        font-size: 48px;
+        font-weight: 900;
+        transform-origin: 50% 50%;
+    }
+</style>

--- a/docs/src/routes/docs/use-presence-data/+page.svx
+++ b/docs/src/routes/docs/use-presence-data/+page.svx
@@ -1,0 +1,100 @@
+---
+title: 'usePresenceData'
+description: 'Read AnimatePresence custom data from an exiting child.'
+---
+
+<script>
+  import Example from '$lib/components/general/Example.svelte';
+  import UsePresenceDataExample from '$lib/examples/use-presence-data/demos/Default.svelte';
+  import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+  const seo = getSeoContext()
+  if (seo) {
+      seo.title = 'usePresenceData | Docs | Svelte Motion'
+      seo.description = 'Read custom data passed to AnimatePresence from entering and exiting children.'
+      seo.ogTitle = 'usePresenceData'
+      seo.ogTagline = 'Presence custom data inside exiting children'
+      seo.ogFeatures = ['AnimatePresence', 'custom', 'usePresenceData', 'Directional Exit']
+      seo.ogSlug = 'docs-use-presence-data'
+  }
+</script>
+
+# usePresenceData
+
+`usePresenceData()` returns the nearest `<AnimatePresence custom={...}>`
+value. It matches Motion's hook shape: inside a presence boundary it returns
+that boundary's `custom` data, and outside a boundary it returns `undefined`.
+
+The main use case is keyed exit animation. Once a child has been removed from
+state, its normal props are stale. Presence data gives that exiting child the
+latest parent-level data, such as a carousel direction.
+
+```svelte
+<script lang="ts">
+    import { AnimatePresence, motion, usePresenceData, wrap } from '@humanspeak/svelte-motion'
+
+    const items = [1, 2, 3]
+    let selected = $state(items[0])
+    let direction = $state(1)
+
+    function paginate(nextDirection: 1 | -1) {
+        selected = wrap(1, items.length, selected + nextDirection)
+        direction = nextDirection
+    }
+</script>
+
+<AnimatePresence custom={direction} initial={false} mode="popLayout">
+    {#key selected}
+        <Slide key={selected} />
+    {/key}
+</AnimatePresence>
+```
+
+Inside the keyed child:
+
+```svelte
+<script lang="ts">
+    import { motion, usePresenceData, type Variants } from '@humanspeak/svelte-motion'
+
+    const direction = $derived(usePresenceData<1 | -1>() ?? 1)
+
+    const variants: Variants = {
+        enter: (custom) => ({ x: custom > 0 ? 50 : -50, opacity: 0 }),
+        center: { x: 0, opacity: 1 },
+        exit: (custom) => ({ x: custom > 0 ? -50 : 50, opacity: 0 })
+    }
+</script>
+
+<motion.div
+    custom={direction}
+    {variants}
+    initial="enter"
+    animate="center"
+    exit="exit"
+/>
+```
+
+<Example isSmall exampleUrl="/examples/use-presence-data">
+  <UsePresenceDataExample />
+</Example>
+
+## API Reference
+
+### `usePresenceData<T = unknown>(): T | undefined`
+
+Returns the current `custom` value from the nearest `<AnimatePresence>`
+boundary.
+
+- Inside `<AnimatePresence custom={value}>`, returns `value`.
+- Outside `<AnimatePresence>`, returns `undefined`.
+- In Svelte reactive contexts, wrap it in `$derived(...)` so updates to
+  `custom` are tracked.
+
+## Related
+
+- [AnimatePresence custom](/docs/animate-presence-custom) — dynamic exit
+  variants using parent custom data.
+- [usePresence](/docs/use-presence) — manually delay removal with
+  `safeToRemove`.
+
+Based on [Motion's usePresenceData API](https://motion.dev/docs/react-use-presence-data).

--- a/docs/src/routes/docs/use-presence-data/+page.ts
+++ b/docs/src/routes/docs/use-presence-data/+page.ts
@@ -1,0 +1,6 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => ({
+    title: 'usePresenceData',
+    description: 'Read AnimatePresence custom data from an exiting child.'
+})

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -137,6 +137,10 @@ const EXAMPLES: Record<string, ExampleEntry> = {
         title: 'usePresence',
         description: 'Interactive usePresence animation example using Svelte Motion.'
     },
+    'use-presence-data': {
+        title: 'usePresenceData',
+        description: 'Read AnimatePresence custom data from an entering or exiting child.'
+    },
     'use-reduced-motion': {
         title: 'useReducedMotion',
         description: 'Interactive useReducedMotion animation example using Svelte Motion.'

--- a/docs/src/routes/examples/use-presence-data/+page.svelte
+++ b/docs/src/routes/examples/use-presence-data/+page.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+    import {
+        CodeReferenceV2,
+        type DemoManifestEntry,
+        ExampleV2,
+        type ExampleSection,
+        formatSheetLabel
+    } from '@humanspeak/docs-kit'
+    import { ArrowLeftRight, Layers, ScanEye } from '@lucide/svelte'
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import UsePresenceDataDefault from '$lib/examples/use-presence-data/demos/Default.svelte'
+    import demoManifest from '$lib/demo-manifest.json'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'usePresenceData' }
+        ]
+    }
+    if (seo) {
+        seo.title = 'usePresenceData | Examples | Svelte Motion'
+        seo.description = 'Read AnimatePresence custom data from an entering or exiting child.'
+        seo.ogTitle = 'usePresenceData'
+        seo.ogTagline = 'Presence custom data inside exiting children'
+        seo.ogFeatures = ['AnimatePresence', 'custom', 'usePresenceData', 'popLayout']
+        seo.ogSlug = 'examples-use-presence-data'
+    }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    const manifest = demoManifest as Record<string, DemoManifestEntry>
+
+    const sections: ExampleSection[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'PRESENCE-DATA',
+            title: { prefix: 'directional exits via ', accent: 'usePresenceData', end: '.' },
+            description:
+                'The parent passes `custom={direction}` to AnimatePresence. The keyed child reads that value with `usePresenceData()` so its enter and exit variants know which way to travel.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [
+                { k: 'api', v: 'usePresenceData' },
+                { k: 'mode', v: 'popLayout' }
+            ],
+            sourceUrl: `${SOURCE_URL}use-presence-data/demos/Default.svelte`
+        }
+    ]
+</script>
+
+{#snippet defaultSection()}
+    <UsePresenceDataDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <ArrowLeftRight />
+            <span>
+                The controls update <code>direction</code> before the keyed slide changes.
+            </span>
+        </li>
+        <li>
+            <ScanEye />
+            <span>
+                The slide calls <code>usePresenceData()</code>, so it can read parent custom data
+                while entering and while held for exit.
+            </span>
+        </li>
+        <li>
+            <Layers />
+            <span>
+                <code>mode="popLayout"</code> lets the leaving slide pop out of layout while the new slide
+                enters.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            {
+                id: 'use-presence-data-default',
+                label: 'Default.svelte',
+                ...manifest['use-presence-data/demos/Default.svelte']
+            },
+            {
+                id: 'use-presence-data-slide',
+                label: 'PresenceDataSlide.svelte',
+                ...manifest['use-presence-data/demos/PresenceDataSlide.svelte']
+            }
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel={formatSheetLabel(i, sections.length)}
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/use-presence-data/+page.ts
+++ b/docs/src/routes/examples/use-presence-data/+page.ts
@@ -1,0 +1,8 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async () => {
+    return {
+        title: 'usePresenceData',
+        description: 'Read AnimatePresence custom data from an exiting child.'
+    }
+}

--- a/e2e/utilities/use-presence-data.spec.ts
+++ b/e2e/utilities/use-presence-data.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const URL = '/tests/use-presence-data?@isPlaywright=true'
+
+async function waitForSettledCard(page: Page, card: string) {
+    await page.waitForFunction(
+        (expectedCard) => {
+            const el = document.querySelector('[data-testid="presence-data-card"]')
+            if (!(el instanceof HTMLElement)) return false
+            if (el.dataset.clone === 'true') return false
+            if (el.dataset.card !== expectedCard) return false
+
+            const style = getComputedStyle(el)
+            return Number.parseFloat(style.opacity) > 0.98
+        },
+        card,
+        { timeout: 5000 }
+    )
+}
+
+async function waitForExitingCardX(page: Page, direction: 'left' | 'right') {
+    const threshold = direction === 'left' ? -18 : 18
+
+    await page.waitForFunction(
+        ({ expectedDirection, expectedThreshold }) => {
+            const clone = document.querySelector(
+                '[data-testid="presence-data-card"][data-clone="true"]'
+            )
+            if (!(clone instanceof HTMLElement)) return false
+
+            const matrix = new DOMMatrixReadOnly(getComputedStyle(clone).transform)
+            return expectedDirection === 'left'
+                ? matrix.m41 < expectedThreshold
+                : matrix.m41 > expectedThreshold
+        },
+        { expectedDirection: direction, expectedThreshold: threshold },
+        { timeout: 5000 }
+    )
+}
+
+test.describe('usePresenceData', () => {
+    test('returns undefined outside AnimatePresence and tracks custom data inside it', async ({
+        page
+    }) => {
+        await page.goto(URL)
+
+        const probes = page.getByTestId('presence-data-probe')
+        await expect(probes.nth(0)).toHaveAttribute('data-value', 'undefined')
+        await expect(probes.nth(1)).toHaveAttribute('data-value', '1')
+
+        await page.getByTestId('presence-data-prev').click()
+        await expect(page.getByTestId('presence-data-direction')).toHaveText('direction -1')
+        await expect(probes.nth(1)).toHaveAttribute('data-value', '-1')
+    })
+
+    test('moves the exiting child from the latest custom direction on first previous click', async ({
+        page
+    }) => {
+        await page.goto(URL)
+        await waitForSettledCard(page, 'alpha')
+
+        await page.getByTestId('presence-data-prev').click()
+        await waitForExitingCardX(page, 'right')
+        await waitForSettledCard(page, 'charlie')
+    })
+
+    test('moves the exiting child from the latest custom direction on next click', async ({
+        page
+    }) => {
+        await page.goto(URL)
+        await waitForSettledCard(page, 'alpha')
+
+        await page.getByTestId('presence-data-next').click()
+        await waitForExitingCardX(page, 'left')
+        await waitForSettledCard(page, 'bravo')
+    })
+
+    test('is linked from the root test index', async ({ page }) => {
+        await page.goto('/?@isPlaywright=true')
+        await expect(page.getByRole('link', { name: 'usePresenceData' })).toHaveAttribute(
+            'href',
+            /\/tests\/use-presence-data/
+        )
+    })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.6.2
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636(@humanspeak/svelte-markdown@1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@humanspeak/svelte-motion@)(@internationalized/date@3.12.2)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))
+        specifier: github:humanspeak/docs-kit#2026.6.5
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/e1198d98213319920f43eceaa83eef3a5b7854b1(@humanspeak/svelte-markdown@1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@humanspeak/svelte-motion@)(@internationalized/date@3.12.2)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       '@humanspeak/svelte-markdown':
         specifier: ^1.5.3
         version: 1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0))
@@ -919,8 +919,8 @@ packages:
     resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/e1198d98213319920f43eceaa83eef3a5b7854b1':
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/e1198d98213319920f43eceaa83eef3a5b7854b1}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4767,7 +4767,7 @@ snapshots:
 
   '@humanfs/types@0.15.0': {}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636(@humanspeak/svelte-markdown@1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@humanspeak/svelte-motion@)(@internationalized/date@3.12.2)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/e1198d98213319920f43eceaa83eef3a5b7854b1(@humanspeak/svelte-markdown@1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@humanspeak/svelte-motion@)(@internationalized/date@3.12.2)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))':
     dependencies:
       '@humanspeak/svelte-motion': 'link:'
       '@humanspeak/svelte-satori-fix': 0.0.6(svelte@5.56.0(@typescript-eslint/types@8.60.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,10 +176,10 @@ importers:
         version: 5.2.8
       '@humanspeak/docs-kit':
         specifier: github:humanspeak/docs-kit#2026.6.2
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636(@humanspeak/svelte-markdown@1.5.3(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@humanspeak/svelte-motion@)(@internationalized/date@3.11.0)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636(@humanspeak/svelte-markdown@1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@humanspeak/svelte-motion@)(@internationalized/date@3.12.2)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       '@humanspeak/svelte-markdown':
         specifier: ^1.5.3
-        version: 1.5.3(svelte@5.56.0(@typescript-eslint/types@8.60.0))
+        version: 1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       '@humanspeak/svelte-motion':
         specifier: workspace:*
         version: link:..
@@ -191,7 +191,7 @@ importers:
         version: 1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       bits-ui:
         specifier: ^2.18.1
-        version: 2.18.1(@internationalized/date@3.11.0)(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))
+        version: 2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       flubber:
         specifier: ^0.4.2
         version: 0.4.2
@@ -210,7 +210,7 @@ importers:
         version: 7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))
       '@sveltejs/adapter-cloudflare':
         specifier: ^7.2.8
-        version: 7.2.8(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(wrangler@4.95.0(@cloudflare/workers-types@4.20260601.1))
+        version: 7.2.8(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(wrangler@4.95.0(@cloudflare/workers-types@4.20260531.1))
       '@sveltejs/kit':
         specifier: ^2.61.1
         version: 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
@@ -315,7 +315,7 @@ importers:
         version: 2.1.1(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vitest@4.1.8)
       wrangler:
         specifier: ^4.95.0
-        version: 4.95.0(@cloudflare/workers-types@4.20260601.1)
+        version: 4.95.0(@cloudflare/workers-types@4.20260531.1)
 
 packages:
 
@@ -471,8 +471,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20260601.1':
-    resolution: {integrity: sha512-pYORr1EKlDu55HCHhln8XSXoOSvKAkrTkovJL66bX8xw6DAT2fhs39B6FLjCJD+x++hjBEE2bmKB1TcFKS+0Dw==}
+  '@cloudflare/workers-types@4.20260531.1':
+    resolution: {integrity: sha512-7DybhbX12n+mVgJEDvm9W/jjqpaUIczg+RWj1Hua9nGEG+pNJnT+yZj1JKENrbdyuGWx3OFEgUCNFcGJN86Dvg==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -920,7 +920,7 @@ packages:
     engines: {node: '>=18.18.0'}
 
   '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636':
-    resolution: {gitHosted: true, integrity: sha512-ya+I6bXJReGZ98PByP+LSON8snpJRPzUzPNkP3usKGFecLlidv0tRi0Jj/eh1wWjp7Ol8gPy8kJ0V3X38cjxkg==, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -940,8 +940,8 @@ packages:
     resolution: {integrity: sha512-8nS/7OIysYsjd5d64cprdwupgqzpMmFDHw25EWuPLRxxJw5q91K7Z+bjIcAPjikMU9vmptY5GyhsZDbcr1ym4Q==}
     engines: {node: '>=18.0.0'}
 
-  '@humanspeak/svelte-markdown@1.5.3':
-    resolution: {integrity: sha512-rfNhZyX5fR7Uoli4f5M0VLjxWhCNvksN8/tvRFT4jU1fE3FwP1jo+dQpDgIg4aslaecKD+0IX7OrfTN3Wiw/3w==}
+  '@humanspeak/svelte-markdown@1.5.4':
+    resolution: {integrity: sha512-UguY+DNg/0wwJ+9PwvhoqFlgmOtPUgKmpiwmvINJMKw6DKoBvYFKzULDF6tNqjwoCTFRW/uvbBW2nE93Xa60pg==}
     peerDependencies:
       katex: '>=0.16.0'
       mermaid: '>=10.0.0'
@@ -1143,8 +1143,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@internationalized/date@3.11.0':
-    resolution: {integrity: sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q==}
+  '@internationalized/date@3.12.2':
+    resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -3785,8 +3785,8 @@ packages:
     peerDependencies:
       svelte: ^5.0.0
 
-  svelte2tsx@0.7.56:
-    resolution: {integrity: sha512-NTvqqL+goYlW8gWNajk81L07+uu7jw5V2m1Az5MZbYm3GEydcHXh+uTrLHM9SuGuaqCtF90vlMXkOVBotfH94g==}
+  svelte2tsx@0.7.55:
+    resolution: {integrity: sha512-JWzgeM3lqySRNfqcsesvVEh8LhTWBxQJ9RMjzJ+VepdmXtVnNd0SbtGctG6+/fbHq0N6mhwSd823gszw9JHeGQ==}
     peerDependencies:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0 || ^6.0.0
@@ -4496,7 +4496,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260526.1':
     optional: true
 
-  '@cloudflare/workers-types@4.20260601.1': {}
+  '@cloudflare/workers-types@4.20260531.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -4767,14 +4767,14 @@ snapshots:
 
   '@humanfs/types@0.15.0': {}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636(@humanspeak/svelte-markdown@1.5.3(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@humanspeak/svelte-motion@)(@internationalized/date@3.11.0)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/5551f3050bf43227499ff17f893fe96c9767c636(@humanspeak/svelte-markdown@1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@humanspeak/svelte-motion@)(@internationalized/date@3.12.2)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))':
     dependencies:
       '@humanspeak/svelte-motion': 'link:'
       '@humanspeak/svelte-satori-fix': 0.0.6(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       '@lucide/svelte': 1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       '@resvg/resvg-js': 2.6.2
       '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
-      bits-ui: 2.18.1(@internationalized/date@3.11.0)(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))
+      bits-ui: 2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       clsx: 2.1.1
       github-slugger: 2.0.0
       mode-watcher: 1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0))
@@ -4784,7 +4784,7 @@ snapshots:
       svelte: 5.56.0(@typescript-eslint/types@8.60.0)
       tailwind-merge: 3.6.0
     optionalDependencies:
-      '@humanspeak/svelte-markdown': 1.5.3(svelte@5.56.0(@typescript-eslint/types@8.60.0))
+      '@humanspeak/svelte-markdown': 1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       shiki: 4.1.0
     transitivePeerDependencies:
       - '@internationalized/date'
@@ -4792,7 +4792,7 @@ snapshots:
 
   '@humanspeak/memory-cache@1.0.6': {}
 
-  '@humanspeak/svelte-markdown@1.5.3(svelte@5.56.0(@typescript-eslint/types@8.60.0))':
+  '@humanspeak/svelte-markdown@1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0))':
     dependencies:
       '@humanspeak/memory-cache': 1.0.6
       github-slugger: 2.0.0
@@ -4939,7 +4939,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@internationalized/date@3.11.0':
+  '@internationalized/date@3.12.2':
     dependencies:
       '@swc/helpers': 0.5.23
 
@@ -5209,12 +5209,12 @@ snapshots:
     dependencies:
       '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
 
-  '@sveltejs/adapter-cloudflare@7.2.8(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(wrangler@4.95.0(@cloudflare/workers-types@4.20260601.1))':
+  '@sveltejs/adapter-cloudflare@7.2.8(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(wrangler@4.95.0(@cloudflare/workers-types@4.20260531.1))':
     dependencies:
-      '@cloudflare/workers-types': 4.20260601.1
+      '@cloudflare/workers-types': 4.20260531.1
       '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
       worktop: 0.8.0-next.18
-      wrangler: 4.95.0(@cloudflare/workers-types@4.20260601.1)
+      wrangler: 4.95.0(@cloudflare/workers-types@4.20260531.1)
 
   '@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))':
     dependencies:
@@ -5243,7 +5243,7 @@ snapshots:
       sade: 1.8.1
       semver: 7.8.1
       svelte: 5.56.0(@typescript-eslint/types@8.60.0)
-      svelte2tsx: 0.7.56(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)
+      svelte2tsx: 0.7.55(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
@@ -5722,11 +5722,11 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  bits-ui@2.18.1(@internationalized/date@3.11.0)(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0)):
+  bits-ui@2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0)):
     dependencies:
       '@floating-ui/core': 1.7.5
       '@floating-ui/dom': 1.7.6
-      '@internationalized/date': 3.11.0
+      '@internationalized/date': 3.12.2
       esm-env: 1.2.2
       runed: 0.35.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       svelte: 5.56.0(@typescript-eslint/types@8.60.0)
@@ -7665,7 +7665,7 @@ snapshots:
       style-to-object: 1.0.14
       svelte: 5.56.0(@typescript-eslint/types@8.60.0)
 
-  svelte2tsx@0.7.56(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3):
+  svelte2tsx@0.7.55(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3):
     dependencies:
       dedent-js: 1.0.1
       scule: 1.3.0
@@ -8086,7 +8086,7 @@ snapshots:
       mrmime: 2.0.1
       regexparam: 3.0.0
 
-  wrangler@4.95.0(@cloudflare/workers-types@4.20260601.1):
+  wrangler@4.95.0(@cloudflare/workers-types@4.20260531.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260526.1)
@@ -8098,7 +8098,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260526.1
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20260601.1
+      '@cloudflare/workers-types': 4.20260531.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,16 @@ allowBuilds:
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
     - '@humanspeak/*'
+    - '@vitest/browser@4.1.8'
+    - '@vitest/coverage-v8@4.1.8'
+    - '@vitest/expect@4.1.8'
+    - '@vitest/mocker@4.1.8'
+    - '@vitest/pretty-format@4.1.8'
+    - '@vitest/runner@4.1.8'
+    - '@vitest/snapshot@4.1.8'
+    - '@vitest/spy@4.1.8'
+    - '@vitest/utils@4.1.8'
+    - prettier-plugin-svelte@4.1.0
+    - svelte-check@4.5.0
+    - vite@8.0.16
+    - vitest@4.1.8

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -377,6 +377,14 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/use-presence-data') + searchParams}
+                    >
+                        usePresenceData
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/reduced-motion') + searchParams}
                     >
                         useReducedMotion

--- a/src/routes/tests/use-presence-data/+page.svelte
+++ b/src/routes/tests/use-presence-data/+page.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+    import { AnimatePresence } from '$lib'
+    import PresenceDataCard from './PresenceDataCard.svelte'
+    import PresenceDataProbe from './PresenceDataProbe.svelte'
+
+    const cards = [
+        { id: 'alpha', label: 'Alpha exits with latest parent data' },
+        { id: 'bravo', label: 'Bravo enters from the selected direction' },
+        { id: 'charlie', label: 'Charlie proves stale child props are avoided' }
+    ]
+
+    let index = $state(0)
+    let direction: 1 | -1 = $state(1)
+    const current = $derived(cards[index])
+
+    function go(nextDirection: 1 | -1) {
+        direction = nextDirection
+        index = (index + nextDirection + cards.length) % cards.length
+    }
+</script>
+
+<svelte:head>
+    <title>usePresenceData</title>
+</svelte:head>
+
+<main>
+    <section class="intro">
+        <p class="kicker">usePresenceData (#305)</p>
+        <h1>Exiting children can read AnimatePresence custom data.</h1>
+        <p>
+            The child calls <code>usePresenceData()</code>. On each navigation, the leaving card
+            should exit using the latest parent <code>custom</code> direction.
+        </p>
+    </section>
+
+    <section class="stage" data-testid="presence-data-stage">
+        <div class="frame" data-testid="presence-data-frame">
+            <AnimatePresence custom={direction} initial={false}>
+                {#key current.id}
+                    <PresenceDataCard id={current.id} label={current.label} />
+                {/key}
+            </AnimatePresence>
+        </div>
+
+        <div class="controls">
+            <button type="button" data-testid="presence-data-prev" onclick={() => go(-1)}>
+                Previous
+            </button>
+            <output data-testid="presence-data-direction">direction {direction}</output>
+            <button type="button" data-testid="presence-data-next" onclick={() => go(1)}>
+                Next
+            </button>
+        </div>
+    </section>
+
+    <section class="readouts" data-testid="presence-data-readouts">
+        <div>
+            <p class="kicker">outside AnimatePresence</p>
+            <PresenceDataProbe />
+        </div>
+        <div>
+            <p class="kicker">inside AnimatePresence</p>
+            <AnimatePresence custom={direction}>
+                <PresenceDataProbe />
+            </AnimatePresence>
+        </div>
+    </section>
+</main>
+
+<style>
+    :global(html),
+    :global(body) {
+        min-height: 100%;
+        height: auto;
+        margin: 0;
+        overflow-y: auto;
+        background: #0b1014;
+        color: #e7f2fb;
+        font-family:
+            Inter,
+            ui-sans-serif,
+            system-ui,
+            -apple-system,
+            BlinkMacSystemFont,
+            'Segoe UI',
+            sans-serif;
+    }
+
+    :global(body > .h-full),
+    :global(body > .h-full > .h-full),
+    :global(.container),
+    :global(#sandbox) {
+        min-height: 100vh;
+        height: auto;
+    }
+
+    main {
+        min-height: 100vh;
+        width: min(880px, calc(100vw - 32px));
+        display: grid;
+        align-content: start;
+        gap: 26px;
+        margin: 0 auto;
+        padding: 48px 0;
+    }
+
+    .intro {
+        max-width: 720px;
+    }
+
+    .kicker {
+        margin: 0 0 8px;
+        color: #72d9f7;
+        font-size: 13px;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    h1 {
+        margin: 0;
+        font-size: 34px;
+        line-height: 1.08;
+    }
+
+    .intro p:not(.kicker) {
+        margin: 12px 0 0;
+        color: #b7c7d4;
+        font-size: 16px;
+        line-height: 1.65;
+    }
+
+    code {
+        color: #f5b7df;
+    }
+
+    .stage,
+    .readouts {
+        display: grid;
+        gap: 18px;
+        padding: 26px;
+        border: 1px solid #263947;
+        background:
+            linear-gradient(90deg, rgba(114, 217, 247, 0.1) 1px, transparent 1px),
+            linear-gradient(0deg, rgba(114, 217, 247, 0.1) 1px, transparent 1px), #0e161c;
+        background-size: 44px 44px;
+    }
+
+    .frame {
+        position: relative;
+        height: 260px;
+        display: grid;
+        place-items: center;
+        overflow: hidden;
+        border: 1px solid #324a5b;
+        background: rgba(9, 15, 20, 0.78);
+    }
+
+    .controls {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 12px;
+    }
+
+    button,
+    output {
+        min-height: 38px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        padding: 0 14px;
+        border: 1px solid #405767;
+        border-radius: 6px;
+        background: #121c24;
+        color: #eef6fb;
+        font-size: 13px;
+        font-weight: 750;
+    }
+
+    button {
+        cursor: pointer;
+    }
+
+    button:hover {
+        border-color: #72d9f7;
+    }
+
+    .readouts {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .readouts > div {
+        display: grid;
+        gap: 10px;
+        padding: 18px;
+        border: 1px solid #324a5b;
+        background: #101922;
+    }
+</style>

--- a/src/routes/tests/use-presence-data/PresenceDataCard.svelte
+++ b/src/routes/tests/use-presence-data/PresenceDataCard.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+    /**
+     * Test card that reads parent AnimatePresence custom data during enter
+     * and exit variants.
+     *
+     * @component
+     * @param id Stable card id exposed to the e2e harness.
+     * @param label Text rendered inside the card.
+     */
+    import { motion, usePresenceData, type Variants } from '$lib'
+
+    let { id, label }: { id: string; label: string } = $props()
+
+    const direction = $derived(usePresenceData<1 | -1>() ?? 1)
+    const variants: Variants = {
+        enter: (custom) => ({
+            x: (custom as number) > 0 ? 90 : -90,
+            opacity: 0
+        }),
+        center: {
+            x: 0,
+            opacity: 1
+        },
+        exit: (custom) => ({
+            x: (custom as number) > 0 ? -90 : 90,
+            opacity: 0
+        })
+    }
+</script>
+
+<motion.div
+    key={id}
+    class="card"
+    data-testid="presence-data-card"
+    data-card={id}
+    data-presence-data={direction}
+    {variants}
+    initial="enter"
+    animate="center"
+    exit="exit"
+    transition={{ duration: 0.5, ease: 'linear' }}
+>
+    <span>{label}</span>
+    <small>presence data {direction}</small>
+</motion.div>
+
+<style>
+    :global(.card) {
+        position: absolute;
+        width: min(320px, calc(100% - 32px));
+        min-height: 128px;
+        display: grid;
+        align-content: center;
+        gap: 10px;
+        padding: 22px;
+        border: 1px solid #72d9f7;
+        background: #142230;
+        box-shadow: 0 24px 70px rgba(0, 0, 0, 0.36);
+        color: #edf7ff;
+        transform-origin: 50% 50%;
+    }
+
+    :global(.card span) {
+        font-size: 24px;
+        font-weight: 800;
+        line-height: 1.1;
+    }
+
+    :global(.card small) {
+        color: #f5b7df;
+        font-size: 13px;
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+    }
+</style>

--- a/src/routes/tests/use-presence-data/PresenceDataProbe.svelte
+++ b/src/routes/tests/use-presence-data/PresenceDataProbe.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+    /**
+     * Renders the current usePresenceData value for unit-like route checks.
+     *
+     * @component
+     */
+    import { usePresenceData } from '$lib'
+
+    const data = $derived(usePresenceData<1 | -1>())
+</script>
+
+<output data-testid="presence-data-probe" data-value={data === undefined ? 'undefined' : data}>
+    {data === undefined ? 'undefined' : data}
+</output>


### PR DESCRIPTION
## Summary

Adds the missing `usePresenceData` parity surface around the upstream-matching hook, so the docs, examples, and test harness clearly demonstrate Motion-style custom presence data for entering and exiting children.

This also carries the docs-kit `2026.6.5` bump and pnpm release-age allowlist needed for the current locked toolchain to install and build cleanly.

## Changes

- ✨ New features: Add a focused `/tests/use-presence-data` harness showing outside/inside presence data and directional exit behavior.
- 📚 Documentation: Add `/docs/use-presence-data`, `/examples/use-presence-data`, docs nav metadata, examples index metadata, and reusable demo components.
- 🧪 Testing: Add Playwright coverage for `usePresenceData` returning `undefined` outside `AnimatePresence`, tracking custom data inside it, direction-aware exits, and root test linking.
- 📦 Dependency/build: Bump docs-kit to `2026.6.5` and allow the pinned pnpm release-age policy to pass for current toolchain packages.

## Validation

- `./node_modules/.bin/vitest run src/lib/utils/usePresence.spec.ts src/lib/index.spec.ts`
- `./node_modules/.bin/playwright test e2e/utilities/use-presence-data.spec.ts`
- `pnpm run check`
- `npm run build` in `docs/`

## Commits

- [`9fbc8e5`](https://github.com/humanspeak/svelte-motion/commit/9fbc8e52a38ff72772fca75e84ce88470a243a4a) feat: document usePresenceData parity
- [`8b8a634`](https://github.com/humanspeak/svelte-motion/commit/8b8a6344aae6c0f452a84136aac94596be463f40) build: allow pnpm release-age policy to pass
- [`ccd8827`](https://github.com/humanspeak/svelte-motion/commit/ccd88276fb524c1b1d55fe8261a0ef31a24590bf) build(docs): bump docs-kit to 2026.6.5
