### PR TITLE
fix: cancel deferred templated style writes

### DIFF
--- a/e2e/variants/stagger-interrupt.test.ts
+++ b/e2e/variants/stagger-interrupt.test.ts
@@ -13,11 +13,13 @@ test.describe('variants/stagger-interrupt', () => {
                     const transform = getComputedStyle(element).transform
                     if (!transform || transform === 'none') return 0
                     const matrix = transform.match(/matrix\(([^)]+)\)/)
-                    if (!matrix) return 0
-                    const values = matrix[1]
+                    const matrix3d = transform.match(/matrix3d\(([^)]+)\)/)
+                    const rawValues = matrix3d?.[1] ?? matrix?.[1]
+                    if (!rawValues) return 0
+                    const values = rawValues
                         .split(',')
                         .map((value) => Number.parseFloat(value.trim()))
-                    return values[5] || 0
+                    return matrix3d ? values[13] || 0 : values[5] || 0
                 })
             )
 

--- a/e2e/variants/stagger-interrupt.test.ts
+++ b/e2e/variants/stagger-interrupt.test.ts
@@ -7,15 +7,8 @@ test.describe('variants/stagger-interrupt', () => {
 
         const cells = page.getByTestId('variant-cell')
         await expect(cells).toHaveCount(12)
-
-        await page.getByTestId('play').click()
-        await page.waitForTimeout(180)
-        await page.getByTestId('stop').click()
-
-        const samples: number[][] = []
-        for (let sample = 0; sample < 10; sample += 1) {
-            await page.waitForTimeout(120)
-            const yValues = await cells.evaluateAll((elements) =>
+        const readYValues = () =>
+            cells.evaluateAll((elements) =>
                 elements.map((element) => {
                     const transform = getComputedStyle(element).transform
                     if (!transform || transform === 'none') return 0
@@ -27,12 +20,21 @@ test.describe('variants/stagger-interrupt', () => {
                     return values[5] || 0
                 })
             )
-            samples.push(yValues)
+
+        await page.getByTestId('play').click()
+        await page.waitForTimeout(180)
+        const yAtStop = await readYValues()
+        await page.getByTestId('stop').click()
+
+        const samples: number[][] = []
+        for (let sample = 0; sample < 10; sample += 1) {
+            await page.waitForTimeout(120)
+            samples.push(await readYValues())
         }
 
         for (const yValues of samples) {
-            for (const y of yValues) {
-                expect(y).toBeGreaterThanOrEqual(-8)
+            for (const [index, y] of yValues.entries()) {
+                expect(y - yAtStop[index]).toBeGreaterThanOrEqual(-16)
             }
         }
 

--- a/e2e/variants/stagger-interrupt.test.ts
+++ b/e2e/variants/stagger-interrupt.test.ts
@@ -22,18 +22,24 @@ test.describe('variants/stagger-interrupt', () => {
             )
 
         await page.getByTestId('play').click()
+        // Let the forward stagger begin, but stop before all delayed children
+        // have started their play animation.
         await page.waitForTimeout(180)
         const yAtStop = await readYValues()
         await page.getByTestId('stop').click()
 
         const samples: number[][] = []
         for (let sample = 0; sample < 10; sample += 1) {
+            // Sample far enough apart to catch delayed children that would pop
+            // upward after stop, while still watching the spring settle.
             await page.waitForTimeout(120)
             samples.push(await readYValues())
         }
 
         for (const yValues of samples) {
             for (const [index, y] of yValues.entries()) {
+                // Allow harmless spring wobble, but fail if a cell starts a
+                // fresh upward play motion after the stop command.
                 expect(y - yAtStop[index]).toBeGreaterThanOrEqual(-16)
             }
         }

--- a/src/lib/utils/style.spec.ts
+++ b/src/lib/utils/style.spec.ts
@@ -1,4 +1,4 @@
-import { motionValue } from 'motion-dom'
+import { frameData, frameSteps, motionValue } from 'motion-dom'
 import { describe, expect, it, vi } from 'vitest'
 import {
     applyMotionStyleEffect,
@@ -7,6 +7,8 @@ import {
     mergeInlineStyles,
     serializeMotionStyle
 } from './style.js'
+
+const flushRenderFrame = () => frameSteps.render.process(frameData)
 
 describe('mergeInlineStyles', () => {
     it('returns existing style when no initial/animate provided', () => {
@@ -383,7 +385,7 @@ describe('applyMotionStyleEffect', () => {
         cleanup?.()
     })
 
-    it('reapplies templated MotionValue styles after later subscribers write generated transforms', async () => {
+    it('reapplies templated MotionValue styles on the Motion render frame', () => {
         const el = document.createElement('div')
         const x = motionValue(12)
 
@@ -397,7 +399,7 @@ describe('applyMotionStyleEffect', () => {
         })
 
         x.set(36)
-        await Promise.resolve()
+        flushRenderFrame()
 
         expect(el.getAttribute('style')).toContain('translateY(36px) translateX(36px)')
 
@@ -409,48 +411,49 @@ describe('applyMotionStyleEffect', () => {
         const el = document.createElement('div')
         const x = motionValue(12)
         const y = motionValue(4)
-        const queuedMicrotasks: VoidFunction[] = []
-        const queuedFrames: FrameRequestCallback[] = []
-        const queueMicrotaskSpy = vi
-            .spyOn(globalThis, 'queueMicrotask')
-            .mockImplementation((callback) => {
-                queuedMicrotasks.push(callback)
-            })
-        const requestAnimationFrameSpy = vi
-            .spyOn(globalThis, 'requestAnimationFrame')
-            .mockImplementation((callback) => {
-                queuedFrames.push(callback)
-                return queuedFrames.length
-            })
+        const transformTemplate = vi.fn(
+            ({ x: latestX }, generated) => `translateY(${latestX}) ${generated}`
+        )
 
-        try {
-            const cleanup = applyMotionStyleEffect(
-                el,
-                { x, y },
-                ({ x: latestX }, generated) => `translateY(${latestX}) ${generated}`
-            )
+        const cleanup = applyMotionStyleEffect(el, { x, y }, transformTemplate)
 
-            expect(queueMicrotaskSpy).toHaveBeenCalledTimes(1)
-            expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1)
+        expect(transformTemplate).toHaveBeenCalledTimes(1)
 
-            x.set(24)
-            y.set(18)
+        x.set(24)
+        y.set(18)
 
-            expect(queueMicrotaskSpy).toHaveBeenCalledTimes(1)
-            expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1)
+        expect(transformTemplate).toHaveBeenCalledTimes(3)
 
-            queuedMicrotasks.shift()?.()
-            queuedFrames.shift()?.(performance.now())
-            x.set(36)
+        flushRenderFrame()
 
-            expect(queueMicrotaskSpy).toHaveBeenCalledTimes(2)
-            expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(2)
+        expect(transformTemplate).toHaveBeenCalledTimes(4)
 
-            cleanup?.()
-        } finally {
-            queueMicrotaskSpy.mockRestore()
-            requestAnimationFrameSpy.mockRestore()
-        }
+        cleanup?.()
+    })
+
+    it('cancels deferred frame writes after cleanup', () => {
+        const el = document.createElement('div')
+        const x = motionValue(12)
+
+        const cleanup = applyMotionStyleEffect(
+            el,
+            { x },
+            ({ x: latestX }, generated) => `translateY(${latestX}) ${generated}`
+        )
+        const generatedCleanup = x.on('change', (latestX) => {
+            el.setAttribute('style', `transform: translateX(${latestX}px)`)
+        })
+
+        x.set(36)
+
+        expect(el.getAttribute('style')).toBe('transform: translateX(36px)')
+
+        cleanup?.()
+        flushRenderFrame()
+
+        expect(el.getAttribute('style')).toBe('transform: translateX(36px)')
+
+        generatedCleanup()
     })
 })
 

--- a/src/lib/utils/style.spec.ts
+++ b/src/lib/utils/style.spec.ts
@@ -440,6 +440,9 @@ describe('applyMotionStyleEffect', () => {
             { x },
             ({ x: latestX }, generated) => `translateY(${latestX}) ${generated}`
         )
+        if (!cleanup) {
+            throw new Error('Expected applyMotionStyleEffect to return a cleanup')
+        }
         const generatedCleanup = x.on('change', (latestX) => {
             el.setAttribute('style', `transform: translateX(${latestX}px)`)
         })
@@ -448,7 +451,7 @@ describe('applyMotionStyleEffect', () => {
 
         expect(el.getAttribute('style')).toBe('transform: translateX(36px)')
 
-        cleanup?.()
+        cleanup()
         flushRenderFrame()
 
         expect(el.getAttribute('style')).toBe('transform: translateX(36px)')

--- a/src/lib/utils/style.ts
+++ b/src/lib/utils/style.ts
@@ -1,5 +1,7 @@
 import {
     buildHTMLStyles,
+    cancelFrame,
+    frame,
     isMotionValue,
     type AnyResolvedKeyframe,
     type HTMLRenderState,
@@ -222,25 +224,17 @@ export const applyMotionStyleEffect = (
         )
     }
 
-    let microtaskQueued = false
-    let rafQueued = false
+    let disposed = false
+
+    const render = () => {
+        if (disposed) return
+        apply()
+    }
 
     const applyAfterOtherSubscribers = () => {
+        if (disposed) return
         apply()
-        if (!microtaskQueued) {
-            microtaskQueued = true
-            queueMicrotask(() => {
-                microtaskQueued = false
-                apply()
-            })
-        }
-        if (typeof requestAnimationFrame === 'function' && !rafQueued) {
-            rafQueued = true
-            requestAnimationFrame(() => {
-                rafQueued = false
-                apply()
-            })
-        }
+        frame.render(render)
     }
 
     applyAfterOtherSubscribers()
@@ -249,7 +243,9 @@ export const applyMotionStyleEffect = (
         value.on('change', applyAfterOtherSubscribers)
     )
     return () => {
+        disposed = true
         for (const cleanup of cleanups) cleanup()
+        cancelFrame(render)
     }
 }
 


### PR DESCRIPTION
## Summary
- route templated MotionValue style repairs through Motion's `frame.render` scheduler
- cancel pending deferred style work during teardown so stale writes do not land after cleanup
- stabilize the stagger interrupt e2e test around the delayed-pop behavior and document the timing assumptions

Fixes #404

## Verification
- `pnpm vitest run src/lib/utils/style.spec.ts`
- `pnpm run check`
- `pnpm test`
- `pnpm test:e2e -- e2e/variants/stagger-interrupt.test.ts`
- `pnpm test:e2e`
- CodeRabbit review issue addressed

## Commits
- [`95a24f5`](https://github.com/humanspeak/svelte-motion/commit/95a24f5d66e1d36f16693eecff63760506a31158) fix: cancel deferred templated style writes
- [`02a4c9a`](https://github.com/humanspeak/svelte-motion/commit/02a4c9a550a85ed3b55780816666135de9cf9c93) test: stabilize stagger interrupt assertion
- [`c6edbf8`](https://github.com/humanspeak/svelte-motion/commit/c6edbf87d22c33e02290e997923d55e119eb8c26) test: document stagger interrupt timing
