### PR TITLE
feat(layout): add layoutDependency prop to gate FLIP measurement

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
     sources:
         - id: trunk
-          ref: v1.10.0
+          ref: v1.10.2
           uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -52,21 +52,21 @@ lint:
               - svelte
               - javascript
     enabled:
-        - grype@0.112.0
-        - sort-package-json@3.6.1
+        - grype@0.114.0
+        - sort-package-json@4.0.0
         - actionlint@1.7.12
-        - checkov@3.2.529
-        - eslint@10.4.0
+        - checkov@3.3.2
+        - eslint@10.5.0
         - git-diff-check
-        - markdownlint@0.48.0
-        - osv-scanner@2.3.8
+        - markdownlint@0.49.0
+        - osv-scanner@2.4.0
         - oxipng@10.1.1
-        - prettier@3.8.3
+        - prettier@3.8.4
         - shellcheck@0.11.0
         - shfmt@3.6.0
         - svgo@4.0.1
         - taplo@0.10.0
-        - trufflehog@3.95.3
+        - trufflehog@3.95.6
         - yamllint@1.38.0
 actions:
     disabled:

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -55,6 +55,7 @@ export const docsSections: NavSection[] = [
         icon: Layers,
         items: [
             { title: 'Layout Animations', href: '/docs/layout-animations', icon: Move },
+            { title: 'layoutDependency', href: '/docs/layout-dependency', icon: Gauge },
             { title: 'transformTemplate', href: '/docs/transform-template', icon: Code },
             { title: 'Variants', href: '/docs/variants', icon: Layers }
         ]

--- a/docs/src/lib/examples/layout-dependency/demos/Default.svelte
+++ b/docs/src/lib/examples/layout-dependency/demos/Default.svelte
@@ -1,0 +1,229 @@
+<script lang="ts">
+    import { Gauge, RotateCcw, Zap } from '@lucide/svelte'
+    import { motion } from '@humanspeak/svelte-motion'
+
+    // A high-frequency render driver: every tick recolors both boxes, forcing
+    // a re-render. Without `layoutDependency`, that re-renders the layout box
+    // AND re-measures it every single time.
+    let tick = $state(0)
+    let dep = $state(0)
+    let shifted = $state(false)
+    let defaultMeasures = $state(0)
+    let gatedMeasures = $state(0)
+    let auto = $state(false)
+
+    const hue = $derived(tick % 360)
+    const boxStyle = $derived(`background: hsl(${hue} 85% 62%)`)
+
+    function reflow() {
+        shifted = !shifted
+        tick += 1
+        dep += 1
+    }
+
+    function reset() {
+        defaultMeasures = 0
+        gatedMeasures = 0
+    }
+
+    $effect(() => {
+        if (!auto) return
+        const id = setInterval(() => (tick += 1), 90)
+        return () => clearInterval(id)
+    })
+</script>
+
+<!-- dk-strip: docs-kit positioning shell - stripped from the published code. -->
+<div class="dk-demo-shell">
+    <div class="toolbar" aria-label="layoutDependency controls">
+        <button type="button" class:active={auto} onclick={() => (auto = !auto)}>
+            <Zap size={15} />
+            {auto ? 'Stop renders' : 'Start renders'}
+        </button>
+        <button type="button" class="primary" onclick={reflow}>
+            <Gauge size={15} />
+            Reflow + bump dep
+        </button>
+        <button type="button" onclick={reset}>
+            <RotateCcw size={15} />
+            Reset counters
+        </button>
+    </div>
+
+    <div class="lanes" class:shifted>
+        <section class="lane">
+            <header>
+                <span>no gate</span>
+                <strong>re-measures every render</strong>
+            </header>
+            <p class="count" data-state={defaultMeasures > 0 ? 'busy' : 'idle'}>
+                {defaultMeasures} measures
+            </p>
+            <div class="track">
+                <motion.div
+                    class="box"
+                    layout
+                    style={boxStyle}
+                    transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
+                    onProjectionUpdate={() => (defaultMeasures += 1)}
+                >
+                    A
+                </motion.div>
+            </div>
+        </section>
+
+        <section class="lane gated">
+            <header>
+                <span>layoutDependency</span>
+                <strong>measures only on dep change</strong>
+            </header>
+            <p class="count" data-state={gatedMeasures > 0 ? 'busy' : 'idle'}>
+                {gatedMeasures} measures
+            </p>
+            <div class="track">
+                <motion.div
+                    class="box"
+                    layout
+                    layoutDependency={dep}
+                    style={boxStyle}
+                    transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
+                    onProjectionUpdate={() => (gatedMeasures += 1)}
+                >
+                    B
+                </motion.div>
+            </div>
+        </section>
+    </div>
+</div>
+
+<style>
+    .dk-demo-shell {
+        width: 100%;
+        height: clamp(520px, calc(100vh - 160px), 600px);
+        display: grid;
+        grid-template-rows: auto minmax(0, 1fr);
+        gap: 16px;
+        padding: 20px 26px;
+        background: #0d1518;
+        color: #eef6fb;
+    }
+
+    .toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 8px;
+    }
+
+    button {
+        height: 36px;
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        padding: 0 12px;
+        border: 1px solid #46616a;
+        border-radius: 6px;
+        background: #142127;
+        color: #eef6fb;
+        font-size: 13px;
+        font-weight: 780;
+        cursor: pointer;
+    }
+
+    button.primary {
+        border-color: #5eead4;
+        background: #0f766e;
+    }
+
+    button.active {
+        border-color: #fbbf24;
+        background: #422006;
+    }
+
+    .lanes {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 14px;
+        min-height: 0;
+    }
+
+    .lane {
+        position: relative;
+        display: grid;
+        grid-template-rows: auto auto minmax(0, 1fr);
+        gap: 12px;
+        padding: 18px 22px;
+        border: 1px solid rgba(134, 184, 199, 0.42);
+        background: rgba(7, 17, 20, 0.55);
+        overflow: hidden;
+    }
+
+    .lane.gated {
+        border-color: rgba(94, 234, 212, 0.5);
+    }
+
+    header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 12px;
+    }
+
+    header span {
+        color: #67e8f9;
+        font-size: 11px;
+        font-weight: 850;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+    }
+
+    header strong {
+        color: #ecfeff;
+        font-size: 15px;
+        text-align: right;
+    }
+
+    .count {
+        margin: 0;
+        font-family: 'SFMono-Regular', Consolas, monospace;
+        font-size: 26px;
+        font-weight: 850;
+        color: #64748b;
+        transition: color 0.2s ease;
+    }
+
+    .count[data-state='busy'] {
+        color: #5eead4;
+    }
+
+    .track {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+        padding: 10px;
+        border: 1px dashed rgba(134, 184, 199, 0.22);
+        min-height: 0;
+    }
+
+    .shifted .track {
+        justify-content: flex-end;
+    }
+
+    :global(.box) {
+        width: 84px;
+        height: 84px;
+        display: grid;
+        place-items: center;
+        border-radius: 20px;
+        color: #031316;
+        font-size: 22px;
+        font-weight: 900;
+    }
+
+    @media (max-width: 760px) {
+        .lanes {
+            grid-template-columns: 1fr;
+        }
+    }
+</style>

--- a/docs/src/routes/docs/layout-dependency/+page.svx
+++ b/docs/src/routes/docs/layout-dependency/+page.svx
@@ -1,0 +1,89 @@
+---
+title: 'layoutDependency'
+description: 'Gate layout measurement so FLIP only recomputes when a dependency changes.'
+---
+
+<script>
+  import Example from '$lib/components/general/Example.svelte';
+  import LayoutDependencyExample from '$lib/examples/layout-dependency/demos/Default.svelte';
+  import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+  const seo = getSeoContext()
+  if (seo) {
+      seo.title = 'layoutDependency | Docs | Svelte Motion'
+      seo.description = 'Gate layout (FLIP) measurement so a frequently-rerendering element only re-measures when a dependency changes.'
+      seo.ogTitle = 'layoutDependency'
+      seo.ogTagline = 'Re-measure only when it matters'
+      seo.ogFeatures = ['Layout Animations', 'FLIP', 'Performance', 'Motion Parity']
+      seo.ogSlug = 'docs-layout-dependency'
+  }
+</script>
+
+# layoutDependency
+
+`layoutDependency` tells a `layout` element when to re-measure. By default a
+`layout` element recomputes its FLIP box on every render that touches its
+`class`, `style`, `layoutId`, or `transition`. When you pass
+`layoutDependency`, measurement is gated on **only that value** — the element
+stops re-measuring on unrelated renders and only snapshots when the dependency
+changes.
+
+It's a performance optimization for `layout` elements that re-render often but
+rarely change box.
+
+```svelte
+<script lang="ts">
+  import { motion } from '@humanspeak/svelte-motion'
+
+  // `order` changes only when the list is actually reordered.
+  let { order } = $props()
+</script>
+
+<motion.div layout layoutDependency={order} />
+```
+
+<Example isSmall exampleUrl="/examples/layout-dependency">
+  <LayoutDependencyExample />
+</Example>
+
+In the example above, both boxes re-render constantly (their color cycles). The
+left box re-measures on every render — its measure counter climbs. The right
+box passes `layoutDependency={dep}`, so its counter stays flat until **Reflow**
+bumps the dependency.
+
+## When to use it
+
+Reach for `layoutDependency` when a `layout` element:
+
+- re-renders frequently (live text, streaming values, a ticking clock), **and**
+- only changes layout box on a specific, known signal.
+
+Pass a value that changes **exactly when the layout should be re-measured** —
+commonly a counter, a sorted key, or the array length / order of a list.
+
+```svelte
+<motion.ul layout layoutDependency={items.length}>
+  {#each items as item (item.id)}
+    <motion.li layout layoutDependency={items.length}>{item.label}</motion.li>
+  {/each}
+</motion.ul>
+```
+
+Any defined value gates — including falsy ones like `0`, `''`, or `null`. Leave
+it `undefined` (the default) to keep framer-motion's "measure on every render"
+behavior.
+
+## API Reference
+
+### `layoutDependency`
+
+```ts
+layoutDependency?: unknown
+```
+
+Pass any value to a `layout` `motion.*` component. While it is defined,
+measurement is gated on changes to this value; while it is `undefined`,
+measurement follows the default render-driven behavior. Requires `layout` to be
+enabled.
+
+Based on [Motion's layoutDependency prop](https://motion.dev/docs/react-motion-component#layoutdependency).

--- a/docs/src/routes/docs/layout-dependency/+page.ts
+++ b/docs/src/routes/docs/layout-dependency/+page.ts
@@ -1,0 +1,6 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => ({
+    title: 'layoutDependency',
+    description: 'Gate layout measurement so FLIP only recomputes when a dependency changes.'
+})

--- a/docs/src/routes/examples/layout-dependency/+page.svelte
+++ b/docs/src/routes/examples/layout-dependency/+page.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        type ExampleSection,
+        formatSheetLabel
+    } from '@humanspeak/docs-kit'
+    import { Gauge, Layers, Zap } from '@lucide/svelte'
+    import { demoCodeSample } from '$lib/demo-loaders'
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import LayoutDependencyDefault from '$lib/examples/layout-dependency/demos/Default.svelte'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'layoutDependency' }
+        ]
+    }
+    if (seo) {
+        seo.title = 'layoutDependency | Examples | Svelte Motion'
+        seo.description =
+            'Gate layout measurement so FLIP only recomputes when a dependency changes.'
+        seo.ogTitle = 'layoutDependency'
+        seo.ogTagline = 'Re-measure only when it matters'
+        seo.ogFeatures = ['layoutDependency', 'Layout Animations', 'FLIP', 'Performance']
+        seo.ogSlug = 'examples-layout-dependency'
+    }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    const sections: ExampleSection[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'LAYOUT',
+            title: { prefix: 'frequent renders, ', accent: 'gated measurement', end: '.' },
+            description:
+                'Both boxes have `layout` and re-render constantly (their color cycles). The left box re-measures on every render; the right box passes `layoutDependency={dep}`, so it only re-measures when `dep` changes — watch its counter stay flat.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [
+                { k: 'api', v: 'layoutDependency' },
+                { k: 'input', v: 'layout' },
+                { k: 'mode', v: 'live' }
+            ],
+            sourceUrl: `${SOURCE_URL}layout-dependency/demos/Default.svelte`
+        }
+    ]
+</script>
+
+{#snippet defaultSection()}
+    <LayoutDependencyDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Zap />
+            <span>
+                Every render recolors both boxes — a stand-in for live text or streaming values that
+                re-render a <code>layout</code> element often.
+            </span>
+        </li>
+        <li>
+            <Gauge />
+            <span>
+                The gated box passes <code>layoutDependency={'{dep}'}</code>, so its measure counter
+                only moves when <code>dep</code> changes on Reflow.
+            </span>
+        </li>
+        <li>
+            <Layers />
+            <span>
+                Both still FLIP-animate to their new position on Reflow — gating skips the wasted
+                measurements, not the real ones.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'layout-dependency/demos/Default.svelte',
+                'layout-dependency-default',
+                'Default.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel={formatSheetLabel(i, sections.length)}
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/e2e/layout/layout-dependency.spec.ts
+++ b/e2e/layout/layout-dependency.spec.ts
@@ -12,6 +12,10 @@ const waitForMotionReady = async (page: Page, testId: string) => {
     await expect(page.getByTestId(testId)).toHaveAttribute('data-is-loaded', 'ready')
 }
 
+const render = async (page: Page, times: number) => {
+    for (let i = 0; i < times; i++) await page.getByTestId('tick').click()
+}
+
 test.describe('layoutDependency (#314)', () => {
     test('gated box does not re-measure on unrelated renders; ungated box does', async ({
         page
@@ -27,9 +31,7 @@ test.describe('layoutDependency (#314)', () => {
 
         // Five unrelated renders (color ticks). The ungated box re-measures
         // each time; the gated box (dep unchanged) must not.
-        for (let i = 0; i < 5; i++) {
-            await page.getByTestId('tick').click()
-        }
+        await render(page, 5)
 
         await expect.poll(readCount(page, 'default-measures')).toBeGreaterThanOrEqual(5)
         await expect.poll(readCount(page, 'gated-measures')).toBe(0)
@@ -43,9 +45,7 @@ test.describe('layoutDependency (#314)', () => {
         await expect.poll(readCount(page, 'gated-measures')).toBe(0)
 
         // Render a few times — still gated.
-        for (let i = 0; i < 3; i++) {
-            await page.getByTestId('tick').click()
-        }
+        await render(page, 3)
         await expect.poll(readCount(page, 'gated-measures')).toBe(0)
 
         // Bumping the dependency lets the gated box measure (and FLIP).
@@ -72,9 +72,7 @@ test.describe('layoutDependency escape hatches', () => {
         await expect.poll(readCount(page, 'drag-measures')).toBe(0)
         await expect.poll(readCount(page, 'nodrag-measures')).toBe(0)
 
-        for (let i = 0; i < 5; i++) {
-            await page.getByTestId('tick').click()
-        }
+        await render(page, 5)
 
         // drag overrides the gate → re-measures every render.
         await expect.poll(readCount(page, 'drag-measures')).toBeGreaterThanOrEqual(5)
@@ -97,9 +95,7 @@ test.describe('layoutDependency escape hatches', () => {
         await expect.poll(readCount(page, 'presence-measures')).toBe(0)
 
         // Renders alone must not measure the gated box.
-        for (let i = 0; i < 4; i++) {
-            await page.getByTestId('tick').click()
-        }
+        await render(page, 4)
         await expect.poll(readCount(page, 'presence-measures')).toBe(0)
 
         const boxTop = () =>

--- a/e2e/layout/layout-dependency.spec.ts
+++ b/e2e/layout/layout-dependency.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const URL = '/tests/layout-dependency?@isPlaywright=true'
+
+const readCount = (page: Page, testId: string) => async () => {
+    const text = (await page.getByTestId(testId).textContent()) ?? ''
+    const match = text.match(/(\d+)/)
+    return match ? Number(match[1]) : Number.NaN
+}
+
+const waitForMotionReady = async (page: Page, testId: string) => {
+    await expect(page.getByTestId(testId)).toHaveAttribute('data-is-loaded', 'ready')
+}
+
+test.describe('layoutDependency (#314)', () => {
+    test('gated box does not re-measure on unrelated renders; ungated box does', async ({
+        page
+    }) => {
+        await page.goto(URL)
+        await waitForMotionReady(page, 'default-box')
+        await waitForMotionReady(page, 'gated-box')
+
+        // Zero the counters so we only measure clicks we control.
+        await page.getByTestId('reset').click()
+        await expect.poll(readCount(page, 'default-measures')).toBe(0)
+        await expect.poll(readCount(page, 'gated-measures')).toBe(0)
+
+        // Five unrelated renders (color ticks). The ungated box re-measures
+        // each time; the gated box (dep unchanged) must not.
+        for (let i = 0; i < 5; i++) {
+            await page.getByTestId('tick').click()
+        }
+
+        await expect.poll(readCount(page, 'default-measures')).toBeGreaterThanOrEqual(5)
+        await expect.poll(readCount(page, 'gated-measures')).toBe(0)
+    })
+
+    test('gated box re-measures exactly once when layoutDependency changes', async ({ page }) => {
+        await page.goto(URL)
+        await waitForMotionReady(page, 'gated-box')
+
+        await page.getByTestId('reset').click()
+        await expect.poll(readCount(page, 'gated-measures')).toBe(0)
+
+        // Render a few times — still gated.
+        for (let i = 0; i < 3; i++) {
+            await page.getByTestId('tick').click()
+        }
+        await expect.poll(readCount(page, 'gated-measures')).toBe(0)
+
+        // Bumping the dependency lets the gated box measure (and FLIP).
+        await page.getByTestId('reflow').click()
+        await expect.poll(readCount(page, 'gated-measures')).toBe(1)
+
+        // A second reflow bumps it again — proves it tracks the dependency.
+        await page.getByTestId('reflow').click()
+        await expect.poll(readCount(page, 'gated-measures')).toBe(2)
+    })
+})
+
+// Upstream MeasureLayout also forces a snapshot while dragging and on presence
+// changes, regardless of layoutDependency. The drag case is handled by an
+// explicit escape hatch in the gate; the presence case flows through the
+// observer path. Both panels hold the dependency constant (never bumped).
+test.describe('layoutDependency escape hatches', () => {
+    test('drag forces measurement on renders; non-drag box stays gated', async ({ page }) => {
+        await page.goto(URL)
+        await waitForMotionReady(page, 'drag-box')
+        await waitForMotionReady(page, 'nodrag-box')
+
+        await page.getByTestId('reset').click()
+        await expect.poll(readCount(page, 'drag-measures')).toBe(0)
+        await expect.poll(readCount(page, 'nodrag-measures')).toBe(0)
+
+        for (let i = 0; i < 5; i++) {
+            await page.getByTestId('tick').click()
+        }
+
+        // drag overrides the gate → re-measures every render.
+        await expect.poll(readCount(page, 'drag-measures')).toBeGreaterThanOrEqual(5)
+        // same constant dependency, no drag → stays gated.
+        await expect.poll(readCount(page, 'nodrag-measures')).toBe(0)
+    })
+
+    test('gated box ignores renders but measures on AnimatePresence sibling toggle', async ({
+        page
+    }) => {
+        // Use a tall viewport so the whole page fits without scrolling: the
+        // projection deliberately suppresses the layout commit that follows a
+        // viewport scroll (so scrolling never triggers FLIP), and it skips
+        // commits for fully-offscreen elements — both would mask the reflow.
+        await page.setViewportSize({ width: 1280, height: 1400 })
+        await page.goto(URL)
+        await waitForMotionReady(page, 'presence-gated-box')
+
+        await page.getByTestId('reset').click()
+        await expect.poll(readCount(page, 'presence-measures')).toBe(0)
+
+        // Renders alone must not measure the gated box.
+        for (let i = 0; i < 4; i++) {
+            await page.getByTestId('tick').click()
+        }
+        await expect.poll(readCount(page, 'presence-measures')).toBe(0)
+
+        const boxTop = () =>
+            page
+                .getByTestId('presence-gated-box')
+                .evaluate((el) => Math.round(el.getBoundingClientRect().top))
+        const startTop = await boxTop()
+
+        // Sibling exits → real layout shift → gated box reflows up and measures.
+        await page.getByTestId('toggle-sibling').click()
+        await expect.poll(readCount(page, 'presence-measures')).toBeGreaterThanOrEqual(1)
+        await expect(page.getByTestId('presence-sibling')).toHaveCount(0)
+        await expect.poll(boxTop).toBeLessThan(startTop)
+
+        // Sibling re-enters → box reflows back down.
+        await page.getByTestId('toggle-sibling').click()
+        await expect(page.getByTestId('presence-sibling')).toHaveCount(1)
+        await expect.poll(boxTop).toBe(startTop)
+    })
+})

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -56,6 +56,7 @@
         finishFlipAnimations,
         setCompositorHints,
         observeLayoutChanges,
+        selectLayoutDependencies,
         type RectLike
     } from '$lib/utils/layout'
     import type { SvelteHTMLElements } from 'svelte/elements'
@@ -192,6 +193,7 @@
         layout: layoutProp,
         layoutId: layoutIdProp,
         layoutScroll: layoutScrollProp,
+        layoutDependency: layoutDependencyProp,
         onProjectionUpdate: onProjectionUpdateProp,
         ref: element = $bindable(null),
         ...rest
@@ -2035,12 +2037,23 @@
 
     let explicitLayoutSnapshot: RectLike | null = null
     let lastRect: RectLike | null = null
-    const trackLayoutProjectionDependencies = () => [
-        classProp,
-        styleProp,
-        scopedLayoutId,
-        mergedTransition
-    ]
+    // Reactive deps the measure effects read to decide when to re-snapshot and
+    // FLIP. When `layoutDependency` is set, gate measurement on *only* that
+    // value so frequent renders that touch class/style/etc. no longer force a
+    // re-measure. The fallback list stays a thunk so those props are tracked
+    // only when gating is off. See `selectLayoutDependencies` for the contract.
+    //
+    // Drag escape hatch: upstream `MeasureLayout` also forces a snapshot while a
+    // drag is active, regardless of `layoutDependency` (MeasureLayout.tsx:92).
+    // We mirror that by ignoring the gate while `drag` is set, so a draggable
+    // `layout` element keeps measuring as the user moves it.
+    const trackLayoutProjectionDependencies = () =>
+        selectLayoutDependencies(dragProp ? undefined : layoutDependencyProp, () => [
+            classProp,
+            styleProp,
+            scopedLayoutId,
+            mergedTransition
+        ])
 
     $effect.pre(() => {
         const shouldProject = element && layoutProp && isLoaded === 'ready' && hasLayoutFeatures

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -642,12 +642,14 @@ export type MotionProps = {
      * When `undefined` (the default), measurement runs on every layout-affecting
      * render, matching framer-motion. Mirrors framer-motion's `layoutDependency`.
      *
-     * The gate is bypassed while `drag` is active (a dragged `layout` element
-     * keeps measuring), matching upstream `MeasureLayout`. The gate only
-     * suppresses render-driven re-measurement; real layout changes detected by
-     * the observer system — element resize, structural/child mutations, and
-     * `AnimatePresence` enter/exit — are still measured so the element keeps
-     * animating genuine moves.
+     * Enabling `drag` opts the element out of `layoutDependency` gating
+     * entirely — a `layout` element with `drag` set re-measures like an ungated
+     * one whether or not a drag is in progress, matching upstream
+     * `MeasureLayout` (which keys off the `drag` prop, not active-gesture
+     * state). The gate only suppresses render-driven re-measurement; real
+     * layout changes detected by the observer system — element resize,
+     * structural/child mutations, and `AnimatePresence` enter/exit — are still
+     * measured so the element keeps animating genuine moves.
      *
      * @example
      * ```svelte

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -643,8 +643,11 @@ export type MotionProps = {
      * render, matching framer-motion. Mirrors framer-motion's `layoutDependency`.
      *
      * The gate is bypassed while `drag` is active (a dragged `layout` element
-     * keeps measuring), matching upstream `MeasureLayout`. Layout changes driven
-     * by `AnimatePresence` enter/exit are still measured regardless of the gate.
+     * keeps measuring), matching upstream `MeasureLayout`. The gate only
+     * suppresses render-driven re-measurement; real layout changes detected by
+     * the observer system — element resize, structural/child mutations, and
+     * `AnimatePresence` enter/exit — are still measured so the element keeps
+     * animating genuine moves.
      *
      * @example
      * ```svelte

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -631,6 +631,28 @@ export type MotionProps = {
      * ```
      */
     layoutScroll?: boolean
+    /**
+     * Gates `layout` measurement so FLIP only recomputes when this value
+     * changes, instead of on every render that touches `class`, `style`,
+     * `layoutId`, or `transition`. Use it as a performance optimization when a
+     * frequently-rerendering `layout` element only changes box rarely — pass a
+     * value (e.g. a counter or the sorted key) that changes exactly when the
+     * layout should be re-measured.
+     *
+     * When `undefined` (the default), measurement runs on every layout-affecting
+     * render, matching framer-motion. Mirrors framer-motion's `layoutDependency`.
+     *
+     * The gate is bypassed while `drag` is active (a dragged `layout` element
+     * keeps measuring), matching upstream `MeasureLayout`. Layout changes driven
+     * by `AnimatePresence` enter/exit are still measured regardless of the gate.
+     *
+     * @example
+     * ```svelte
+     * <!-- Re-measures only when `order` changes, not on every tick -->
+     * <motion.div layout layoutDependency={order} />
+     * ```
+     */
+    layoutDependency?: unknown
     /** Ref to the element */
     ref?: HTMLElement | null
     /** Enable drag gestures. true for both axes, or lock to 'x'/'y'. */

--- a/src/lib/utils/layout.spec.ts
+++ b/src/lib/utils/layout.spec.ts
@@ -4,6 +4,7 @@ import {
     measureRect,
     observeLayoutChanges,
     runFlipAnimation,
+    selectLayoutDependencies,
     setCompositorHints
 } from './layout.js'
 
@@ -553,5 +554,42 @@ describe('utils/layout', () => {
         ;(window as unknown as { requestAnimationFrame?: unknown }).requestAnimationFrame =
             originalRaf
         vi.unstubAllGlobals()
+    })
+
+    describe('selectLayoutDependencies (#314 layoutDependency)', () => {
+        it('gates on only the dependency when one is provided', () => {
+            expect(selectLayoutDependencies('order-key', () => ['class', 'style'])).toEqual([
+                'order-key'
+            ])
+        })
+
+        it('does NOT evaluate the fallback when gated (laziness is the optimization)', () => {
+            const fallback = vi.fn(() => ['class', 'style'])
+            const deps = selectLayoutDependencies(42, fallback)
+
+            expect(deps).toEqual([42])
+            // The whole point: fallback props are never read while gating is on,
+            // so they cannot register as reactive dependencies and force a
+            // re-measure.
+            expect(fallback).not.toHaveBeenCalled()
+        })
+
+        it('uses the (lazily evaluated) fallback deps when dependency is undefined', () => {
+            const fallback = vi.fn(() => ['class', 'style', 'layoutId'])
+            const deps = selectLayoutDependencies(undefined, fallback)
+
+            expect(deps).toEqual(['class', 'style', 'layoutId'])
+            expect(fallback).toHaveBeenCalledTimes(1)
+        })
+
+        it('treats falsy-but-defined values (0, "", null, false) as gating', () => {
+            const fallback = vi.fn(() => ['class'])
+
+            expect(selectLayoutDependencies(0, fallback)).toEqual([0])
+            expect(selectLayoutDependencies('', fallback)).toEqual([''])
+            expect(selectLayoutDependencies(null, fallback)).toEqual([null])
+            expect(selectLayoutDependencies(false, fallback)).toEqual([false])
+            expect(fallback).not.toHaveBeenCalled()
+        })
     })
 })

--- a/src/lib/utils/layout.spec.ts
+++ b/src/lib/utils/layout.spec.ts
@@ -591,5 +591,15 @@ describe('utils/layout', () => {
             expect(selectLayoutDependencies(false, fallback)).toEqual([false])
             expect(fallback).not.toHaveBeenCalled()
         })
+
+        it('treats objects and arrays as gating dependencies', () => {
+            const fallback = vi.fn(() => ['class'])
+            const obj = { foo: 'bar' }
+            const arr = [1, 2, 3]
+
+            expect(selectLayoutDependencies(obj, fallback)).toEqual([obj])
+            expect(selectLayoutDependencies(arr, fallback)).toEqual([arr])
+            expect(fallback).not.toHaveBeenCalled()
+        })
     })
 })

--- a/src/lib/utils/layout.ts
+++ b/src/lib/utils/layout.ts
@@ -385,6 +385,38 @@ export const setCompositorHints = (el: HTMLElement, enabled: boolean): void => {
 }
 
 /**
+ * Select the reactive dependencies that gate `layout` (FLIP) measurement.
+ *
+ * When `layoutDependency` is provided — any value, including falsy ones like
+ * `0`, `''`, or `null` — measurement is gated on *only* that value, so a
+ * frequently-rerendering `layout` element stops re-measuring on every render
+ * that merely touches `class`, `style`, `layoutId`, or `transition`. When it is
+ * `undefined`, the lazily-evaluated `fallback` dependencies drive measurement,
+ * matching framer-motion's default behavior.
+ *
+ * `fallback` is a thunk so its values are read (and, in a reactive context,
+ * tracked) only when gating is off — that laziness is what makes the
+ * optimization effective. Mirrors framer-motion's `MeasureLayout`, which calls
+ * `willUpdate()` only when `layoutDependency` changed or is `undefined`.
+ *
+ * @param layoutDependency The user-supplied `layoutDependency` prop value.
+ * @param fallback Thunk returning the default dependency list, evaluated only
+ *   when `layoutDependency` is `undefined`.
+ * @returns The dependency list the measurement effects should track.
+ * @example
+ * ```ts
+ * // Gated: only re-measures when `order` changes.
+ * selectLayoutDependencies(order, () => [klass, style]) // => [order]
+ * // Default: tracks the fallback deps.
+ * selectLayoutDependencies(undefined, () => [klass, style]) // => [klass, style]
+ * ```
+ */
+export const selectLayoutDependencies = (
+    layoutDependency: unknown,
+    fallback: () => unknown[]
+): unknown[] => (layoutDependency !== undefined ? [layoutDependency] : fallback())
+
+/**
  * Observe size/attribute changes that commonly trigger layout changes.
  *
  * Returns a cleanup function that disconnects observers. The callback is called

--- a/src/lib/utils/layoutId.ts
+++ b/src/lib/utils/layoutId.ts
@@ -26,6 +26,20 @@ export type LayoutIdRegistry = {
  */
 const entries = new Map<string, LayoutIdEntry>()
 
+/**
+ * The global singleton `LayoutIdRegistry` shared across the component tree.
+ *
+ * Bridges `layoutId` shared-element transitions: an unmounting element calls
+ * `snapshot` to store its last-known rect, and a newly mounted element with the
+ * same id calls `consume` to read and clear it (one-shot). Prefer
+ * {@link getLayoutIdRegistry} at call sites for indirection.
+ *
+ * @example
+ * ```ts
+ * layoutIdRegistry.snapshot('hero', element.getBoundingClientRect())
+ * const entry = layoutIdRegistry.consume('hero') // returns and deletes
+ * ```
+ */
 export const layoutIdRegistry: LayoutIdRegistry = {
     snapshot(id, rect, transition) {
         entries.set(id, { rect, transition })

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -88,6 +88,14 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/layout-dependency') + searchParams}
+                    >
+                        layoutDependency
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/motion/aspect-ratio') + searchParams}
                     >
                         Aspect Ratio

--- a/src/routes/app.css
+++ b/src/routes/app.css
@@ -106,12 +106,14 @@ body {
     display: flex;
     justify-content: center;
     align-items: center;
-    height: 100%;
+    min-height: 100%;
+    height: auto;
     width: 100%;
 }
 
 .container {
-    height: 100vh;
+    min-height: 100vh;
+    height: auto;
     width: 100%;
     display: flex;
     margin: 0;

--- a/src/routes/tests/layout-dependency/+page.svelte
+++ b/src/routes/tests/layout-dependency/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import { onMount } from 'svelte'
     import { AnimatePresence, motion } from '$lib'
 
     // A high-frequency render driver. Each tick changes both boxes' inline
@@ -59,13 +58,13 @@
         siblingPresent = !siblingPresent
     }
 
-    onMount(() => {
-        let raf = 0
-        const loop = () => {
-            if (autoTicking) tick += 1
+    // Only spin the rAF loop while auto-render is on.
+    $effect(() => {
+        if (!autoTicking) return
+        let raf = requestAnimationFrame(function loop() {
+            tick += 1
             raf = requestAnimationFrame(loop)
-        }
-        raf = requestAnimationFrame(loop)
+        })
         return () => cancelAnimationFrame(raf)
     })
 </script>

--- a/src/routes/tests/layout-dependency/+page.svelte
+++ b/src/routes/tests/layout-dependency/+page.svelte
@@ -1,0 +1,449 @@
+<script lang="ts">
+    import { onMount } from 'svelte'
+    import { AnimatePresence, motion } from '$lib'
+
+    // A high-frequency render driver. Each tick changes both boxes' inline
+    // `style` (the background hue), forcing a re-render that — without
+    // `layoutDependency` — re-measures the layout box every single time.
+    let tick = $state(0)
+
+    // The gate value. Bumping this is the ONLY thing that should let the
+    // gated box re-measure.
+    let dep = $state(0)
+
+    // Toggles a container modifier so both boxes physically move (a real
+    // FLIP-able layout change) when we choose to reflow.
+    let shifted = $state(false)
+
+    // Measurement counters: each box increments when its render-driven
+    // projection cycle actually runs (onProjectionUpdate fires).
+    let defaultMeasures = $state(0)
+    let gatedMeasures = $state(0)
+
+    // Escape-hatch sections (upstream MeasureLayout parity).
+    // Drag: a gated box with `drag` should ignore the gate and keep measuring.
+    let dragMeasures = $state(0)
+    let noDragMeasures = $state(0)
+    // Presence: a gated box whose sibling toggles via AnimatePresence should
+    // still measure when the real layout shift happens (observer path).
+    let presenceMeasures = $state(0)
+    let siblingPresent = $state(true)
+
+    let autoTicking = $state(false)
+
+    const hue = $derived(tick % 360)
+    const boxStyle = $derived(`background: hsl(${hue} 85% 60%)`)
+
+    function tickOnce() {
+        tick += 1
+    }
+
+    // Reflow: move the boxes AND bump the gate. The tick bump lets the
+    // ungated box re-render into its new position; the dep bump is what lets
+    // the gated box measure and FLIP-animate to the same new position.
+    function reflow() {
+        shifted = !shifted
+        tick += 1
+        dep += 1
+    }
+
+    function resetCounters() {
+        defaultMeasures = 0
+        gatedMeasures = 0
+        dragMeasures = 0
+        noDragMeasures = 0
+        presenceMeasures = 0
+    }
+
+    function toggleSibling() {
+        siblingPresent = !siblingPresent
+    }
+
+    onMount(() => {
+        let raf = 0
+        const loop = () => {
+            if (autoTicking) tick += 1
+            raf = requestAnimationFrame(loop)
+        }
+        raf = requestAnimationFrame(loop)
+        return () => cancelAnimationFrame(raf)
+    })
+</script>
+
+<svelte:head>
+    <title>layoutDependency</title>
+</svelte:head>
+
+<main>
+    <section class="intro">
+        <p class="kicker">layoutDependency (#314)</p>
+        <h1>Re-measure only when it matters.</h1>
+        <p>
+            Both boxes have <code>layout</code> and re-render constantly (their color cycles every
+            frame). The left box re-measures on <em>every</em> render. The right box passes
+            <code>layoutDependency={'{dep}'}</code>, so it only re-measures when <code>dep</code> changes
+            — watch its measure counter stay flat while it shimmers.
+        </p>
+    </section>
+
+    <section class="controls" data-testid="controls">
+        <button type="button" data-testid="tick" onclick={tickOnce}>Render once</button>
+        <button
+            type="button"
+            data-testid="toggle-auto"
+            onclick={() => (autoTicking = !autoTicking)}
+        >
+            {autoTicking ? 'Stop' : 'Start'} auto-render
+        </button>
+        <button type="button" data-testid="reflow" onclick={reflow}>Reflow + bump dep</button>
+        <button type="button" data-testid="toggle-sibling" onclick={toggleSibling}>
+            Toggle sibling
+        </button>
+        <button type="button" data-testid="reset" onclick={resetCounters}>Reset counters</button>
+        <span class="readout" data-testid="tick-count">renders: {tick}</span>
+    </section>
+
+    <section class="grid" class:shifted>
+        <article>
+            <h2>Default (no gate)</h2>
+            <p class="expectation">
+                Re-measures on every render. Measure counter climbs with the render count.
+            </p>
+            <p class="measure" data-testid="default-measures">measures: {defaultMeasures}</p>
+            <div class="track">
+                <motion.div
+                    class="orb"
+                    data-testid="default-box"
+                    layout
+                    style={boxStyle}
+                    transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+                    onProjectionUpdate={() => (defaultMeasures += 1)}
+                >
+                    A
+                </motion.div>
+            </div>
+        </article>
+
+        <article>
+            <h2>Gated (layoutDependency)</h2>
+            <p class="expectation">
+                Same renders, but measurement is gated on <code>dep</code>. Counter only moves on
+                Reflow.
+            </p>
+            <p class="measure" data-testid="gated-measures">measures: {gatedMeasures}</p>
+            <div class="track">
+                <motion.div
+                    class="orb"
+                    data-testid="gated-box"
+                    layout
+                    layoutDependency={dep}
+                    style={boxStyle}
+                    transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+                    onProjectionUpdate={() => (gatedMeasures += 1)}
+                >
+                    B
+                </motion.div>
+            </div>
+        </article>
+    </section>
+
+    <section class="escape">
+        <h2 class="section-title">Escape hatches (upstream parity)</h2>
+        <p class="section-note">
+            Upstream <code>MeasureLayout</code> ignores the gate while a drag is active, and re-snapshots
+            on presence changes. These two panels show both, with the dependency held constant (never
+            bumped).
+        </p>
+
+        <div class="grid">
+            <article>
+                <h2>drag forces measurement</h2>
+                <p class="expectation">
+                    Both boxes are gated with a constant <code>layoutDependency={0}</code>. The left
+                    also has <code>drag</code> — so renders re-measure it; the right stays flat.
+                </p>
+                <div class="readouts">
+                    <p class="measure" data-testid="drag-measures">drag: {dragMeasures}</p>
+                    <p class="measure muted" data-testid="nodrag-measures">
+                        no-drag: {noDragMeasures}
+                    </p>
+                </div>
+                <div class="track two">
+                    <motion.div
+                        class="orb"
+                        data-testid="drag-box"
+                        layout
+                        layoutDependency={0}
+                        drag
+                        dragSnapToOrigin
+                        style={boxStyle}
+                        transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+                        onProjectionUpdate={() => (dragMeasures += 1)}
+                    >
+                        D
+                    </motion.div>
+                    <motion.div
+                        class="orb"
+                        data-testid="nodrag-box"
+                        layout
+                        layoutDependency={0}
+                        style={boxStyle}
+                        transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+                        onProjectionUpdate={() => (noDragMeasures += 1)}
+                    >
+                        N
+                    </motion.div>
+                </div>
+            </article>
+
+            <article>
+                <h2>presence-driven reflow</h2>
+                <p class="expectation">
+                    The gated box (constant <code>layoutDependency={0}</code>) ignores renders, but
+                    when its AnimatePresence sibling enters/exits the real layout shift still
+                    measures via the observer path.
+                </p>
+                <p class="measure" data-testid="presence-measures">measures: {presenceMeasures}</p>
+                <div class="track column">
+                    <AnimatePresence>
+                        {#if siblingPresent}
+                            <motion.div
+                                key="presence-sibling"
+                                class="sibling"
+                                data-testid="presence-sibling"
+                                initial={{ opacity: 0 }}
+                                animate={{ opacity: 1 }}
+                                exit={{ opacity: 0 }}
+                                transition={{ duration: 0.25 }}
+                            >
+                                sibling
+                            </motion.div>
+                        {/if}
+                    </AnimatePresence>
+                    <motion.div
+                        class="orb"
+                        data-testid="presence-gated-box"
+                        layout
+                        layoutDependency={0}
+                        style={boxStyle}
+                        transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+                        onProjectionUpdate={() => (presenceMeasures += 1)}
+                    >
+                        C
+                    </motion.div>
+                </div>
+            </article>
+        </div>
+    </section>
+</main>
+
+<style>
+    /* Layout/scroll is owned centrally by app.css (.container/#sandbox +
+       html/body). Only theme the page here. */
+    :global(html),
+    :global(body) {
+        background: #071012;
+        color: #ecfdf5;
+        font-family:
+            Inter,
+            ui-sans-serif,
+            system-ui,
+            -apple-system,
+            BlinkMacSystemFont,
+            'Segoe UI',
+            sans-serif;
+    }
+
+    main {
+        min-height: 100vh;
+        width: min(1080px, calc(100vw - 32px));
+        display: grid;
+        align-content: center;
+        gap: 28px;
+        margin: 0 auto;
+        padding: 48px 0;
+    }
+
+    .intro {
+        max-width: 760px;
+    }
+
+    .kicker {
+        margin: 0 0 8px;
+        color: #67e8f9;
+        font-size: 13px;
+        font-weight: 850;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    h1 {
+        margin: 0;
+        font-size: clamp(34px, 5vw, 56px);
+        line-height: 0.95;
+    }
+
+    .intro p:not(.kicker) {
+        margin: 14px 0 0;
+        color: #b7d4d8;
+        font-size: 16px;
+        line-height: 1.65;
+    }
+
+    code {
+        color: #f0abfc;
+    }
+
+    .controls {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .readout {
+        margin-left: 6px;
+        color: #a9c9cf;
+        font-family: 'SFMono-Regular', Consolas, monospace;
+        font-size: 13px;
+    }
+
+    .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 18px;
+    }
+
+    article {
+        display: grid;
+        align-content: start;
+        gap: 14px;
+        padding: 24px;
+        border: 1px solid rgba(125, 211, 252, 0.3);
+        background: #0b171a;
+        overflow: hidden;
+    }
+
+    h2 {
+        margin: 0;
+        color: #dff8ff;
+        font-size: 18px;
+    }
+
+    .expectation {
+        margin: 0;
+        color: #a9c9cf;
+        font-size: 13px;
+        line-height: 1.45;
+    }
+
+    .measure {
+        margin: 0;
+        color: #67e8f9;
+        font-family: 'SFMono-Regular', Consolas, monospace;
+        font-size: 15px;
+        font-weight: 800;
+    }
+
+    .track {
+        display: flex;
+        justify-content: flex-start;
+        padding: 12px;
+        border: 1px dashed rgba(125, 211, 252, 0.24);
+        min-height: 140px;
+        align-items: center;
+    }
+
+    /* Reflow moves the box to the opposite edge — a real layout change. */
+    .grid.shifted .track {
+        justify-content: flex-end;
+    }
+
+    .track.two {
+        justify-content: space-between;
+    }
+
+    .track.column {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
+
+    .escape {
+        display: grid;
+        gap: 14px;
+        margin-top: 8px;
+        padding-top: 24px;
+        border-top: 1px solid rgba(125, 211, 252, 0.18);
+    }
+
+    .section-title {
+        margin: 0;
+        color: #dff8ff;
+        font-size: 20px;
+    }
+
+    .section-note {
+        margin: 0 0 4px;
+        max-width: 760px;
+        color: #a9c9cf;
+        font-size: 14px;
+        line-height: 1.55;
+    }
+
+    .readouts {
+        display: flex;
+        gap: 18px;
+    }
+
+    .measure.muted {
+        color: #64748b;
+    }
+
+    .sibling {
+        width: 100%;
+        padding: 14px 16px;
+        border: 1px solid rgba(125, 211, 252, 0.35);
+        background: rgba(56, 189, 248, 0.12);
+        color: #bae6fd;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        font-size: 12px;
+        box-sizing: border-box;
+    }
+
+    :global(.orb) {
+        width: 96px;
+        height: 96px;
+        display: grid;
+        place-items: center;
+        border-radius: 24px;
+        color: #031316;
+        font-size: 22px;
+        font-weight: 900;
+    }
+
+    button {
+        min-width: 96px;
+        border: 1px solid rgba(125, 211, 252, 0.45);
+        border-radius: 6px;
+        background: #102332;
+        color: #ecfeff;
+        padding: 10px 14px;
+        font: inherit;
+        font-weight: 850;
+        cursor: pointer;
+    }
+
+    button:hover {
+        border-color: #67e8f9;
+        background: #153247;
+    }
+
+    @media (max-width: 760px) {
+        .grid {
+            grid-template-columns: 1fr;
+        }
+    }
+</style>


### PR DESCRIPTION
## Summary

Adds the `layoutDependency` prop (#314) — a performance optimization that gates
`layout` (FLIP) measurement so a frequently-rerendering element only re-measures
when a value you control changes, instead of on every render. Mirrors
framer-motion's `layoutDependency`, including the `drag` escape hatch.

Along the way this also fixes an app-wide scrolling bug in the test routes and
bundles a routine `trunk` tooling upgrade.

## Changes

### ✨ `layoutDependency` (#314)
- `layoutDependency?: unknown` prop with Google-style JSDoc
- Pure `selectLayoutDependencies(dep, fallback)` helper whose lazy fallback
  thunk is what keeps the gated props untracked (the actual optimization)
- Gated dependency tracker in `_MotionContainer`, plus a **drag escape hatch**
  that bypasses the gate while `drag` is active (upstream `MeasureLayout` parity)
- Any defined value gates — including falsy `0`/`''`/`null`/`false`; only
  `undefined` keeps the default "measure every render" behavior
- Real layout changes (resize, structural, AnimatePresence) still measure via
  the observer path — the gate only suppresses the render-driven re-measure

### 🐛 Scrolling fix
- `.container`/`#sandbox` used fixed `height`, clamping every test route to one
  viewport so taller content couldn't scroll. Switched to `min-height` +
  `height: auto` (finishes the #405 fix) — fixes scrolling app-wide.

### 🧪 Testing
- Unit tests for the gate (primitives, falsy-but-defined, object/array, lazy
  fallback)
- Playwright e2e: gating, dependency change, drag hatch, presence-driven reflow
- `/tests/layout-dependency` demo with measure counters + escape-hatch panels,
  linked from the test index

### 📚 Docs
- Docs page `/docs/layout-dependency` + example route + reusable demo + nav entry
- JSDoc on the previously-undocumented `layoutIdRegistry` export

### 📦 Tooling
- `trunk upgrade`: linter/plugin version bumps

## Known follow-up

The projection system measures in viewport coordinates and uses a
scroll-suppression heuristic where upstream measures in scroll-invariant page
space. Captured as a separate brave-when-ready issue (#415); not a blocker here.

## Commits

- [`7db2e49`](https://github.com/humanspeak/svelte-motion/commit/7db2e49) feat(layout): add layoutDependency prop to gate FLIP measurement
- [`80f50cf`](https://github.com/humanspeak/svelte-motion/commit/80f50cf) fix(tests): let demo wrappers grow so pages scroll past the viewport
- [`f0dd2d1`](https://github.com/humanspeak/svelte-motion/commit/f0dd2d1) chore: upgrade trunk linters and plugins
- [`30422dc`](https://github.com/humanspeak/svelte-motion/commit/30422dc) refactor(layout): tidy layoutDependency demo and e2e
- [`cf5ee54`](https://github.com/humanspeak/svelte-motion/commit/cf5ee54) test(layout): cover object/array layoutDependency values
- [`8aee4f7`](https://github.com/humanspeak/svelte-motion/commit/8aee4f7) docs(layout): clarify what layoutDependency does and does not gate
- [`e326bcd`](https://github.com/humanspeak/svelte-motion/commit/e326bcd) docs(layout): add JSDoc to layoutIdRegistry export

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)
