### PR TITLE
feat: support object style MotionValues

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -39,6 +39,7 @@ src/lib/sitemap-manifest.json
 # Generated demo manifest (docs-kit's demoManifestPlugin output)
 src/lib/demo-manifest.json
 src/lib/demo-loaders.ts
+src/lib/demo-virtual.d.ts
 
 # Generated GitHub stats (build artifact)
 src/lib/github-stats.json

--- a/docs/package.json
+++ b/docs/package.json
@@ -24,7 +24,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.6.8",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.6.9",
         "@humanspeak/svelte-markdown": "^1.5.3",
         "@humanspeak/svelte-motion": "workspace:*",
         "@inlang/paraglide-js": "^2.18.1",

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -69,6 +69,11 @@ export const docsSections: NavSection[] = [
         items: [
             { title: 'Overview', href: '/docs/motion-values', icon: Signal },
             { title: 'MotionValue children', href: '/docs/motion-value-children', icon: Code },
+            {
+                title: 'Object style MotionValues',
+                href: '/docs/object-style-motion-values',
+                icon: Code
+            },
             { title: 'useFollowValue', href: '/docs/use-follow-value', icon: Activity },
             { title: 'useMotionTemplate', href: '/docs/use-motion-template', icon: Code },
             { title: 'useMotionValueEvent', href: '/docs/use-motion-value-event', icon: Zap },

--- a/docs/src/lib/examples/object-style-motion-values/demos/Default.svelte
+++ b/docs/src/lib/examples/object-style-motion-values/demos/Default.svelte
@@ -38,7 +38,6 @@
     async function reverse() {
         const id = ++runId
         phase = 'routing'
-        progress.jump(1)
         await animate(progress as unknown as RawMotionValue<number>, 0, {
             duration: 0.95,
             ease: [0.22, 1, 0.36, 1]
@@ -56,16 +55,16 @@
 <!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
 <div class="dk-demo-shell">
     <div class="toolbar" aria-label="Packet route controls">
-        <button type="button" onclick={reverse} aria-label="Route left">
+        <button type="button" onclick={reverse}>
             <ArrowLeft size={15} />
             Return
         </button>
-        <button type="button" class="primary" onclick={route} aria-label="Route right">
+        <button type="button" class="primary" onclick={route}>
             <Send size={15} />
             Deliver
             <ArrowRight size={15} />
         </button>
-        <button type="button" onclick={reset} aria-label="Reset route">
+        <button type="button" onclick={reset}>
             <RotateCcw size={15} />
             Reset
         </button>

--- a/docs/src/lib/examples/object-style-motion-values/demos/Default.svelte
+++ b/docs/src/lib/examples/object-style-motion-values/demos/Default.svelte
@@ -23,29 +23,44 @@
 
     let phase = $state<'queued' | 'routing' | 'delivered'>('queued')
     let runId = 0
+    let activeAnimation: { stop: () => void } | null = null
+
+    function stopActiveAnimation() {
+        activeAnimation?.stop()
+        activeAnimation = null
+    }
 
     async function route() {
+        stopActiveAnimation()
         const id = ++runId
         phase = 'routing'
         progress.jump(0)
-        await animate(progress as unknown as RawMotionValue<number>, 1, {
+        const animation = animate(progress as unknown as RawMotionValue<number>, 1, {
             duration: 0.95,
             ease: [0.22, 1, 0.36, 1]
         })
+        activeAnimation = animation
+        await animation
+        if (activeAnimation === animation) activeAnimation = null
         if (id === runId) phase = 'delivered'
     }
 
     async function reverse() {
+        stopActiveAnimation()
         const id = ++runId
         phase = 'routing'
-        await animate(progress as unknown as RawMotionValue<number>, 0, {
+        const animation = animate(progress as unknown as RawMotionValue<number>, 0, {
             duration: 0.95,
             ease: [0.22, 1, 0.36, 1]
         })
+        activeAnimation = animation
+        await animation
+        if (activeAnimation === animation) activeAnimation = null
         if (id === runId) phase = 'queued'
     }
 
     function reset() {
+        stopActiveAnimation()
         runId += 1
         phase = 'queued'
         progress.jump(0)

--- a/docs/src/lib/examples/object-style-motion-values/demos/Default.svelte
+++ b/docs/src/lib/examples/object-style-motion-values/demos/Default.svelte
@@ -1,0 +1,286 @@
+<script lang="ts">
+    import { ArrowLeft, ArrowRight, RotateCcw, Send } from '@lucide/svelte'
+    import {
+        animate,
+        motion,
+        useMotionTemplate,
+        useMotionValue,
+        useTransform,
+        type RawMotionValue
+    } from '@humanspeak/svelte-motion'
+
+    const progress = useMotionValue(0)
+    const x = useTransform(progress, [0, 1], ['-30vw', '30vw'])
+    const y = useTransform(progress, [0, 0.5, 1], [76, -64, 52])
+    const rotate = useTransform(progress, [0, 1], [-7, 8])
+    const scale = useTransform(progress, [0, 0.5, 1], [0.92, 1.18, 1])
+    const opacity = useTransform(progress, [0, 0.15, 1], [0.62, 1, 1])
+    const hue = useTransform(progress, (latest) => 192 + latest * 126)
+    const backgroundColor = useTransform(hue, (latest) => `hsl(${latest}, 82%, 46%)`)
+    const glowX = x
+    const shadowAlpha = useTransform(progress, [0, 1], [0.2, 0.52])
+    const boxShadow = useMotionTemplate`0 28px 90px rgba(45, 212, 191, ${shadowAlpha})`
+
+    let phase = $state<'queued' | 'routing' | 'delivered'>('queued')
+    let runId = 0
+
+    async function route() {
+        const id = ++runId
+        phase = 'routing'
+        progress.jump(0)
+        await animate(progress as unknown as RawMotionValue<number>, 1, {
+            duration: 0.95,
+            ease: [0.22, 1, 0.36, 1]
+        })
+        if (id === runId) phase = 'delivered'
+    }
+
+    async function reverse() {
+        const id = ++runId
+        phase = 'routing'
+        progress.jump(1)
+        await animate(progress as unknown as RawMotionValue<number>, 0, {
+            duration: 0.95,
+            ease: [0.22, 1, 0.36, 1]
+        })
+        if (id === runId) phase = 'queued'
+    }
+
+    function reset() {
+        runId += 1
+        phase = 'queued'
+        progress.jump(0)
+    }
+</script>
+
+<!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
+<div class="dk-demo-shell">
+    <div class="toolbar" aria-label="Packet route controls">
+        <button type="button" onclick={reverse} aria-label="Route left">
+            <ArrowLeft size={15} />
+            Return
+        </button>
+        <button type="button" class="primary" onclick={route} aria-label="Route right">
+            <Send size={15} />
+            Deliver
+            <ArrowRight size={15} />
+        </button>
+        <button type="button" onclick={reset} aria-label="Reset route">
+            <RotateCcw size={15} />
+            Reset
+        </button>
+    </div>
+
+    <div class="stage">
+        <div class="endpoint left-end">
+            <span>Origin</span>
+            <small>queued</small>
+        </div>
+        <div class="endpoint right-end">
+            <span>Destination</span>
+            <small>delivered</small>
+        </div>
+        <div class="route-line" aria-hidden="true"></div>
+
+        <motion.div
+            class="packet"
+            data-phase={phase}
+            style={{
+                x,
+                y,
+                rotate,
+                scale,
+                opacity,
+                backgroundColor,
+                boxShadow,
+                '--packet-x': glowX
+            }}
+        >
+            <span>{phase}</span>
+            <small>style object</small>
+        </motion.div>
+    </div>
+</div>
+
+<style>
+    .dk-demo-shell {
+        position: relative;
+        width: 100%;
+        min-height: 520px;
+        display: grid;
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-rows: auto 1fr;
+        align-items: stretch;
+        gap: 20px;
+        padding: 2rem;
+        background: #0d1518;
+        color: #eef6fb;
+    }
+
+    .toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 8px;
+    }
+
+    button {
+        height: 36px;
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        padding: 0 12px;
+        border: 1px solid #46616a;
+        border-radius: 6px;
+        background: #142127;
+        color: #eef6fb;
+        font-size: 13px;
+        font-weight: 780;
+        cursor: pointer;
+    }
+
+    button.primary {
+        border-color: #5eead4;
+        background: #0f766e;
+    }
+
+    .stage {
+        position: relative;
+        width: 100%;
+        min-height: 460px;
+        display: grid;
+        place-items: center;
+        overflow: hidden;
+        border: 1px solid #2b4650;
+        background:
+            linear-gradient(90deg, rgba(94, 234, 212, 0.1) 1px, transparent 1px),
+            linear-gradient(0deg, rgba(94, 234, 212, 0.1) 1px, transparent 1px), #071114;
+        background-size: 44px 44px;
+    }
+
+    .stage::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background:
+            radial-gradient(circle at 14% 62%, rgba(45, 212, 191, 0.12), transparent 24%),
+            radial-gradient(circle at 86% 34%, rgba(251, 113, 133, 0.12), transparent 28%);
+        pointer-events: none;
+    }
+
+    .route-line {
+        position: absolute;
+        left: 10%;
+        right: 10%;
+        top: 50%;
+        height: 1px;
+        background: linear-gradient(90deg, #5eead4, #38bdf8, #fb7185);
+        opacity: 0.55;
+    }
+
+    .endpoint {
+        position: absolute;
+        top: calc(50% - 72px);
+        width: 148px;
+        min-height: 72px;
+        display: grid;
+        align-content: center;
+        gap: 5px;
+        padding: 0 16px;
+        border: 1px solid #365766;
+        background: rgba(16, 31, 38, 0.78);
+        color: #dff7ff;
+        font-weight: 850;
+    }
+
+    .endpoint span {
+        font-size: 14px;
+    }
+
+    .endpoint small {
+        color: #86b8c7;
+        font-size: 10px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+    }
+
+    .left-end {
+        left: 6%;
+        border-radius: 16px 4px 4px 16px;
+    }
+
+    .right-end {
+        right: 6%;
+        border-radius: 4px 16px 16px 4px;
+        text-align: right;
+    }
+
+    :global(.packet) {
+        position: absolute;
+        top: calc(50% - 60px);
+        left: calc(50% - 78px);
+        width: 156px;
+        height: 120px;
+        display: grid;
+        align-content: center;
+        justify-items: center;
+        gap: 6px;
+        border: 1px solid rgba(236, 254, 255, 0.48);
+        border-radius: 18px;
+        background:
+            radial-gradient(
+                circle at calc(50% + var(--packet-x, 0px)) 50%,
+                rgba(255, 255, 255, 0.22),
+                transparent 52%
+            ),
+            #0f766e;
+        color: #f8fafc;
+        text-align: center;
+        transform-origin: 50% 50%;
+        will-change: transform;
+    }
+
+    :global(.packet) span {
+        font-size: 22px;
+        font-weight: 900;
+        letter-spacing: 0;
+    }
+
+    :global(.packet) small {
+        color: rgba(255, 255, 255, 0.76);
+        font-size: 11px;
+        font-weight: 820;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    @media (max-width: 560px) {
+        .dk-demo-shell {
+            padding: 1rem;
+        }
+
+        .stage {
+            min-height: 390px;
+        }
+
+        .endpoint {
+            width: 118px;
+            min-height: 62px;
+            padding: 0 12px;
+        }
+
+        .left-end {
+            left: 16px;
+        }
+
+        .right-end {
+            right: 16px;
+        }
+
+        :global(.packet) {
+            width: 140px;
+            height: 100px;
+            left: calc(50% - 70px);
+        }
+    }
+</style>

--- a/docs/src/routes/docs/object-style-motion-values/+page.svx
+++ b/docs/src/routes/docs/object-style-motion-values/+page.svx
@@ -1,0 +1,98 @@
+---
+title: 'Object style MotionValues'
+description: 'Pass MotionValues directly to object-form style props.'
+---
+
+<script>
+  import Example from '$lib/components/general/Example.svelte';
+  import ObjectStyleMotionValuesExample from '$lib/examples/object-style-motion-values/demos/Default.svelte';
+  import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+  const seo = getSeoContext()
+  if (seo) {
+      seo.title = 'Object style MotionValues | Docs | Svelte Motion'
+      seo.description = 'Pass MotionValues directly to object-form style props and let motion-dom update inline styles.'
+      seo.ogTitle = 'Object style MotionValues'
+      seo.ogTagline = 'MotionValue interpolation directly inside style objects'
+      seo.ogFeatures = ['MotionValue', 'Style Objects', 'Transforms', 'motion-dom']
+      seo.ogSlug = 'docs-object-style-motion-values'
+  }
+</script>
+
+# Object style MotionValues
+
+Motion components accept object-form styles in addition to CSS strings. Static
+entries render into the initial inline style, while MotionValue entries are
+subscribed with Motion's `styleEffect` so they update on animation frames
+without `styleString`.
+
+```svelte
+<script lang="ts">
+  import { motion, useMotionValue, useTransform } from '@humanspeak/svelte-motion'
+
+  const x = useMotionValue(24)
+  const opacity = useTransform(x, [24, 160], [0.6, 1])
+</script>
+
+<motion.div
+  style={{
+    x,
+    opacity,
+    width: 160,
+    height: 96,
+    backgroundColor: '#0f766e'
+  }}
+/>
+```
+
+<Example isSmall exampleUrl="/examples/object-style-motion-values">
+  <ObjectStyleMotionValuesExample />
+</Example>
+
+## What Updates Live
+
+MotionValue entries inside `style` update live:
+
+```svelte
+<motion.div
+  style={{
+    x,
+    scale,
+    opacity,
+    backgroundColor,
+    '--glow-x': glowX
+  }}
+/>
+```
+
+Transform shortcuts like `x`, `y`, `scale`, and `rotate` are composed into one
+`transform` string by `motion-dom`. CSS variables use `style.setProperty`, and
+normal CSS properties write to the element's inline style.
+
+## Static Entries
+
+Static object entries are serialized into the rendered style attribute:
+
+```svelte
+<motion.div
+  style={{
+    width: 180,
+    height: 120,
+    borderRadius: 18,
+    backgroundColor: '#123244'
+  }}
+/>
+```
+
+Numbers follow Motion's existing style handling for common dimensional and
+transform properties. Use strings when a value needs a specific unit.
+
+## API Reference
+
+### `style={object}`
+
+Object-form `style` accepts CSS property names, CSS variables, and Motion
+transform shortcuts. Values may be strings, numbers, or MotionValues.
+
+This matches Motion's style MotionValue path in `motion-dom`:
+`packages/motion-dom/src/effects/style/index.ts`.

--- a/docs/src/routes/docs/object-style-motion-values/+page.ts
+++ b/docs/src/routes/docs/object-style-motion-values/+page.ts
@@ -1,0 +1,6 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => ({
+    title: 'Object style MotionValues',
+    description: 'Pass MotionValues directly to object-form style props.'
+})

--- a/docs/src/routes/examples/object-style-motion-values/+page.svelte
+++ b/docs/src/routes/examples/object-style-motion-values/+page.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        type ExampleSection,
+        formatSheetLabel
+    } from '@humanspeak/docs-kit'
+    import { Boxes, Palette, Route } from '@lucide/svelte'
+    import { demoCodeSample } from '$lib/demo-loaders'
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import ObjectStyleMotionValuesDefault from '$lib/examples/object-style-motion-values/demos/Default.svelte'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'Object style MotionValues' }
+        ]
+    }
+    if (seo) {
+        seo.title = 'Object style MotionValues | Examples | Svelte Motion'
+        seo.description = 'Drive object-form style props with live MotionValues.'
+        seo.ogTitle = 'Object style MotionValues'
+        seo.ogTagline = 'MotionValue interpolation directly inside style objects'
+        seo.ogFeatures = ['MotionValue', 'Style Objects', 'Transforms', 'CSS Variables']
+        seo.ogSlug = 'examples-object-style-motion-values'
+    }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    const sections: ExampleSection[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'MOTION-VALUE',
+            title: { prefix: 'style objects can ', accent: 'carry MotionValues', end: '.' },
+            description:
+                'One progress MotionValue derives transform shortcuts, opacity, color, box-shadow, and a CSS variable directly inside the style object. Static entries render immediately; live entries update through motion-dom.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [
+                { k: 'api', v: 'style={{ x, opacity }}' },
+                { k: 'effect', v: 'motion-dom' }
+            ],
+            sourceUrl: `${SOURCE_URL}object-style-motion-values/demos/Default.svelte`
+        }
+    ]
+</script>
+
+{#snippet defaultSection()}
+    <ObjectStyleMotionValuesDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Route />
+            <span>
+                Transform shortcuts like <code>x</code>, <code>y</code>, <code>rotate</code>, and
+                <code>scale</code> are composed by Motion's style effect.
+            </span>
+        </li>
+        <li>
+            <Palette />
+            <span>
+                Non-transform properties like <code>backgroundColor</code> and
+                <code>boxShadow</code> can be MotionValues too.
+            </span>
+        </li>
+        <li>
+            <Boxes />
+            <span>
+                Static object entries such as <code>width</code> and <code>height</code> render with the
+                initial markup, so the first paint is stable.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'object-style-motion-values/demos/Default.svelte',
+                'object-style-motion-values-default',
+                'Default.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel={formatSheetLabel(i, sections.length)}
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/object-style-motion-values/+page.ts
+++ b/docs/src/routes/examples/object-style-motion-values/+page.ts
@@ -1,0 +1,8 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => {
+    return {
+        title: 'Object style MotionValues',
+        description: 'Drive object-form style props with live MotionValues.'
+    }
+}

--- a/e2e/utilities/object-style-motion-values.spec.ts
+++ b/e2e/utilities/object-style-motion-values.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const URL = '/tests/object-style-motion-values?@isPlaywright=true'
+
+const readCardStyle = async (page: Page) =>
+    page.getByTestId('object-style-card').evaluate((element) => {
+        const style = getComputedStyle(element)
+        const matrix = new DOMMatrixReadOnly(style.transform)
+        return {
+            x: matrix.m41,
+            scaleX: matrix.a,
+            opacity: Number(style.opacity),
+            glowX: style.getPropertyValue('--glow-x').trim(),
+            width: style.width,
+            backgroundColor: style.backgroundColor
+        }
+    })
+
+test.describe('object style MotionValues', () => {
+    test('server-renders initial object-form style values', async ({ request }) => {
+        const response = await request.get(URL)
+        const html = await response.text()
+
+        expect(response.ok()).toBe(true)
+        expect(html).toContain('transform: translateX(24px) scale(0.92)')
+        expect(html).toContain('opacity: 0.58')
+        expect(html).toContain('--glow-x: 24px')
+    })
+
+    test('updates object-form MotionValue styles without styleString', async ({ page }) => {
+        await page.goto(URL)
+
+        await expect
+            .poll(async () => {
+                const style = await readCardStyle(page)
+                return Math.round(style.x)
+            })
+            .toBe(24)
+
+        const initial = await readCardStyle(page)
+        expect(initial.glowX).toBe('24px')
+        expect(initial.width).toBe('172px')
+        expect(initial.backgroundColor).toBe('rgb(18, 50, 68)')
+
+        await page.getByTestId('object-style-toggle').click()
+
+        await expect
+            .poll(async () => {
+                const style = await readCardStyle(page)
+                return {
+                    x: Math.round(style.x),
+                    opacity: Math.round(style.opacity * 100),
+                    scaleX: Math.round(style.scaleX * 100)
+                }
+            })
+            .toEqual({ x: 168, opacity: 100, scaleX: 108 })
+
+        await expect
+            .poll(async () => {
+                const style = await readCardStyle(page)
+                return style.glowX
+            })
+            .toBe('168px')
+
+        await page.getByTestId('object-style-reset').click()
+
+        await expect
+            .poll(async () => {
+                const style = await readCardStyle(page)
+                return Math.round(style.x)
+            })
+            .toBe(24)
+    })
+
+    test('is linked from the root test index', async ({ page }) => {
+        await page.goto('/?@isPlaywright=true')
+        await expect(page.getByRole('link', { name: 'Object style MotionValues' })).toHaveAttribute(
+            'href',
+            /\/tests\/object-style-motion-values/
+        )
+    })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.6.8
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/a95d0e126504c0caa3007ebbd4928d5a1bea2175(@humanspeak/svelte-markdown@1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@humanspeak/svelte-motion@)(@internationalized/date@3.12.2)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))
+        specifier: github:humanspeak/docs-kit#2026.6.9
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/480c160c9839e47f0856b707dff70147167ea845(@humanspeak/svelte-markdown@1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@humanspeak/svelte-motion@)(@internationalized/date@3.12.2)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       '@humanspeak/svelte-markdown':
         specifier: ^1.5.3
         version: 1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0))
@@ -919,8 +919,8 @@ packages:
     resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a95d0e126504c0caa3007ebbd4928d5a1bea2175':
-    resolution: {gitHosted: true, integrity: sha512-UEm1F9yJWeWqeuRt6s3BE4guiH5+7vQJ5RZF2gseK13d14DxEvDkeBLpJjttMeoo7an0grtQmAwRrHfdevw5Fg==, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/a95d0e126504c0caa3007ebbd4928d5a1bea2175}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/480c160c9839e47f0856b707dff70147167ea845':
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/480c160c9839e47f0856b707dff70147167ea845}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4767,7 +4767,7 @@ snapshots:
 
   '@humanfs/types@0.15.0': {}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a95d0e126504c0caa3007ebbd4928d5a1bea2175(@humanspeak/svelte-markdown@1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@humanspeak/svelte-motion@)(@internationalized/date@3.12.2)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/480c160c9839e47f0856b707dff70147167ea845(@humanspeak/svelte-markdown@1.5.4(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@humanspeak/svelte-motion@)(@internationalized/date@3.12.2)(@lucide/svelte@1.17.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.0(@typescript-eslint/types@8.60.0)))(shiki@4.1.0)(svelte@5.56.0(@typescript-eslint/types@8.60.0))':
     dependencies:
       '@humanspeak/svelte-motion': 'link:'
       '@humanspeak/svelte-satori-fix': 0.0.6(svelte@5.56.0(@typescript-eslint/types@8.60.0))

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -30,7 +30,7 @@
     import { isNotEmpty } from '$lib/utils/objects'
     import { sleep } from '$lib/utils/testing'
     import { animate, type AnimationOptions, type DOMKeyframesDefinition } from 'motion'
-    import { motionValue, svgEffect, type MotionValue } from 'motion-dom'
+    import { motionValue, styleEffect, svgEffect, type MotionValue } from 'motion-dom'
     import { isPlaywrightEnv, pwLog } from '$lib/utils/log'
     import { onDestroy, untrack, type Snippet } from 'svelte'
     import { VOID_TAGS } from '$lib/utils/constants'
@@ -49,7 +49,12 @@
         type RectLike
     } from '$lib/utils/layout'
     import type { SvelteHTMLElements } from 'svelte/elements'
-    import { mergeInlineStyles, extractTransform } from '$lib/utils/style'
+    import {
+        collectMotionStyleValues,
+        extractTransform,
+        mergeInlineStyles,
+        serializeMotionStyle
+    } from '$lib/utils/style'
     import { isNativelyFocusable } from '$lib/utils/a11y'
     import {
         getAnimatePresenceContext,
@@ -254,6 +259,7 @@
     // than the live inline transform — the latter already carries any
     // transform-type `initial`/`animate` keyframe by the time the node
     // measures, which would be mistaken for the user's base.
+    const serializedStyleProp = $derived(serializeMotionStyle(styleProp))
     const userBaseTransform = $derived(extractTransform(styleProp))
 
     const projectionParent = getProjectionParent()
@@ -505,6 +511,15 @@
         return bindMotionValueChild(motionValueChild, element, (text) => {
             motionValueChildText = text
         })
+    })
+
+    $effect(() => {
+        if (!element) return
+
+        const styleValues = collectMotionStyleValues(styleProp)
+        if (!styleValues) return
+
+        return styleEffect(element, styleValues)
     })
 
     // Variant inheritance and resolution
@@ -1046,7 +1061,7 @@
             return {}
         })(),
         style: mergeInlineStyles(
-            `${initialKeyframes && 'pathLength' in initialKeyframes && isLoaded === 'mounting' ? `${styleProp || ''};visibility:hidden` : (styleProp ?? '')}${waitEnterBlockedBeforeMount || waitHiddenDisplay !== null ? ';display:none' : ''}`,
+            `${initialKeyframes && 'pathLength' in initialKeyframes && isLoaded === 'mounting' ? `${serializedStyleProp};visibility:hidden` : serializedStyleProp}${waitEnterBlockedBeforeMount || waitHiddenDisplay !== null ? ';display:none' : ''}`,
             // The "from" slot: apply initialKeyframes as inline styles during
             // the mounting/initial phases (before the WAAPI animation locks
             // its from-value and we promote to 'ready' — see the lifecycle

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 import type { MotionValueChild } from '$lib/utils/motionValueChild'
+import type { MotionStyle } from '$lib/utils/style'
 import type { AnimationOptions, DOMKeyframesDefinition } from 'motion'
 import type { Snippet } from 'svelte'
 
@@ -563,8 +564,8 @@ export type MotionProps = {
     onPan?: MotionOnPan
     /** Pan gesture: fires on pointerup if onPanStart ever fired */
     onPanEnd?: MotionOnPanEnd
-    /** Inline styles */
-    style?: string
+    /** Inline styles as a CSS string or Motion-style object with live MotionValue entries. */
+    style?: string | MotionStyle
     /** CSS classes */
     class?: string
     /** Enable FLIP layout animations; string values select the upstream projection animation type. */

--- a/src/lib/utils/style.spec.ts
+++ b/src/lib/utils/style.spec.ts
@@ -1,5 +1,11 @@
+import { motionValue } from 'motion-dom'
 import { describe, expect, it } from 'vitest'
-import { mergeInlineStyles } from './style.js'
+import {
+    collectMotionStyleValues,
+    extractTransform,
+    mergeInlineStyles,
+    serializeMotionStyle
+} from './style.js'
 
 describe('mergeInlineStyles', () => {
     it('returns existing style when no initial/animate provided', () => {
@@ -213,5 +219,65 @@ describe('mergeInlineStyles', () => {
             expect(out).toContain('pointer-events: none')
             expect(out).toContain('transform: translateY(60px) scale(0.8)')
         })
+    })
+})
+
+describe('serializeMotionStyle', () => {
+    it('serializes object-form styles with static CSS and transform shortcuts', () => {
+        const out = serializeMotionStyle({
+            x: 24,
+            opacity: 0.5,
+            backgroundColor: 'rgb(255, 0, 0)',
+            '--glow-x': 12
+        })
+
+        expect(out).toContain('transform: translateX(24px)')
+        expect(out).toContain('opacity: 0.5')
+        expect(out).toContain('background-color: rgb(255, 0, 0)')
+        expect(out).toContain('--glow-x: 12')
+    })
+
+    it('serializes MotionValues with their current value for initial markup', () => {
+        const x = motionValue(48)
+        const opacity = motionValue(0.75)
+
+        const out = serializeMotionStyle({ x, opacity })
+
+        expect(out).toContain('transform: translateX(48px)')
+        expect(out).toContain('opacity: 0.75')
+    })
+
+    it('passes string styles through unchanged', () => {
+        expect(serializeMotionStyle('color: red')).toBe('color: red')
+    })
+})
+
+describe('collectMotionStyleValues', () => {
+    it('returns only MotionValue entries from object-form styles', () => {
+        const x = motionValue(24)
+        const glow = motionValue('40%')
+
+        const values = collectMotionStyleValues({
+            x,
+            opacity: 0.5,
+            '--glow-x': glow
+        })
+
+        expect(values).toEqual({ x, '--glow-x': glow })
+    })
+
+    it('returns undefined when no MotionValues are present', () => {
+        expect(collectMotionStyleValues({ opacity: 0.5 })).toBeUndefined()
+        expect(collectMotionStyleValues('opacity: 0.5')).toBeUndefined()
+    })
+})
+
+describe('extractTransform', () => {
+    it('reads transform from object-form style props', () => {
+        expect(extractTransform({ transform: 'rotate(12deg)' })).toBe('rotate(12deg)')
+    })
+
+    it('reads transform from object-form MotionValues', () => {
+        expect(extractTransform({ transform: motionValue('scale(1.2)') })).toBe('scale(1.2)')
     })
 })

--- a/src/lib/utils/style.ts
+++ b/src/lib/utils/style.ts
@@ -1,3 +1,33 @@
+import { isMotionValue, type MotionValue } from 'motion-dom'
+
+/**
+ * Structural MotionValue shape accepted by object-form styles.
+ *
+ * The public API intentionally stays structural because Svelte Motion wraps
+ * and augments MotionValues while preserving Motion's runtime contract.
+ */
+export type MotionStyleMotionValue = {
+    /** Read the current style value. */
+    get: () => string | number
+}
+
+/**
+ * A value accepted inside Motion's object-form `style` prop.
+ *
+ * Static values are serialized into the rendered inline style. MotionValues
+ * are also serialized with their current value, then subscribed with
+ * `motion-dom`'s `styleEffect` so they can update the DOM without rerenders.
+ */
+export type MotionStyleValue = string | number | MotionStyleMotionValue | null | undefined
+
+/**
+ * React-style object form for the `style` prop.
+ *
+ * Supports normal CSS properties, CSS variables, and Motion transform
+ * shortcuts like `x`, `y`, `scale`, and `rotate`.
+ */
+export type MotionStyle = Record<string, MotionStyleValue>
+
 /**
  * Merge inline CSS styles from an existing style string with a Motion initial definition.
  * This is used during SSR to reflect the initial state in server-rendered markup.
@@ -168,9 +198,68 @@ export const mergeInlineStyles = (
  * ```
  */
 export const extractTransform = (style: unknown): string => {
-    if (typeof style !== 'string') return ''
+    if (typeof style !== 'string') {
+        if (!isMotionStyleObject(style)) return ''
+        const transform = resolveStyleValue(style.transform)
+        return transform == null ? '' : String(transform)
+    }
     return parseStyleString(style).transform ?? ''
 }
+
+/**
+ * Serialize a string or object-form Motion style prop into inline CSS.
+ *
+ * @param style The consumer-provided style prop.
+ * @returns Inline CSS suitable for Svelte's `style` attribute.
+ */
+export const serializeMotionStyle = (style: string | MotionStyle | null | undefined): string => {
+    if (typeof style === 'string') return style
+    if (!isMotionStyleObject(style)) return ''
+    return mergeInlineStyles('', resolveMotionStyle(style), null)
+}
+
+/**
+ * Collect MotionValue entries from object-form style props.
+ *
+ * @param style The consumer-provided style prop.
+ * @returns A map of style keys to MotionValues, or `undefined` when no live
+ *   style values are present.
+ */
+export const collectMotionStyleValues = (
+    style: unknown
+): Record<string, MotionValue> | undefined => {
+    if (!isMotionStyleObject(style)) return undefined
+
+    const values: Record<string, MotionValue> = {}
+    for (const [key, value] of Object.entries(style)) {
+        if (isMotionValue(value)) {
+            values[key] = value as MotionValue
+        }
+    }
+
+    return Object.keys(values).length ? values : undefined
+}
+
+const isMotionStyleObject = (style: unknown): style is MotionStyle =>
+    !!style && typeof style === 'object' && !Array.isArray(style)
+
+const resolveMotionStyle = (style: MotionStyle): Record<string, unknown> => {
+    const resolved: Record<string, unknown> = {}
+
+    for (const [key, value] of Object.entries(style)) {
+        resolved[key] = resolveStyleValue(value)
+    }
+
+    return resolved
+}
+
+const resolveStyleValue = (value: MotionStyleValue): string | number | null | undefined => {
+    if (isMotionStyleMotionValue(value)) return value.get()
+    return value
+}
+
+const isMotionStyleMotionValue = (value: MotionStyleValue): value is MotionStyleMotionValue =>
+    !!value && typeof value === 'object' && 'get' in value && typeof value.get === 'function'
 
 const parseStyleString = (style: string): Record<string, string> => {
     const out: Record<string, string> = {}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -72,6 +72,14 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/object-style-motion-values') + searchParams}
+                    >
+                        Object style MotionValues
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/motion/aspect-ratio') + searchParams}
                     >
                         Aspect Ratio

--- a/src/routes/tests/object-style-motion-values/+page.svelte
+++ b/src/routes/tests/object-style-motion-values/+page.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+    import {
+        animate,
+        motion,
+        useMotionTemplate,
+        useMotionValue,
+        useTransform,
+        type RawMotionValue
+    } from '$lib'
+
+    const x = useMotionValue(24)
+    const opacity = useTransform(x, [24, 168], [0.58, 1])
+    const scale = useTransform(x, [24, 168], [0.92, 1.08])
+    const glowX = useMotionTemplate`${x}px`
+    const shadowAlpha = useTransform(x, [24, 168], [0.18, 0.46])
+    const shadow = useMotionTemplate`0 26px 90px rgba(56, 189, 248, ${shadowAlpha})`
+
+    let moved = $state(false)
+
+    async function toggle() {
+        moved = !moved
+        await animate(x as unknown as RawMotionValue<number>, moved ? 168 : 24, {
+            duration: 0.45,
+            ease: [0.22, 1, 0.36, 1]
+        })
+    }
+
+    function reset() {
+        moved = false
+        x.jump(24)
+    }
+</script>
+
+<svelte:head>
+    <title>Object style MotionValues</title>
+</svelte:head>
+
+<main>
+    <section class="intro">
+        <p class="kicker">Object style MotionValues (#317)</p>
+        <h1>MotionValues can live directly in style objects.</h1>
+        <p>
+            The card uses <code
+                >style=&#123;&#123; x, opacity, scale, '--glow-x': glowX &#125;&#125;</code
+            >
+            without <code>styleString</code>. MotionValue entries update the inline style through
+            <code>motion-dom</code>'s style effect.
+        </p>
+    </section>
+
+    <section class="stage" data-testid="object-style-stage">
+        <div class="rail">
+            <motion.div
+                class="card"
+                data-testid="object-style-card"
+                style={{
+                    x,
+                    opacity,
+                    scale,
+                    '--glow-x': glowX,
+                    boxShadow: shadow,
+                    width: 172,
+                    height: 112,
+                    borderRadius: 18,
+                    backgroundColor: '#123244'
+                }}
+            >
+                <span>live style</span>
+            </motion.div>
+        </div>
+
+        <div class="controls">
+            <button type="button" data-testid="object-style-toggle" onclick={toggle}>
+                {moved ? 'Move back' : 'Move right'}
+            </button>
+            <button type="button" data-testid="object-style-reset" onclick={reset}>Reset</button>
+        </div>
+    </section>
+</main>
+
+<style>
+    :global(html),
+    :global(body) {
+        min-height: 100%;
+        height: auto;
+        margin: 0;
+        overflow-y: auto;
+        background: #071012;
+        color: #ecfdf5;
+        font-family:
+            Inter,
+            ui-sans-serif,
+            system-ui,
+            -apple-system,
+            BlinkMacSystemFont,
+            'Segoe UI',
+            sans-serif;
+    }
+
+    :global(body > .h-full),
+    :global(body > .h-full > .h-full),
+    :global(.container),
+    :global(#sandbox) {
+        min-height: 100vh;
+        height: auto;
+    }
+
+    main {
+        min-height: 100vh;
+        width: min(920px, calc(100vw - 32px));
+        display: grid;
+        align-content: center;
+        gap: 28px;
+        margin: 0 auto;
+        padding: 48px 0;
+    }
+
+    .intro {
+        max-width: 720px;
+    }
+
+    .kicker {
+        margin: 0 0 8px;
+        color: #67e8f9;
+        font-size: 13px;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    h1 {
+        margin: 0;
+        font-size: clamp(32px, 5vw, 58px);
+        line-height: 0.95;
+        letter-spacing: 0;
+    }
+
+    .intro p:not(.kicker) {
+        margin: 14px 0 0;
+        color: #a7c7c9;
+        font-size: 16px;
+        line-height: 1.65;
+    }
+
+    code {
+        color: #f0abfc;
+    }
+
+    .stage {
+        display: grid;
+        gap: 22px;
+        padding: 28px;
+        border: 1px solid rgba(103, 232, 249, 0.28);
+        background:
+            linear-gradient(90deg, rgba(103, 232, 249, 0.1) 1px, transparent 1px),
+            linear-gradient(0deg, rgba(103, 232, 249, 0.1) 1px, transparent 1px), #0b171a;
+        background-size: 42px 42px;
+    }
+
+    .rail {
+        position: relative;
+        height: 220px;
+        border: 1px solid rgba(103, 232, 249, 0.22);
+        background:
+            radial-gradient(
+                circle at var(--glow-x, 24px) 50%,
+                rgba(56, 189, 248, 0.28),
+                transparent 34%
+            ),
+            rgba(5, 12, 15, 0.62);
+        overflow: hidden;
+    }
+
+    :global(.card) {
+        position: absolute;
+        top: 54px;
+        left: 0;
+        display: grid;
+        place-items: center;
+        border: 1px solid rgba(186, 230, 253, 0.42);
+        color: #e0f2fe;
+        font-size: 18px;
+        font-weight: 850;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        transform-origin: 50% 50%;
+    }
+
+    .controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+    }
+
+    button {
+        min-width: 126px;
+        border: 1px solid rgba(125, 211, 252, 0.45);
+        border-radius: 6px;
+        background: #102332;
+        color: #ecfeff;
+        padding: 10px 14px;
+        font: inherit;
+        font-weight: 800;
+        cursor: pointer;
+    }
+
+    button:hover {
+        border-color: #67e8f9;
+        background: #153247;
+    }
+</style>


### PR DESCRIPTION
## Summary

Adds object-form `style` support for MotionValues so consumers can pass transform shortcuts, CSS variables, and ordinary style properties directly through `style={{ ... }}` without building a `styleString`. Live style values are wired through upstream `motion-dom`'s `styleEffect`, while static/current values serialize into SSR markup for stable first paint.

This branch also carries the docs-kit virtual-output update needed by the current docs build.

## Changes

✨ New features
- Accept `style` as either a CSS string or object-form `MotionStyle` on motion components.
- Subscribe object-form MotionValues through `motion-dom` `styleEffect`, including transform shortcuts and CSS variables.
- Serialize object-form style values for SSR and initial inline markup.

📚 Documentation
- Add Object style MotionValues docs and example pages.
- Add a full-width route demo showing live `x`, `y`, `rotate`, `scale`, `opacity`, `backgroundColor`, `boxShadow`, and CSS variable values inside a style object.
- Link the new docs page from Motion Values navigation.

🧪 Testing
- Add unit coverage for object-style serialization, MotionValue collection, and transform extraction.
- Add a focused test page and Playwright e2e coverage for SSR output, live browser updates, and root test index linking.

🔧 Build/docs
- Update docs-kit to `2026.6.9` and ignore the generated `demo-virtual.d.ts` output.

## Validation

- `pnpm exec vitest run src/lib/utils/style.spec.ts`
- `pnpm exec playwright test e2e/utilities/object-style-motion-values.spec.ts`
- `pnpm --dir docs run build`
- Pre-commit hook passed formatting, lint, and `svelte-check`

## Commits

- [`17a512e`](https://github.com/humanspeak/svelte-motion/commit/17a512ef39a9f90a1cf821baca897e0fbb1cad0f) build(docs): update docs-kit demo virtual output
- [`8f43f01`](https://github.com/humanspeak/svelte-motion/commit/8f43f015cd99ac68724819468f21bedee8933ce4) feat: support object style MotionValues
- [`565ab95`](https://github.com/humanspeak/svelte-motion/commit/565ab9562ff50e69ced87c1de1d15000f26a3e50) fix: address object style demo feedback

Closes #317
