### PR TITLE
feat(docs): add posthog analytics integration

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -55,3 +55,5 @@ static/llms-full.txt
 .dev.vars*
 !.dev.vars.example
 .env*
+.env.local
+.claude/

--- a/docs/package.json
+++ b/docs/package.json
@@ -31,6 +31,8 @@
         "@lucide/svelte": "^1.17.0",
         "bits-ui": "^2.18.1",
         "flubber": "^0.4.2",
+        "posthog-js": "^1.250.0",
+        "posthog-node": "^4.17.0",
         "runed": "^0.37.1"
     },
     "devDependencies": {

--- a/docs/posthog-setup-report.md
+++ b/docs/posthog-setup-report.md
@@ -1,0 +1,49 @@
+# PostHog post-wizard report
+
+The wizard has completed a deep integration of PostHog into the Svelte Motion docs site. The core foundation (client init, server singleton, reverse proxy, error tracking, and the major conversion events) was already in place. This run extended coverage to two additional discovery pages and rebuilt the analytics dashboard with fresh insights.
+
+- **Client initialization** (`src/hooks.client.ts`): PostHog is initialized via the SvelteKit `init` hook with a `/ingest` proxy host and exception capture enabled. `handleError` forwards all unhandled client-side errors to PostHog.
+- **Server-side singleton** (`src/lib/server/posthog.ts`): A `getPostHogClient()` singleton provides a `posthog-node` instance for server routes, configured with `flushAt: 1` / `flushInterval: 0` for immediate flushing.
+- **Reverse proxy + server error capture** (`src/hooks.server.ts`): A `handlePostHogProxy` handle routes `/ingest/*` (and `/ingest/static/*`, `/ingest/array/*`) to the PostHog ingestion servers, bypassing ad-blockers. `handleError` captures server-side errors with status and message.
+- **Session replay config** (`svelte.config.js`): `paths: { relative: false }` is set, required for PostHog session replay to work correctly under SSR.
+- **Environment variables** written to `.env.local`: `PUBLIC_POSTHOG_PROJECT_TOKEN`, `PUBLIC_POSTHOG_HOST`.
+- **New events added this run**: `examples_index_viewed` (examples index page) and `svelte_animations_viewed` (pattern gallery page).
+
+| Event                           | Description                                                                     | File                                                |
+| ------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `get_started_clicked`           | User clicks the primary "get started" CTA on the hero section                   | `src/routes/+page.svelte`                           |
+| `install_command_copied`        | User copies the npm install command from the homepage hero or footer            | `src/routes/+page.svelte`                           |
+| `example_tile_clicked`          | User clicks a featured example tile on the homepage grid                        | `src/routes/+page.svelte`                           |
+| `compare_library_clicked`       | User clicks a competitor library link in the comparison table                   | `src/routes/+page.svelte`                           |
+| `llms_txt_opened`               | User clicks an AI-ready docs link (llms.txt, llms-full.txt, or per-page mirror) | `src/routes/+page.svelte`                           |
+| `compare_index_viewed`          | User views the compare index — signals competitive research intent              | `src/routes/compare/+page.svelte`                   |
+| `compare_page_viewed`           | User views a library comparison page                                            | `src/routes/compare/[slug]/+page.svelte`            |
+| `doc_page_viewed`               | User navigates to a documentation page — top of the adoption funnel             | `src/routes/docs/+layout.svelte`                    |
+| `examples_index_viewed`         | User views the full examples index page                                         | `src/routes/examples/+page.svelte`                  |
+| `svelte_animations_viewed`      | User views the Svelte Animations pattern gallery page                           | `src/routes/svelte-animations/+page.svelte`         |
+| `component_source_opened`       | User opens the Component Source dialog to view a component's code               | `src/lib/components/general/ComponentSource.svelte` |
+| `component_source_copied`       | User copies source code from the Component Source dialog                        | `src/lib/components/general/ComponentSource.svelte` |
+| `registry_component_downloaded` | Server: tooling fetches a component JSON from the registry endpoint             | `src/routes/r/[slug].json/+server.ts`               |
+| `server_error`                  | Server: unhandled server-side error captured with status and message            | `src/hooks.server.ts`                               |
+
+## Next steps
+
+We've built some insights and a dashboard for you to keep an eye on user behavior, based on the events we just instrumented:
+
+- **Dashboard**: [Analytics basics (wizard)](https://us.posthog.com/project/477595/dashboard/1735755)
+- [Install command copies (last 30 days)](https://us.posthog.com/project/477595/insights/2DqWjUy3) — bold-number of total copy actions, the primary install conversion signal
+- [Registry component downloads over time](https://us.posthog.com/project/477595/insights/yEPGeIUX) — server-side line chart of CLI/API component fetches
+- [Docs page views by unique visitors](https://us.posthog.com/project/477595/insights/lZnGrTP3) — daily unique visitors reading documentation
+- [Get started → Docs conversion](https://us.posthog.com/project/477595/insights/ivG8gJEn) — CTA clicks vs docs visits, side-by-side
+- [Example & source exploration](https://us.posthog.com/project/477595/insights/GFsf6vka) — example tile clicks, source opens, and source copies on one chart
+
+## Verify before merging
+
+- [ ] Run a full production build (`pnpm run build` from the docs workspace) and fix any lint or type errors introduced by the generated code.
+- [ ] Run the test suite — call sites that were rewritten or instrumented may need updated mocks or fixtures.
+- [ ] Add `PUBLIC_POSTHOG_PROJECT_TOKEN` and `PUBLIC_POSTHOG_HOST` to `.env.example` and any monorepo bootstrap scripts so collaborators know what to set.
+- [ ] Wire source-map upload (`posthog-cli sourcemap` or Wrangler's upload step) into CI so production stack traces de-minify in PostHog error tracking.
+
+### Agent skill
+
+We've left an agent skill folder in your project at `.claude/skills/integration-sveltekit/`. You can use this context for further agent development when using Claude Code. This will help ensure the model provides the most up-to-date approaches for integrating PostHog.

--- a/docs/src/hooks.client.ts
+++ b/docs/src/hooks.client.ts
@@ -1,1 +1,21 @@
-// Client hooks (no-op)
+import { PUBLIC_POSTHOG_PROJECT_TOKEN } from '$env/static/public'
+import type { HandleClientError } from '@sveltejs/kit'
+import posthog from 'posthog-js'
+
+export async function init() {
+    posthog.init(PUBLIC_POSTHOG_PROJECT_TOKEN, {
+        ['api_host']: 'https://t.svelte.page',
+        ['ui_host']: 'https://us.posthog.com',
+        defaults: '2026-01-30',
+        ['capture_exceptions']: true
+    })
+}
+
+export const handleError: HandleClientError = async ({ error, status, message }) => {
+    posthog.captureException(error)
+
+    return {
+        message,
+        status
+    }
+}

--- a/docs/src/hooks.client.ts
+++ b/docs/src/hooks.client.ts
@@ -1,10 +1,14 @@
-import { PUBLIC_POSTHOG_PROJECT_TOKEN } from '$env/static/public'
+import { env } from '$env/dynamic/public'
 import type { HandleClientError } from '@sveltejs/kit'
 import posthog from 'posthog-js'
 
 export async function init() {
-    posthog.init(PUBLIC_POSTHOG_PROJECT_TOKEN, {
-        ['api_host']: 'https://t.svelte.page',
+    if (!env.PUBLIC_POSTHOG_PROJECT_TOKEN || !env.PUBLIC_POSTHOG_HOST) {
+        return
+    }
+
+    posthog.init(env.PUBLIC_POSTHOG_PROJECT_TOKEN, {
+        ['api_host']: env.PUBLIC_POSTHOG_HOST,
         ['ui_host']: 'https://us.posthog.com',
         defaults: '2026-01-30',
         ['capture_exceptions']: true

--- a/docs/src/hooks.server.ts
+++ b/docs/src/hooks.server.ts
@@ -1,6 +1,7 @@
 import { paraglideMiddleware } from '$lib/paraglide/server'
+import { getPostHogClient } from '$lib/server/posthog'
 import { createSecurityHeadersHandle } from '@humanspeak/docs-kit/hooks'
-import type { Handle } from '@sveltejs/kit'
+import type { Handle, HandleServerError } from '@sveltejs/kit'
 import { sequence } from '@sveltejs/kit/hooks'
 
 const handleParaglide: Handle = ({ event, resolve }) =>
@@ -12,4 +13,64 @@ const handleParaglide: Handle = ({ event, resolve }) =>
         })
     })
 
-export const handle: Handle = sequence(handleParaglide, createSecurityHeadersHandle())
+const handlePostHogProxy: Handle = async ({ event, resolve }) => {
+    const { pathname } = event.url
+
+    if (pathname.startsWith('/ingest')) {
+        const useAssetHost =
+            pathname.startsWith('/ingest/static/') || pathname.startsWith('/ingest/array/')
+        const hostname = useAssetHost ? 'us-assets.i.posthog.com' : 'us.i.posthog.com'
+
+        const url = new URL(event.request.url)
+        url.protocol = 'https:'
+        url.hostname = hostname
+        url.port = '443'
+        url.pathname = pathname.replace(/^\/ingest/, '')
+
+        const headers = new Headers(event.request.headers)
+        headers.set('host', hostname)
+        headers.set('accept-encoding', '')
+
+        const clientIp = event.request.headers.get('x-forwarded-for') || event.getClientAddress()
+        if (clientIp) {
+            headers.set('x-forwarded-for', clientIp)
+        }
+
+        const response = await fetch(url.toString(), {
+            method: event.request.method,
+            headers,
+            body: event.request.body,
+            // @ts-expect-error - duplex is required for streaming request bodies
+            duplex: 'half'
+        })
+
+        return response
+    }
+
+    return resolve(event)
+}
+
+export const handle: Handle = sequence(
+    handlePostHogProxy,
+    handleParaglide,
+    createSecurityHeadersHandle()
+)
+
+export const handleError: HandleServerError = async ({ error, status, message }) => {
+    const posthog = getPostHogClient()
+
+    posthog.capture({
+        distinctId: 'server',
+        event: 'server_error',
+        properties: {
+            error: error instanceof Error ? error.message : String(error),
+            status,
+            message
+        }
+    })
+
+    return {
+        message,
+        status
+    }
+}

--- a/docs/src/lib/components/general/ComponentSource.svelte
+++ b/docs/src/lib/components/general/ComponentSource.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { Dialog } from 'bits-ui'
     import { AnimatePresence, motion } from '@humanspeak/svelte-motion'
+    import posthog from 'posthog-js'
     import { registryItems } from '$lib/generated/registry-data'
     import {
         Code,
@@ -73,9 +74,14 @@
     let highlightedFiles = $state<Array<{ light: string; dark: string }> | null>(null)
     let highlighterLoaded = $state(false)
 
-    // Lazy-load shiki when dialog opens
+    // Lazy-load shiki when dialog opens; track first open
     $effect(() => {
         if (open && !highlighterLoaded) {
+            posthog.capture('component_source_opened', {
+                component: name,
+                slug,
+                ['file_count']: files.length
+            })
             highlighterLoaded = true
             ;(async () => {
                 const [{ createHighlighter }, { createJavaScriptRegexEngine }] = await Promise.all([
@@ -107,6 +113,11 @@
         navigator.clipboard.writeText(content)
         copied = true
         setTimeout(() => (copied = false), 2000)
+        posthog.capture('component_source_copied', {
+            component: name,
+            slug,
+            file: files[activeFileIndex]?.target ?? ''
+        })
     }
 </script>
 

--- a/docs/src/lib/server/posthog.ts
+++ b/docs/src/lib/server/posthog.ts
@@ -1,0 +1,21 @@
+import { PUBLIC_POSTHOG_HOST, PUBLIC_POSTHOG_PROJECT_TOKEN } from '$env/static/public'
+import { PostHog } from 'posthog-node'
+
+let posthogClient: PostHog | null = null
+
+export function getPostHogClient() {
+    if (!posthogClient) {
+        posthogClient = new PostHog(PUBLIC_POSTHOG_PROJECT_TOKEN, {
+            host: PUBLIC_POSTHOG_HOST,
+            flushAt: 1,
+            flushInterval: 0
+        })
+    }
+    return posthogClient
+}
+
+export async function shutdownPostHog() {
+    if (posthogClient) {
+        await posthogClient.shutdown()
+    }
+}

--- a/docs/src/lib/server/posthog.ts
+++ b/docs/src/lib/server/posthog.ts
@@ -1,12 +1,12 @@
-import { PUBLIC_POSTHOG_HOST, PUBLIC_POSTHOG_PROJECT_TOKEN } from '$env/static/public'
+import { env } from '$env/dynamic/public'
 import { PostHog } from 'posthog-node'
 
 let posthogClient: PostHog | null = null
 
 export function getPostHogClient() {
     if (!posthogClient) {
-        posthogClient = new PostHog(PUBLIC_POSTHOG_PROJECT_TOKEN, {
-            host: PUBLIC_POSTHOG_HOST,
+        posthogClient = new PostHog(env.PUBLIC_POSTHOG_PROJECT_TOKEN, {
+            host: env.PUBLIC_POSTHOG_HOST,
             flushAt: 1,
             flushInterval: 0
         })

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -12,6 +12,7 @@
     import githubStats from '$lib/github-stats.json'
     import '@fontsource-variable/inter/index.css'
     import '@fontsource-variable/jetbrains-mono/index.css'
+    import posthog from 'posthog-js'
     import type { PageData } from './$types'
 
     const { data }: { data: PageData } = $props()
@@ -294,6 +295,15 @@
         }
     ]
 
+    // ── PostHog event handlers ───────────────────────────────────────
+    const captureGetStarted = () => posthog.capture('get_started_clicked', { location: 'hero' })
+    const captureExampleTile = (slug: string, title: string, index: number) =>
+        posthog.capture('example_tile_clicked', { slug, title, index })
+    const captureCompareLibrary = (library: string, libraryName: string) =>
+        posthog.capture('compare_library_clicked', { library, ['library_name']: libraryName })
+    const captureAILink = (type: string, path: string) =>
+        posthog.capture('llms_txt_opened', { type, path })
+
     // ── Copy install command ─────────────────────────────────────────
     const installCmd = $derived(`npm i ${PKG_NAME}`)
     let copied = $state(false)
@@ -303,6 +313,7 @@
             await navigator.clipboard.writeText(installCmd)
             copied = true
             setTimeout(() => (copied = false), 1500)
+            posthog.capture('install_command_copied', { package: PKG_NAME, version: PKG_VERSION })
         } catch {
             /* clipboard blocked — fail quiet */
         }
@@ -433,7 +444,7 @@
                     <code>svelte/transition</code> for declarative gestures, layout, and exit animations.
                 </p>
                 <div class="cta-row">
-                    <a class="pri" href="/docs">get started ↗</a>
+                    <a class="pri" href="/docs" onclick={captureGetStarted}>get started ↗</a>
                     <a href="/docs/animate-presence">api reference</a>
                     <a href="/examples">examples</a>
                     <MotionButton
@@ -676,7 +687,11 @@
                             <tr class={i === 0 ? 'us-row' : ''}>
                                 <td class={i === 0 ? 'us' : ''}>
                                     {#if row.slug}
-                                        <a class="comp-link" href="/compare/{row.slug}"
+                                        <a
+                                            class="comp-link"
+                                            href="/compare/{row.slug}"
+                                            onclick={() =>
+                                                captureCompareLibrary(row.slug!, row.name)}
                                             >{row.name}</a
                                         >
                                     {:else}
@@ -715,7 +730,13 @@
                     <span class="ai-meta">/llmstxt.org</span>
                 </div>
                 <div class="ai-grid">
-                    <a class="ai-cell" href="/llms.txt" target="_blank" rel="noopener">
+                    <a
+                        class="ai-cell"
+                        href="/llms.txt"
+                        target="_blank"
+                        rel="noopener"
+                        onclick={() => captureAILink('index', '/llms.txt')}
+                    >
                         <div class="ai-cell-k">01 · index</div>
                         <h3>
                             <code>/llms.txt</code>
@@ -726,7 +747,13 @@
                         </p>
                         <div class="ai-cell-foot">~3 kB · open ↗</div>
                     </a>
-                    <a class="ai-cell" href="/llms-full.txt" target="_blank" rel="noopener">
+                    <a
+                        class="ai-cell"
+                        href="/llms-full.txt"
+                        target="_blank"
+                        rel="noopener"
+                        onclick={() => captureAILink('full', '/llms-full.txt')}
+                    >
                         <div class="ai-cell-k">02 · full</div>
                         <h3>
                             <code>/llms-full.txt</code>
@@ -737,7 +764,13 @@
                         </p>
                         <div class="ai-cell-foot">~16 kB · open ↗</div>
                     </a>
-                    <a class="ai-cell" href="/docs" target="_blank" rel="noopener">
+                    <a
+                        class="ai-cell"
+                        href="/docs"
+                        target="_blank"
+                        rel="noopener"
+                        onclick={() => captureAILink('per-page', '/docs')}
+                    >
                         <div class="ai-cell-k">03 · per-page mirrors</div>
                         <h3>
                             <code>/docs/&lt;slug&gt;.md</code>
@@ -773,7 +806,11 @@
             <div>
                 <div class="grid">
                     {#each featuredExamples as ex, i (ex.slug)}
-                        <a class="cell" href="/examples/{ex.slug}">
+                        <a
+                            class="cell"
+                            href="/examples/{ex.slug}"
+                            onclick={() => captureExampleTile(ex.slug, ex.title, i)}
+                        >
                             <div class="id">
                                 № {String(i + 1).padStart(2, '0')} / {String(
                                     featuredExamples.length

--- a/docs/src/routes/compare/+page.svelte
+++ b/docs/src/routes/compare/+page.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
     import { CompareIndexV2 } from '@humanspeak/docs-kit'
     import { competitors, ours } from '$lib/compare-data'
+    import posthog from 'posthog-js'
+    import { browser } from '$app/environment'
+
+    $effect(() => {
+        if (browser) {
+            posthog.capture('compare_index_viewed')
+        }
+    })
 </script>
 
 <CompareIndexV2

--- a/docs/src/routes/compare/[slug]/+page.svelte
+++ b/docs/src/routes/compare/[slug]/+page.svelte
@@ -1,9 +1,17 @@
 <script lang="ts">
     import { ComparisonPageV2, type CompareSlugLoadData } from '@humanspeak/docs-kit'
     import { competitors, ours } from '$lib/compare-data'
+    import posthog from 'posthog-js'
+    import { browser } from '$app/environment'
 
     const { data }: { data: CompareSlugLoadData } = $props()
     const others = $derived(competitors.filter((c) => c.slug !== data.competitor.slug))
+
+    $effect(() => {
+        if (browser) {
+            posthog.capture('compare_page_viewed', { competitor: data.competitor.slug })
+        }
+    })
 </script>
 
 <ComparisonPageV2 competitor={data.competitor} {others} {ours} getStartedHref="/docs" />

--- a/docs/src/routes/docs/+layout.svelte
+++ b/docs/src/routes/docs/+layout.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import { page } from '$app/state'
     import { afterNavigate } from '$app/navigation'
+    import { browser } from '$app/environment'
+    import posthog from 'posthog-js'
     import {
         HeaderV2,
         FooterV2,
@@ -130,6 +132,13 @@
 
     afterNavigate(() => {
         requestAnimationFrame(refreshHeadings)
+        if (browser) {
+            posthog.capture('doc_page_viewed', {
+                pathname: page.url.pathname,
+                slug: page.url.pathname.replace(/^\/docs\/?/, '') || 'index',
+                title: (page.data?.title as string | undefined) ?? undefined
+            })
+        }
     })
 </script>
 

--- a/docs/src/routes/examples/+page.svelte
+++ b/docs/src/routes/examples/+page.svelte
@@ -3,7 +3,13 @@
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import sitemapManifest from '$lib/sitemap-manifest.json'
+    import posthog from 'posthog-js'
+    import { browser } from '$app/environment'
     import type { PageData } from './$types'
+
+    $effect(() => {
+        if (browser) posthog.capture('examples_index_viewed')
+    })
 
     type ExampleData = {
         title: string

--- a/docs/src/routes/r/[slug].json/+server.ts
+++ b/docs/src/routes/r/[slug].json/+server.ts
@@ -1,8 +1,9 @@
 import { registryIndex, registryItems } from '$lib/generated/registry-data'
+import { getPostHogClient } from '$lib/server/posthog'
 import { error, json } from '@sveltejs/kit'
 import type { RequestHandler } from './$types'
 
-export const GET: RequestHandler = async ({ params, platform }) => {
+export const GET: RequestHandler = async ({ params, platform, request }) => {
     const slug = params.slug
 
     // Registry index — serve without tracking
@@ -12,6 +13,24 @@ export const GET: RequestHandler = async ({ params, platform }) => {
 
     const item = registryItems[slug]
     if (!item) throw error(404, `Registry item "${slug}" not found`)
+
+    const distinctId = request.headers.get('x-forwarded-for') || 'anonymous'
+
+    // Track download in PostHog; wrap in waitUntil on Cloudflare so the flush
+    // completes after the response is returned without blocking it.
+    const phFlush = (async () => {
+        const posthog = getPostHogClient()
+        posthog.capture({
+            distinctId,
+            event: 'registry_component_downloaded',
+            properties: {
+                component: slug,
+                ['user_agent']: request.headers.get('user-agent') ?? undefined
+            }
+        })
+        await posthog.flush()
+    })()
+    platform?.ctx?.waitUntil(phFlush)
 
     // Increment KV counter (fire-and-forget via waitUntil)
     const kv = platform?.env?.REGISTRY_DOWNLOADS

--- a/docs/src/routes/svelte-animations/+page.svelte
+++ b/docs/src/routes/svelte-animations/+page.svelte
@@ -5,8 +5,14 @@
     import rootPkg from '../../../../package.json'
     import '@fontsource-variable/inter/index.css'
     import '@fontsource-variable/jetbrains-mono/index.css'
+    import posthog from 'posthog-js'
+    import { browser } from '$app/environment'
 
     const PKG_VERSION = rootPkg.version
+
+    $effect(() => {
+        if (browser) posthog.capture('svelte_animations_viewed')
+    })
 
     const breadcrumbs = getBreadcrumbContext()
     if (breadcrumbs) breadcrumbs.breadcrumbs = [{ title: 'Svelte Animations' }]

--- a/docs/svelte.config.js
+++ b/docs/svelte.config.js
@@ -48,6 +48,9 @@ const config = {
         // If your environment is not supported, or you settled on a specific environment, switch out the adapter.
         // See https://svelte.dev/docs/kit/adapters for more information about adapters.
         adapter: adapter(),
+        paths: {
+            relative: false
+        },
         alias: {
             $msgs: 'src/lib/paraglide/messages.js'
         },
@@ -59,13 +62,21 @@ const config = {
                     'self',
                     'https://*.ahrefs.com',
                     'https://*.posthog.com',
+                    'https://t.svelte.page',
                     'unsafe-inline'
                 ],
                 'style-src': ['self', 'unsafe-inline'],
                 'img-src': ['self', 'data:', 'https:'],
                 'font-src': ['self', 'data:'],
                 'worker-src': ['self', 'blob:'],
-                'connect-src': ['self', 'https:'],
+                'connect-src': [
+                    'self',
+                    'https://analytics.ahrefs.com',
+                    'https://*.posthog.com',
+                    'https://t.svelte.page',
+                    'ws://localhost:*',
+                    'ws://127.0.0.1:*'
+                ],
                 'frame-ancestors': ['none'],
                 'form-action': ['self'],
                 'base-uri': ['self'],

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -37,6 +37,9 @@
     "vars": {
         "PUBLIC_SITE_URL": "https://motion.svelte.page",
         "PUBLIC_ENVIRONMENT": "production",
+        // checkov:skip=CKV_SECRET_6: PostHog project tokens are public client-side SDK identifiers.
+        "PUBLIC_POSTHOG_PROJECT_TOKEN": "phc_urqpUgNEfk5aMzbZYTtHvYvyMtD4feCik6rqGaZQzdXA",
+        "PUBLIC_POSTHOG_HOST": "https://t.svelte.page",
         "ENVIRONMENT": "production",
         "NODE_ENV": "production"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,12 @@ importers:
       flubber:
         specifier: ^0.4.2
         version: 0.4.2
+      posthog-js:
+        specifier: ^1.250.0
+        version: 1.388.1
+      posthog-node:
+        specifier: ^4.17.0
+        version: 4.18.0
       runed:
         specifier: ^0.37.1
         version: 0.37.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))
@@ -1221,6 +1227,12 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@posthog/core@1.34.0':
+    resolution: {integrity: sha512-hf+COAWSAG1UQHluPsfAOJDOR8tr8YY7cdf58ENGt20pEEWZ6sH3IbtvFDWkhp0ulSftA62x17w8R/f6IAwwEA==}
+
+  '@posthog/types@1.388.0':
+    resolution: {integrity: sha512-BQO7e9ESdjOyKsCnoPoeHtq78ologEkPiemibsUlaAWC/Gk538jdTqyd0E1oSAlXnQqEANwjMn/A26vF2jljeQ==}
+
   '@publint/pack@0.1.4':
     resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
     engines: {node: '>=18'}
@@ -1815,6 +1827,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -1901,9 +1917,15 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2020,6 +2042,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -2051,6 +2077,9 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2157,6 +2186,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -2200,6 +2233,9 @@ packages:
   domhandler@6.0.1:
     resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
     engines: {node: '>=20.19.0'}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@4.0.2:
     resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
@@ -2446,6 +2482,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+
   fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
 
@@ -2479,9 +2518,22 @@ packages:
   flubber@0.4.2:
     resolution: {integrity: sha512-79RkJe3rA4nvRCVc2uXjj7U/BAUq84TS3KHn6c0Hr9K64vhj83ZNLUziNx4pJoBumSPhOl5VjH+Z0uhi+eE8Uw==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
 
   framer-motion@12.40.0:
     resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
@@ -2636,6 +2688,10 @@ packages:
   htmlparser2@12.0.0:
     resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
     engines: {node: '>=20.19.0'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -3048,6 +3104,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -3320,6 +3384,16 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.388.1:
+    resolution: {integrity: sha512-3WaTv0LPWRx3hT3frBd4Z7fMZcqPS4St0otB+AGO6ixOFc2KCTGSIJwujtArC2rraWS3UPlAYVf7QaA0Fgy+MA==}
+
+  posthog-node@4.18.0:
+    resolution: {integrity: sha512-XROs1h+DNatgKh/AlIlCtDxWzwrKdYDb2mOs58n4yN8BkGN9ewqeQwG5ApS4/IzwCb7HPttUkOVulkYatd2PIw==}
+    engines: {node: '>=15.0.0'}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -3426,6 +3500,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   publint@0.3.21:
     resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
     engines: {node: '>=18'}
@@ -3437,6 +3515,9 @@ packages:
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -4142,6 +4223,9 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -5040,6 +5124,12 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@posthog/core@1.34.0':
+    dependencies:
+      '@posthog/types': 1.388.0
+
+  '@posthog/types@1.388.0': {}
+
   '@publint/pack@0.1.4': {}
 
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
@@ -5598,6 +5688,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -5700,9 +5796,21 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  asynckit@0.4.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axios@1.18.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -5824,6 +5932,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
@@ -5844,6 +5956,8 @@ snapshots:
   cookie@0.6.0: {}
 
   cookie@1.1.1: {}
+
+  core-js@3.49.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5935,6 +6049,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  delayed-stream@1.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
@@ -5970,6 +6086,10 @@ snapshots:
   domhandler@6.0.1:
     dependencies:
       domelementtype: 3.0.0
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@4.0.2:
     dependencies:
@@ -6343,6 +6463,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fflate@0.4.8: {}
+
   fflate@0.7.4: {}
 
   file-entry-cache@8.0.0:
@@ -6383,9 +6505,19 @@ snapshots:
       svgpath: 2.6.0
       topojson-client: 3.1.0
 
+  follow-redirects@1.16.0: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
 
   framer-motion@12.40.0:
     dependencies:
@@ -6546,6 +6678,13 @@ snapshots:
       domhandler: 6.0.1
       domutils: 4.0.2
       entities: 8.0.0
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-id@4.1.3: {}
 
@@ -6935,6 +7074,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   min-indent@1.0.1: {}
 
   mini-svg-data-uri@1.4.4: {}
@@ -7178,6 +7323,26 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.388.1:
+    dependencies:
+      '@posthog/core': 1.34.0
+      '@posthog/types': 1.388.0
+      core-js: 3.49.0
+      dompurify: 3.4.11
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+
+  posthog-node@4.18.0:
+    dependencies:
+      axios: 1.18.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  preact@10.29.2: {}
+
   prelude-ls@1.2.1: {}
 
   prettier-plugin-organize-imports@4.3.0(prettier@3.8.3)(typescript@6.0.3):
@@ -7217,6 +7382,8 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   publint@0.3.21:
     dependencies:
       '@publint/pack': 0.1.4
@@ -7227,6 +7394,8 @@ snapshots:
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -8004,6 +8173,8 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  web-vitals@5.3.0: {}
 
   webidl-conversions@8.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
     - docs
 allowBuilds:
     '@humanspeak/docs-kit': true
+    core-js: true
     esbuild: true
     sharp: true
     workerd: true


### PR DESCRIPTION
## Summary

Adds PostHog analytics to the Svelte Motion docs site so homepage, docs, comparison, examples, source-copy, and registry-download behavior can be measured in production. The integration uses the `t.svelte.page` proxy host and includes deployment/CSP configuration for the Cloudflare docs worker.

## Changes

✨ New features
- Initialize PostHog in SvelteKit client hooks with exception capture enabled.
- Add a server-side PostHog singleton and capture server errors plus registry component downloads.
- Track key docs conversion and discovery events, including install copies, get-started clicks, docs page views, examples/compare views, source opens/copies, and AI docs link opens.

🔒 Security and deployment
- Configure CSP to explicitly allow `https://t.svelte.page`, PostHog, Ahrefs, and local dev websocket connections.
- Add Wrangler public PostHog vars for the production docs worker, with a Checkov skip noting that the PostHog project token is a public client SDK identifier.
- Keep generated wizard context and local env files ignored.

📦 Dependency changes
- Add `posthog-js` and `posthog-node` to the docs package and lockfile.
- Approve `core-js` build scripts required by the PostHog client dependency chain.

📚 Documentation
- Add the PostHog setup report documenting captured events and follow-up verification steps.

## Commits

- [`0c0af5e`](https://github.com/humanspeak/svelte-motion/commit/0c0af5e0258047de2bc3f47ba417d0051eca8db7) feat(docs): add posthog analytics integration
