### PR TITLE
ci: build docs on pull requests

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -52,3 +52,33 @@ jobs:
 
             - name: Build package and app
               run: pnpm build
+
+    docs-build:
+        if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        timeout-minutes: 15
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              with:
+                  persist-credentials: false
+                  fetch-depth: 1
+
+            - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
+
+            - name: Use Node.js - 24
+              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              with:
+                  node-version: 24
+
+            - name: Install workspace dependencies
+              run: pnpm install --frozen-lockfile --config.engine-strict=false
+
+            - name: Build package
+              run: pnpm build
+
+            - name: Build docs
+              working-directory: docs
+              env:
+                  NODE_OPTIONS: --max-old-space-size=4096
+              run: pnpm run build

--- a/docs/src/lib/demo-code-samples.ts
+++ b/docs/src/lib/demo-code-samples.ts
@@ -1,0 +1,62 @@
+import { demoCodeSample, type DemoCodeLoaderKey, type DemoCodeSample } from '$lib/demo-loaders'
+
+const demoCodeDependencies: Partial<Record<DemoCodeLoaderKey, DemoCodeLoaderKey[]>> = {
+    'armed-buttons/demos/Archive.svelte': ['armed-buttons/ArchiveArmedButton.svelte'],
+    'armed-buttons/demos/Default.svelte': ['armed-buttons/RecordingInsightRow.svelte'],
+    'armed-buttons/demos/DeleteWait.svelte': ['armed-buttons/DeleteArmedWaitButton.svelte'],
+    'multi-state-badge/demos/Default.svelte': [
+        'multi-state-badge/Badge.svelte',
+        'multi-state-badge/Icon.svelte',
+        'multi-state-badge/Check.svelte',
+        'multi-state-badge/Loader.svelte',
+        'multi-state-badge/XIcon.svelte',
+        'multi-state-badge/Label.svelte'
+    ],
+    'pan/demos/SwipeCards.svelte': ['pan/demos/CardItem.svelte'],
+    'use-presence-data/demos/Default.svelte': ['use-presence-data/demos/PresenceDataSlide.svelte'],
+    'use-presence/demos/Default.svelte': ['use-presence/demos/UsePresenceCard.svelte']
+}
+
+function demoCodeLabelForKey(key: DemoCodeLoaderKey): string {
+    return key.split('/').pop() ?? key
+}
+
+function demoCodeIdForKey(baseId: string, key: DemoCodeLoaderKey, index: number): string {
+    if (index === 0) return baseId
+
+    const fileName = demoCodeLabelForKey(key).replace(/\.svelte$/, '')
+    const slug = fileName
+        .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+        .replace(/[^a-zA-Z0-9]+/g, '-')
+        .replace(/^-|-$/g, '')
+        .toLowerCase()
+
+    return `${baseId}-${slug || index}`
+}
+
+/**
+ * Builds lazy `CodeReferenceV2` samples for a demo entrypoint and every
+ * co-located `.svelte` component imported by that demo.
+ *
+ * @param key - Demo path emitted by `demoManifestPlugin({ split: true })`.
+ * @param id - Stable sample identifier for the demo entrypoint.
+ * @param label - Human-readable file label for the demo entrypoint.
+ * @param preload - Optional override for docs-kit's idle preload behavior.
+ * @returns Lazy code samples for the demo followed by local component dependencies.
+ */
+export function demoCodeSamples(
+    key: DemoCodeLoaderKey,
+    id: string,
+    label: string,
+    preload?: 'idle' | false
+): DemoCodeSample[] {
+    const keys = [key, ...(demoCodeDependencies[key] ?? [])]
+    return keys.map((sampleKey, index) =>
+        demoCodeSample(
+            sampleKey,
+            demoCodeIdForKey(id, sampleKey, index),
+            index === 0 ? label : demoCodeLabelForKey(sampleKey),
+            preload
+        )
+    )
+}

--- a/docs/src/routes/examples/armed-buttons/+page.svelte
+++ b/docs/src/routes/examples/armed-buttons/+page.svelte
@@ -6,7 +6,7 @@
         formatSheetLabel
     } from '@humanspeak/docs-kit'
     import { Archive, ShieldCheck, Sparkles, TimerReset, Trash2 } from '@lucide/svelte'
-    import { demoCodeSamples } from '$lib/demo-loaders'
+    import { demoCodeSamples } from '$lib/demo-code-samples'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import ArchiveArmedDemo from '$lib/examples/armed-buttons/demos/Archive.svelte'


### PR DESCRIPTION
## Summary
- add a docs-build job to the PR Build workflow
- mirror the deploy build path by installing the full workspace, building the package, then running the docs build with the deploy memory setting

## Verification
- `pnpm build`
- `cd docs && NODE_OPTIONS=--max-old-space-size=4096 pnpm run build`
- Ruby YAML parse for `.github/workflows/pr-build.yml`
