### PR TITLE
feat(motion-values): add useWillChange hook (#327)

### DIFF
--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -87,7 +87,8 @@ export const docsSections: NavSection[] = [
             { title: 'useSpring', href: '/docs/use-spring', icon: Activity },
             { title: 'useTime', href: '/docs/use-time', icon: Timer },
             { title: 'useTransform', href: '/docs/use-transform', icon: SlidersHorizontal },
-            { title: 'useVelocity', href: '/docs/use-velocity', icon: Gauge }
+            { title: 'useVelocity', href: '/docs/use-velocity', icon: Gauge },
+            { title: 'useWillChange', href: '/docs/use-will-change', icon: Zap }
         ]
     },
     {

--- a/docs/src/lib/examples/use-will-change/demos/Default.svelte
+++ b/docs/src/lib/examples/use-will-change/demos/Default.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+    import { ArrowLeftRight, Sparkles } from '@lucide/svelte'
+    import { motion, useWillChange } from '@humanspeak/svelte-motion'
+
+    const willChange = useWillChange()
+    let started = $state(false)
+    let moved = $state(false)
+
+    // No transform key until the first interaction, so will-change starts at
+    // "auto". After that, toggle x both ways. will-change latches to "transform"
+    // on the first animation and stays there (upstream useWillChange is one-way).
+    const target = $derived(started ? { x: moved ? 220 : 0 } : {})
+
+    const toggle = () => {
+        started = true
+        moved = !moved
+    }
+</script>
+
+<!-- dk-strip: docs-kit positioning shell - stripped from the published code. -->
+<div class="dk-demo-shell">
+    <div class="toolbar">
+        <button type="button" class="primary" onclick={toggle}>
+            {#if moved}
+                <ArrowLeftRight size={15} />
+                Return
+            {:else}
+                <Sparkles size={15} />
+                Animate x
+            {/if}
+        </button>
+        <span class="value">will-change: <strong>{willChange.current}</strong></span>
+    </div>
+
+    <div class="stage">
+        <div class="track">
+            <motion.div
+                class="card"
+                style={{ willChange }}
+                initial={false}
+                animate={target}
+                transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+            >
+                <small>style.willChange</small>
+                <strong>{willChange.current}</strong>
+            </motion.div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .dk-demo-shell {
+        width: 100%;
+        height: clamp(420px, calc(100vh - 160px), 520px);
+        display: grid;
+        grid-template-rows: auto minmax(0, 1fr);
+        gap: 16px;
+        padding: 20px 26px;
+        background: #0d1518;
+        color: #eef6fb;
+    }
+
+    .toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 14px;
+    }
+
+    button {
+        height: 36px;
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        padding: 0 12px;
+        border: 1px solid #46616a;
+        border-radius: 6px;
+        background: #142127;
+        color: #eef6fb;
+        font-size: 13px;
+        font-weight: 780;
+        cursor: pointer;
+    }
+
+    button.primary {
+        border-color: #5eead4;
+        background: #0f766e;
+    }
+
+    .value {
+        font-family: 'SFMono-Regular', Consolas, monospace;
+        font-size: 13px;
+        color: #a9c9cf;
+    }
+
+    .value strong {
+        color: #5eead4;
+    }
+
+    .stage {
+        position: relative;
+        overflow: hidden;
+        border: 1px solid #2b4650;
+        background:
+            linear-gradient(90deg, rgba(94, 234, 212, 0.1) 1px, transparent 1px),
+            linear-gradient(0deg, rgba(94, 234, 212, 0.1) 1px, transparent 1px), #071114;
+        background-size: 44px 44px;
+    }
+
+    .track {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        padding: 0 32px;
+    }
+
+    :global(.card) {
+        width: 150px;
+        min-height: 90px;
+        display: grid;
+        align-content: center;
+        gap: 6px;
+        padding: 0 18px;
+        border-radius: 14px;
+        background: linear-gradient(135deg, #67e8f9, #2dd4bf);
+        color: #031316;
+        box-shadow: 0 22px 80px rgba(45, 212, 191, 0.34);
+    }
+
+    :global(.card small) {
+        font-size: 10px;
+        font-weight: 850;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+    }
+
+    :global(.card strong) {
+        font-size: 20px;
+        font-family: 'SFMono-Regular', Consolas, monospace;
+    }
+</style>

--- a/docs/src/lib/examples/use-will-change/demos/Default.svelte
+++ b/docs/src/lib/examples/use-will-change/demos/Default.svelte
@@ -1,142 +1,260 @@
 <script lang="ts">
-    import { ArrowLeftRight, Sparkles } from '@lucide/svelte'
+    import { Sparkles } from '@lucide/svelte'
     import { motion, useWillChange } from '@humanspeak/svelte-motion'
 
-    const willChange = useWillChange()
+    // Two independent will-change values: one attached to a transform animation,
+    // one to a paint-only animation. The badge on each box shows its live value.
+    const moveWillChange = useWillChange()
+    const paintWillChange = useWillChange()
+
     let started = $state(false)
     let moved = $state(false)
+    let recolored = $state(false)
 
-    // No transform key until the first interaction, so will-change starts at
-    // "auto". After that, toggle x both ways. will-change latches to "transform"
-    // on the first animation and stays there (upstream useWillChange is one-way).
-    const target = $derived(started ? { x: moved ? 220 : 0 } : {})
+    // No transform key until the first click, so will-change starts at "auto".
+    const moveTarget = $derived(started ? { x: moved ? 150 : 0 } : {})
 
-    const toggle = () => {
+    const toggleMove = () => {
         started = true
         moved = !moved
     }
 </script>
 
-<!-- dk-strip: docs-kit positioning shell - stripped from the published code. -->
-<div class="dk-demo-shell">
-    <div class="toolbar">
-        <button type="button" class="primary" onclick={toggle}>
-            {#if moved}
-                <ArrowLeftRight size={15} />
-                Return
-            {:else}
+<div class="demo">
+    <div class="row">
+        <section class="cell">
+            <header>
+                <span class="tag promote">promotes</span>
+                Animating <code>x</code> (transform)
+            </header>
+            <div class="lane">
+                <motion.div
+                    class="box move"
+                    style={{ willChange: moveWillChange }}
+                    initial={false}
+                    animate={moveTarget}
+                    transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+                >
+                    <small>will-change</small>
+                    <span class="val" class:on={moveWillChange.current === 'transform'}>
+                        {moveWillChange.current}
+                    </span>
+                </motion.div>
+            </div>
+            <button type="button" onclick={toggleMove}>
                 <Sparkles size={15} />
-                Animate x
-            {/if}
-        </button>
-        <span class="value">will-change: <strong>{willChange.current}</strong></span>
-    </div>
+                {moved ? 'Return' : 'Animate x'}
+            </button>
+        </section>
 
-    <div class="stage">
-        <div class="track">
-            <motion.div
-                class="card"
-                style={{ willChange }}
-                initial={false}
-                animate={target}
-                transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
-            >
-                <small>style.willChange</small>
-                <strong>{willChange.current}</strong>
-            </motion.div>
-        </div>
+        <section class="cell">
+            <header>
+                <span class="tag stay">stays auto</span>
+                Animating <code>backgroundColor</code> (paint)
+            </header>
+            <div class="lane">
+                <motion.div
+                    class="box paint"
+                    style={{ willChange: paintWillChange }}
+                    initial={false}
+                    animate={{ backgroundColor: recolored ? '#f0abfc' : '#67e8f9' }}
+                    transition={{ duration: 0.6 }}
+                >
+                    <small>will-change</small>
+                    <span class="val" class:on={paintWillChange.current === 'transform'}>
+                        {paintWillChange.current}
+                    </span>
+                </motion.div>
+            </div>
+            <button type="button" onclick={() => (recolored = !recolored)}>
+                <Sparkles size={15} />
+                {recolored ? 'Reset' : 'Animate color'}
+            </button>
+        </section>
     </div>
 </div>
 
 <style>
-    .dk-demo-shell {
-        width: 100%;
-        height: clamp(420px, calc(100vh - 160px), 520px);
+    /* Theme-aware: light is the default; html.dark overrides below. Surfaces are
+       built from the docs brand scale (--color-brand-50…900) so the stage adapts
+       to the page theme instead of being a hardcoded dark slab. */
+    .demo {
         display: grid;
-        grid-template-rows: auto minmax(0, 1fr);
         gap: 16px;
-        padding: 20px 26px;
-        background: #0d1518;
-        color: #eef6fb;
+        padding: 22px 24px;
+        background: var(--color-brand-50);
+        color: color-mix(in oklab, var(--color-brand-900) 80%, transparent);
     }
 
-    .toolbar {
+    :global(html.dark) .demo {
+        background: var(--color-brand-900);
+        color: color-mix(in oklab, var(--color-brand-100) 80%, transparent);
+    }
+
+    .row {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 16px;
+    }
+
+    .cell {
+        display: grid;
+        gap: 12px;
+        align-content: start;
+        padding: 16px;
+        border: 1px solid color-mix(in oklab, var(--color-brand-500) 22%, transparent);
+        border-radius: 10px;
+        background: color-mix(in oklab, var(--color-brand-50) 55%, white);
+    }
+
+    :global(html.dark) .cell {
+        border-color: color-mix(in oklab, var(--color-brand-500) 26%, transparent);
+        background: color-mix(in oklab, var(--color-brand-800) 45%, var(--color-brand-900));
+    }
+
+    header {
         display: flex;
         flex-wrap: wrap;
         align-items: center;
-        gap: 14px;
+        gap: 8px;
+        font-size: 13px;
+        color: color-mix(in oklab, var(--color-brand-900) 72%, transparent);
+    }
+
+    :global(html.dark) header {
+        color: color-mix(in oklab, var(--color-brand-100) 72%, transparent);
+    }
+
+    header code {
+        color: var(--color-brand-700);
+        font-family: 'SFMono-Regular', Consolas, monospace;
+    }
+
+    :global(html.dark) header code {
+        color: var(--color-brand-300);
+    }
+
+    .tag {
+        padding: 2px 8px;
+        border-radius: 999px;
+        font-size: 11px;
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+    }
+
+    .tag.promote {
+        background: color-mix(in oklab, var(--color-brand-500) 20%, transparent);
+        color: var(--color-brand-700);
+    }
+
+    .tag.stay {
+        background: color-mix(in oklab, var(--color-brand-900) 9%, transparent);
+        color: color-mix(in oklab, var(--color-brand-900) 60%, transparent);
+    }
+
+    :global(html.dark) .tag.promote {
+        background: color-mix(in oklab, var(--color-brand-500) 26%, transparent);
+        color: var(--color-brand-200);
+    }
+
+    :global(html.dark) .tag.stay {
+        background: color-mix(in oklab, var(--color-brand-100) 12%, transparent);
+        color: color-mix(in oklab, var(--color-brand-100) 62%, transparent);
+    }
+
+    /* Fixed-height lane in normal flow — can't collapse, and overflow clips the
+       box as it slides so the translate stays self-contained. */
+    .lane {
+        position: relative;
+        height: 124px;
+        display: flex;
+        align-items: center;
+        padding: 0 16px;
+        overflow: hidden;
+        border-radius: 8px;
+        border: 1px solid color-mix(in oklab, var(--color-brand-500) 16%, transparent);
+        background: color-mix(in oklab, var(--color-brand-500) 9%, var(--color-brand-50));
+    }
+
+    :global(html.dark) .lane {
+        border-color: color-mix(in oklab, var(--color-brand-500) 22%, transparent);
+        background: color-mix(in oklab, var(--color-brand-500) 14%, var(--color-brand-900));
+    }
+
+    /* The boxes are vivid by design (they're the thing being animated), so their
+       label ink is dark in both themes. */
+    :global(.demo .box) {
+        flex: none;
+        width: 116px;
+        height: 92px;
+        display: grid;
+        align-content: center;
+        justify-items: center;
+        gap: 4px;
+        border-radius: 14px;
+        color: color-mix(in oklab, var(--color-brand-900) 90%, black);
+        box-shadow: 0 14px 40px color-mix(in oklab, var(--color-brand-500) 32%, transparent);
+    }
+
+    :global(.demo .box.move) {
+        background: linear-gradient(135deg, var(--color-brand-400), var(--color-brand-600));
+    }
+
+    :global(.demo .box.paint) {
+        background: #67e8f9;
+    }
+
+    :global(.demo .box small) {
+        font-size: 9px;
+        font-weight: 850;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        opacity: 0.72;
+    }
+
+    /* Self-contained chip colors. The boxes are a constant vivid teal/cyan in
+       both themes, so fixed ink/light pairs keep contrast regardless of the
+       page theme — and a <span> avoids docs-kit's global <strong> color rule. */
+    :global(.demo .box .val) {
+        padding: 2px 9px;
+        border-radius: 999px;
+        background: rgba(3, 19, 22, 0.82);
+        color: #ecfeff;
+        font-size: 15px;
+        font-weight: 700;
+        font-family: 'SFMono-Regular', Consolas, monospace;
+    }
+
+    :global(.demo .box .val.on) {
+        background: #ecfeff;
+        color: #0b3b33;
     }
 
     button {
-        height: 36px;
+        justify-self: start;
+        height: 34px;
         display: inline-flex;
         align-items: center;
         gap: 7px;
-        padding: 0 12px;
-        border: 1px solid #46616a;
+        padding: 0 13px;
+        border: 1px solid var(--color-brand-600);
         border-radius: 6px;
-        background: #142127;
-        color: #eef6fb;
+        background: var(--color-brand-600);
+        color: var(--color-brand-50);
         font-size: 13px;
         font-weight: 780;
         cursor: pointer;
     }
 
-    button.primary {
-        border-color: #5eead4;
-        background: #0f766e;
+    button:hover {
+        background: var(--color-brand-700);
+        border-color: var(--color-brand-700);
     }
 
-    .value {
-        font-family: 'SFMono-Regular', Consolas, monospace;
-        font-size: 13px;
-        color: #a9c9cf;
-    }
-
-    .value strong {
-        color: #5eead4;
-    }
-
-    .stage {
-        position: relative;
-        overflow: hidden;
-        border: 1px solid #2b4650;
-        background:
-            linear-gradient(90deg, rgba(94, 234, 212, 0.1) 1px, transparent 1px),
-            linear-gradient(0deg, rgba(94, 234, 212, 0.1) 1px, transparent 1px), #071114;
-        background-size: 44px 44px;
-    }
-
-    .track {
-        position: absolute;
-        inset: 0;
-        display: flex;
-        align-items: center;
-        padding: 0 32px;
-    }
-
-    :global(.card) {
-        width: 150px;
-        min-height: 90px;
-        display: grid;
-        align-content: center;
-        gap: 6px;
-        padding: 0 18px;
-        border-radius: 14px;
-        background: linear-gradient(135deg, #67e8f9, #2dd4bf);
-        color: #031316;
-        box-shadow: 0 22px 80px rgba(45, 212, 191, 0.34);
-    }
-
-    :global(.card small) {
-        font-size: 10px;
-        font-weight: 850;
-        letter-spacing: 0.12em;
-        text-transform: uppercase;
-    }
-
-    :global(.card strong) {
-        font-size: 20px;
-        font-family: 'SFMono-Regular', Consolas, monospace;
+    @media (max-width: 720px) {
+        .row {
+            grid-template-columns: 1fr;
+        }
     }
 </style>

--- a/docs/src/routes/docs/api-reference/+page.svx
+++ b/docs/src/routes/docs/api-reference/+page.svx
@@ -60,6 +60,7 @@ import type {
     AugmentedMotionValue,
     SpringMotionValue,
     UseSpringOptions,
+    WillChangeMotionValue,
 
     // useTransform
     TransformOptions,

--- a/docs/src/routes/docs/use-will-change/+page.svx
+++ b/docs/src/routes/docs/use-will-change/+page.svx
@@ -1,6 +1,6 @@
 ---
 title: 'useWillChange'
-description: 'Auto-managed CSS will-change that promotes an element only while it animates.'
+description: 'Auto-managed CSS will-change that starts at auto and latches to transform after a qualifying animation.'
 ---
 
 <script>
@@ -13,7 +13,7 @@ description: 'Auto-managed CSS will-change that promotes an element only while i
       seo.title = 'useWillChange | Docs | Svelte Motion'
       seo.description = 'A MotionValue for CSS will-change that flips to "transform" only while a transform or accelerated property animates.'
       seo.ogTitle = 'useWillChange'
-      seo.ogTagline = 'Promote only while it animates'
+      seo.ogTagline = 'Promote once it animates, then stay latched'
       seo.ogFeatures = ['MotionValue', 'will-change', 'Performance', 'Motion Parity']
       seo.ogSlug = 'docs-use-will-change'
   }
@@ -26,10 +26,10 @@ description: 'Auto-managed CSS will-change that promotes an element only while i
 or accelerated property animates on that element, then flips to `transform`.
 
 Setting `will-change` permanently forces the browser to keep an element on its
-own compositor layer — which costs memory. `useWillChange` only applies the
-hint while the element is actually animating, then leaves it in place, so you
-get the paint/compositing win without the standing cost. Mirrors
-framer-motion's `useWillChange`.
+own compositor layer — which costs memory. `useWillChange` starts at `auto` and
+flips to `transform` when a transform or accelerated property animates, then
+stays latched — avoiding eager promotion before first use while still capturing
+the compositor win once it's needed. Mirrors framer-motion's `useWillChange`.
 
 ```svelte
 <script lang="ts">

--- a/docs/src/routes/docs/use-will-change/+page.svx
+++ b/docs/src/routes/docs/use-will-change/+page.svx
@@ -1,0 +1,72 @@
+---
+title: 'useWillChange'
+description: 'Auto-managed CSS will-change that promotes an element only while it animates.'
+---
+
+<script>
+  import Example from '$lib/components/general/Example.svelte';
+  import UseWillChangeExample from '$lib/examples/use-will-change/demos/Default.svelte';
+  import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+  const seo = getSeoContext()
+  if (seo) {
+      seo.title = 'useWillChange | Docs | Svelte Motion'
+      seo.description = 'A MotionValue for CSS will-change that flips to "transform" only while a transform or accelerated property animates.'
+      seo.ogTitle = 'useWillChange'
+      seo.ogTagline = 'Promote only while it animates'
+      seo.ogFeatures = ['MotionValue', 'will-change', 'Performance', 'Motion Parity']
+      seo.ogSlug = 'docs-use-will-change'
+  }
+</script>
+
+# useWillChange
+
+`useWillChange()` returns a MotionValue you assign to an element's
+`style.willChange`. It manages its own value: it stays `auto` until a transform
+or accelerated property animates on that element, then flips to `transform`.
+
+Setting `will-change` permanently forces the browser to keep an element on its
+own compositor layer — which costs memory. `useWillChange` only applies the
+hint while the element is actually animating, then leaves it in place, so you
+get the paint/compositing win without the standing cost. Mirrors
+framer-motion's `useWillChange`.
+
+```svelte
+<script lang="ts">
+  import { motion, useWillChange } from '@humanspeak/svelte-motion'
+
+  const willChange = useWillChange()
+</script>
+
+<motion.div style={{ willChange }} animate={{ x: 100 }} />
+```
+
+<Example isSmall exampleUrl="/examples/use-will-change">
+  <UseWillChangeExample />
+</Example>
+
+## How it works
+
+Assign the value through object-form `style`. As animations start, the motion
+runtime notifies the value which keys are animating:
+
+- A transform shortcut (`x`, `y`, `scale`, `rotate`, …) or an accelerated value
+  (e.g. `opacity`) flips `will-change` to `transform`.
+- Any other property (e.g. `backgroundColor`) leaves it at `auto`.
+
+Once flipped, the hint stays `transform` — there's no benefit to thrashing it
+back to `auto` between animations.
+
+## API Reference
+
+### `useWillChange`
+
+```ts
+function useWillChange(): WillChangeMotionValue
+```
+
+Returns a `MotionValue<string>` (so it composes with object-form `style`) with
+an extra `add(name)` method the runtime calls as animations start. Assign it to
+`style.willChange`.
+
+Based on [Motion's useWillChange hook](https://motion.dev/docs/react-use-will-change).

--- a/docs/src/routes/docs/use-will-change/+page.svx
+++ b/docs/src/routes/docs/use-will-change/+page.svx
@@ -11,7 +11,7 @@ description: 'Auto-managed CSS will-change that starts at auto and latches to tr
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'useWillChange | Docs | Svelte Motion'
-      seo.description = 'A MotionValue for CSS will-change that flips to "transform" only while a transform or accelerated property animates.'
+      seo.description = 'A MotionValue for CSS will-change that starts at "auto" and latches to "transform" after the first transform or accelerated animation.'
       seo.ogTitle = 'useWillChange'
       seo.ogTagline = 'Promote once it animates, then stay latched'
       seo.ogFeatures = ['MotionValue', 'will-change', 'Performance', 'Motion Parity']

--- a/docs/src/routes/docs/use-will-change/+page.ts
+++ b/docs/src/routes/docs/use-will-change/+page.ts
@@ -2,5 +2,6 @@ import type { PageLoad } from './$types'
 
 export const load: PageLoad = () => ({
     title: 'useWillChange',
-    description: 'Auto-managed CSS will-change that promotes an element only while it animates.'
+    description:
+        'Auto-managed CSS will-change that starts at auto and latches to transform after a qualifying animation.'
 })

--- a/docs/src/routes/docs/use-will-change/+page.ts
+++ b/docs/src/routes/docs/use-will-change/+page.ts
@@ -1,0 +1,6 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => ({
+    title: 'useWillChange',
+    description: 'Auto-managed CSS will-change that promotes an element only while it animates.'
+})

--- a/docs/src/routes/examples/use-will-change/+page.svelte
+++ b/docs/src/routes/examples/use-will-change/+page.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        type ExampleSection,
+        formatSheetLabel
+    } from '@humanspeak/docs-kit'
+    import { Gauge, Layers, Zap } from '@lucide/svelte'
+    import { demoCodeSample } from '$lib/demo-loaders'
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import UseWillChangeDefault from '$lib/examples/use-will-change/demos/Default.svelte'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'useWillChange' }
+        ]
+    }
+    if (seo) {
+        seo.title = 'useWillChange | Examples | Svelte Motion'
+        seo.description =
+            'Auto-managed CSS will-change that promotes an element only while it animates.'
+        seo.ogTitle = 'useWillChange'
+        seo.ogTagline = 'Promote only while it animates'
+        seo.ogFeatures = ['useWillChange', 'MotionValue', 'will-change', 'Performance']
+        seo.ogSlug = 'examples-use-will-change'
+    }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    const sections: ExampleSection[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'PERFORMANCE',
+            title: { prefix: 'will-change, ', accent: 'only when needed', end: '.' },
+            description:
+                'The card starts at `will-change: auto`. Animating `x` flips it to `transform` so the browser promotes it to its own compositor layer — only while it actually animates.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [
+                { k: 'api', v: 'useWillChange' },
+                { k: 'input', v: 'style={{ willChange }}' },
+                { k: 'mode', v: 'live' }
+            ],
+            sourceUrl: `${SOURCE_URL}use-will-change/demos/Default.svelte`
+        }
+    ]
+</script>
+
+{#snippet defaultSection()}
+    <UseWillChangeDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Gauge />
+            <span>
+                The hook returns a MotionValue assigned to <code>style.willChange</code>, starting
+                at
+                <code>auto</code>.
+            </span>
+        </li>
+        <li>
+            <Zap />
+            <span>
+                When a transform (or accelerated) property animates, the runtime flips the value to
+                <code>transform</code>.
+            </span>
+        </li>
+        <li>
+            <Layers />
+            <span>
+                Non-transform animations (e.g. <code>backgroundColor</code>) leave it at
+                <code>auto</code> — no needless layer promotion.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'use-will-change/demos/Default.svelte',
+                'use-will-change-default',
+                'Default.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel={formatSheetLabel(i, sections.length)}
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/use-will-change/+page.svelte
+++ b/docs/src/routes/examples/use-will-change/+page.svelte
@@ -22,9 +22,9 @@
     if (seo) {
         seo.title = 'useWillChange | Examples | Svelte Motion'
         seo.description =
-            'Auto-managed CSS will-change that promotes an element only while it animates.'
+            'Auto-managed CSS will-change that starts at auto and latches to transform after a qualifying animation.'
         seo.ogTitle = 'useWillChange'
-        seo.ogTagline = 'Promote only while it animates'
+        seo.ogTagline = 'Promote once it animates, then stay latched'
         seo.ogFeatures = ['useWillChange', 'MotionValue', 'will-change', 'Performance']
         seo.ogSlug = 'examples-use-will-change'
     }
@@ -38,7 +38,7 @@
             tag: 'PERFORMANCE',
             title: { prefix: 'will-change, ', accent: 'only when needed', end: '.' },
             description:
-                'The card starts at `will-change: auto`. Animating `x` flips it to `transform` so the browser promotes it to its own compositor layer — only while it actually animates.',
+                'The card starts at `will-change: auto`. Animating `x` flips it to `transform`, promoting it to its own compositor layer; once flipped it stays latched for subsequent animations.',
             snippet: defaultSection,
             codeSnippet: defaultCode,
             notes: defaultNotes,

--- a/docs/src/routes/examples/use-will-change/+page.svelte
+++ b/docs/src/routes/examples/use-will-change/+page.svelte
@@ -38,7 +38,7 @@
             tag: 'PERFORMANCE',
             title: { prefix: 'will-change, ', accent: 'only when needed', end: '.' },
             description:
-                'The card starts at `will-change: auto`. Animating `x` flips it to `transform`, promoting it to its own compositor layer; once flipped it stays latched for subsequent animations.',
+                '`will-change` is an invisible hint — the motion looks identical with or without it, so watch each box’s badge. Both start at `auto`. The left box animates `x` (a transform) and latches to `transform`; the right box animates `backgroundColor` (paint only) and stays at `auto` — no needless layer promotion.',
             snippet: defaultSection,
             codeSnippet: defaultCode,
             notes: defaultNotes,

--- a/e2e/utilities/will-change.spec.ts
+++ b/e2e/utilities/will-change.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const URL = '/tests/will-change?@isPlaywright=true'
+
+const valueText = (page: Page, testId: string) => async () =>
+    (await page.getByTestId(testId).textContent())?.trim() ?? ''
+
+const computedWillChange = (page: Page, testId: string) => async () =>
+    page.getByTestId(testId).evaluate((el) => getComputedStyle(el).willChange)
+
+const waitForMotionReady = async (page: Page, testId: string) => {
+    await expect(page.getByTestId(testId)).toHaveAttribute('data-is-loaded', 'ready')
+}
+
+test.describe('useWillChange (#327)', () => {
+    test('flips will-change to "transform" when a transform prop animates', async ({ page }) => {
+        await page.goto(URL)
+        await waitForMotionReady(page, 'transform-box')
+
+        // Idle: no transform has animated yet.
+        await expect.poll(valueText(page, 'transform-value')).toBe('value: auto')
+        await expect.poll(computedWillChange(page, 'transform-box')).toBe('auto')
+
+        // Animate x → will-change becomes "transform" (MotionValue + DOM).
+        await page.getByTestId('move').click()
+        await expect.poll(valueText(page, 'transform-value')).toBe('value: transform')
+        await expect.poll(computedWillChange(page, 'transform-box')).toBe('transform')
+
+        // One-way latch: returning to x:0 still animates, but will-change stays
+        // "transform" — it never reverts once promoted (matches upstream).
+        await page.getByTestId('move').click()
+        await expect.poll(valueText(page, 'transform-value')).toBe('value: transform')
+        await expect.poll(computedWillChange(page, 'transform-box')).toBe('transform')
+    })
+
+    test('leaves will-change at "auto" for a non-transform animation', async ({ page }) => {
+        await page.goto(URL)
+        await waitForMotionReady(page, 'color-box')
+
+        await expect.poll(valueText(page, 'color-value')).toBe('value: auto')
+
+        // Animating only backgroundColor must not promote the element.
+        await page.getByTestId('recolor').click()
+        await expect.poll(computedWillChange(page, 'color-box')).toBe('auto')
+        await expect.poll(valueText(page, 'color-value')).toBe('value: auto')
+    })
+})

--- a/e2e/utilities/will-change.spec.ts
+++ b/e2e/utilities/will-change.spec.ts
@@ -43,5 +43,36 @@ test.describe('useWillChange (#327)', () => {
         await page.getByTestId('recolor').click()
         await expect.poll(computedWillChange(page, 'color-box')).toBe('auto')
         await expect.poll(valueText(page, 'color-value')).toBe('value: auto')
+
+        // Edge: repeated non-transform animations still must not promote.
+        await page.getByTestId('recolor').click()
+        await expect.poll(computedWillChange(page, 'color-box')).toBe('auto')
+        await expect.poll(valueText(page, 'color-value')).toBe('value: auto')
+    })
+
+    test('flips will-change via imperative animation controls', async ({ page }) => {
+        await page.goto(URL)
+        await waitForMotionReady(page, 'controls-box')
+
+        await expect.poll(valueText(page, 'controls-value')).toBe('value: auto')
+        await expect.poll(computedWillChange(page, 'controls-box')).toBe('auto')
+
+        // controls.start({ x }) animates a transform → will-change becomes "transform".
+        await page.getByTestId('run-controls').click()
+        await expect.poll(valueText(page, 'controls-value')).toBe('value: transform')
+        await expect.poll(computedWillChange(page, 'controls-box')).toBe('transform')
+    })
+
+    test('triggers the transform flip via keyboard activation', async ({ page }) => {
+        await page.goto(URL)
+        await waitForMotionReady(page, 'transform-box')
+
+        await expect.poll(valueText(page, 'transform-value')).toBe('value: auto')
+
+        // The control is a native button — Enter must drive the same animation.
+        await page.getByTestId('move').focus()
+        await page.keyboard.press('Enter')
+        await expect.poll(valueText(page, 'transform-value')).toBe('value: transform')
+        await expect.poll(computedWillChange(page, 'transform-box')).toBe('transform')
     })
 })

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -67,6 +67,7 @@
         mergeInlineStyles,
         serializeMotionStyle
     } from '$lib/utils/style'
+    import { isWillChangeMotionValue } from '$lib/utils/willChange.svelte'
     import { isNativelyFocusable } from '$lib/utils/a11y'
     import {
         getAnimatePresenceContext,
@@ -780,6 +781,24 @@
                 transitionOverride ?? mergeTransitions(mergedTransition ?? {}, transition ?? {}),
             transitionEnd
         }
+    }
+
+    /**
+     * Notify a `useWillChange()` value carried in object-form `style` that the
+     * given keys are animating, so it can promote the element to its own
+     * compositor layer. Mirrors framer-motion wiring the will-change value into
+     * the animation pipeline. `add()` self-filters to transform/accelerated
+     * keys, so passing the full key set is safe.
+     *
+     * @param {string[]} keys The property keys about to animate.
+     */
+    const notifyWillChange = (keys: string[]) => {
+        // Widen to `unknown` first: narrowing the motion-dom `MotionValue` union
+        // directly against `WillChangeMotionValue` collapses to `never` (the
+        // augmented public `current` clashes with the base's private one).
+        const willChange: unknown = collectMotionStyleValues(styleProp)?.willChange
+        if (!isWillChangeMotionValue(willChange)) return
+        for (const key of keys) willChange.add(key)
     }
 
     const applyAnimateRestingStyle = () => {
@@ -1737,6 +1756,8 @@
             payload,
             transitionAnimate
         })
+
+        notifyWillChange(Object.keys(payload as Record<string, unknown>))
 
         // A fresh run owns the transform again until it completes.
         enterAnimationSettled = false

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -1262,6 +1262,10 @@
             svgPathFinished.length > 0 ? stripSVGPathKeyframes(target) : target
         ) as Record<string, unknown>
 
+        // Imperative controls (useAnimationControls/useAnimate) animate transforms
+        // too — notify will-change here just like the declarative path does.
+        notifyWillChange(Object.keys(payload))
+
         const controlsGeneration = ++animationControlsGeneration
         enterAnimationSettled = false
         onAnimationStartProp?.(definition as unknown as DOMKeyframesDefinition)

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -98,6 +98,8 @@ export { useIsPresent, usePresence, usePresenceData } from '$lib/utils/usePresen
 export type { UsePresenceState } from '$lib/utils/usePresence'
 export { useVelocity } from '$lib/utils/velocity.svelte'
 export type { VelocitySource } from '$lib/utils/velocity.svelte'
+export { useWillChange } from '$lib/utils/willChange.svelte'
+export type { WillChangeMotionValue } from '$lib/utils/willChange.svelte'
 /**
  * @deprecated Use `styleString` instead for reactive styles with automatic unit handling.
  */

--- a/src/lib/utils/willChange.svelte.spec.ts
+++ b/src/lib/utils/willChange.svelte.spec.ts
@@ -1,0 +1,83 @@
+import { isMotionValue, motionValue } from 'motion-dom'
+import { afterEach, describe, expect, it } from 'vitest'
+import { isWillChangeMotionValue, useWillChange } from './willChange.svelte.js'
+
+/**
+ * `useWillChange` returns a motion-dom MotionValue (tested upstream for the
+ * value machinery) augmented with an `add()` method that flips `will-change`
+ * from `'auto'` to `'transform'` once a transform or accelerated property
+ * animates. These tests cover that gating logic and the augmentation layer.
+ */
+describe('utils/willChange - useWillChange', () => {
+    let cleanups: VoidFunction[] = []
+
+    afterEach(() => {
+        for (const fn of cleanups) fn()
+        cleanups = []
+    })
+
+    const inRoot = <T>(fn: () => T): T => {
+        let result: T
+        const stop = $effect.root(() => {
+            result = fn()
+        })
+        cleanups.push(stop)
+        return result!
+    }
+
+    it('returns a real MotionValue starting at "auto"', () => {
+        inRoot(() => {
+            const wc = useWillChange()
+            expect(isMotionValue(wc)).toBe(true)
+            expect(wc.get()).toBe('auto')
+            expect(wc.current).toBe('auto')
+        })
+    })
+
+    it('flips to "transform" when a transform prop animates', () => {
+        inRoot(() => {
+            const wc = useWillChange()
+            wc.add('x')
+            expect(wc.get()).toBe('transform')
+            expect(wc.current).toBe('transform')
+        })
+    })
+
+    it('flips to "transform" for accelerated values like opacity', () => {
+        inRoot(() => {
+            const wc = useWillChange()
+            wc.add('opacity')
+            expect(wc.get()).toBe('transform')
+        })
+    })
+
+    it('ignores non-transform, non-accelerated properties', () => {
+        inRoot(() => {
+            const wc = useWillChange()
+            wc.add('backgroundColor')
+            wc.add('borderRadius')
+            expect(wc.get()).toBe('auto')
+        })
+    })
+
+    it('stays enabled once a transform animates (idempotent)', () => {
+        inRoot(() => {
+            const wc = useWillChange()
+            wc.add('scale')
+            expect(wc.get()).toBe('transform')
+            // A later non-transform key must not reset the hint.
+            wc.add('backgroundColor')
+            expect(wc.get()).toBe('transform')
+        })
+    })
+
+    it('isWillChangeMotionValue detects the hook value, rejects plain values', () => {
+        inRoot(() => {
+            const wc = useWillChange()
+            expect(isWillChangeMotionValue(wc)).toBe(true)
+            expect(isWillChangeMotionValue(motionValue('auto'))).toBe(false)
+            expect(isWillChangeMotionValue(null)).toBe(false)
+            expect(isWillChangeMotionValue('transform')).toBe(false)
+        })
+    })
+})

--- a/src/lib/utils/willChange.svelte.ts
+++ b/src/lib/utils/willChange.svelte.ts
@@ -31,6 +31,13 @@ export type WillChangeMotionValue = AugmentedMotionValue<string> & {
  *
  * @param value Any value to test.
  * @returns Whether `value` is a will-change MotionValue.
+ *
+ * @example
+ * ```ts
+ * const willChange = useWillChange()
+ * isWillChangeMotionValue(willChange) // true
+ * isWillChangeMotionValue(motionValue('auto')) // false
+ * ```
  */
 export const isWillChangeMotionValue = (value: unknown): value is WillChangeMotionValue =>
     !!value && typeof (value as { add?: unknown }).add === 'function'

--- a/src/lib/utils/willChange.svelte.ts
+++ b/src/lib/utils/willChange.svelte.ts
@@ -1,0 +1,85 @@
+import { acceleratedValues, motionValue, transformProps } from 'motion-dom'
+import { augmentMotionValue, type AugmentedMotionValue } from './augmentMotionValue.svelte.js'
+
+/**
+ * A `MotionValue<string>` for the CSS `will-change` property that manages its
+ * own value: it stays `'auto'` until a transform or otherwise GPU-accelerated
+ * property animates, then flips to `'transform'`.
+ *
+ * Returned by {@link useWillChange}. Assign it to an element's
+ * `style.willChange` (object-form `style`) so the hint is written to the DOM,
+ * and the motion runtime calls {@link WillChangeMotionValue.add} for you as
+ * animations start.
+ *
+ * @see https://motion.dev/docs/react-use-will-change
+ */
+export type WillChangeMotionValue = AugmentedMotionValue<string> & {
+    /**
+     * Notify the value that `name` is animating. If `name` is a transform
+     * shortcut (`x`, `scale`, `rotate`, …) or an accelerated value
+     * (e.g. `opacity`), `will-change` flips to `'transform'`. Other property
+     * names are ignored. Idempotent once enabled.
+     *
+     * @param name The animating property/value key.
+     */
+    add: (name: string) => void
+}
+
+/**
+ * Detect a {@link WillChangeMotionValue} — a MotionValue carrying the
+ * auto-managing `add` method — so the runtime can opt into notifying it.
+ *
+ * @param value Any value to test.
+ * @returns Whether `value` is a will-change MotionValue.
+ */
+export const isWillChangeMotionValue = (value: unknown): value is WillChangeMotionValue =>
+    !!value && typeof (value as { add?: unknown }).add === 'function'
+
+/**
+ * Creates an auto-managed CSS `will-change` MotionValue.
+ *
+ * The returned value starts at `'auto'` and becomes `'transform'` once a
+ * transform or accelerated property animates on the element it is attached to,
+ * mirroring framer-motion's `useWillChange`. Promoting the element to its own
+ * compositor layer only while it animates avoids the memory cost of a
+ * permanent `will-change` hint.
+ *
+ * Assign the value to an element via object-form `style`; the motion runtime
+ * notifies it as animations start, and the same MotionValue writes the hint to
+ * the DOM.
+ *
+ * Lifecycle: call during component initialization. The underlying MotionValue
+ * is destroyed via `$effect` cleanup when the surrounding component tears down.
+ *
+ * @returns A {@link WillChangeMotionValue} for `style.willChange`.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { motion, useWillChange } from '@humanspeak/svelte-motion'
+ *
+ *   const willChange = useWillChange()
+ * </script>
+ *
+ * <motion.div style={{ willChange }} animate={{ x: 100 }} />
+ * ```
+ *
+ * @see https://motion.dev/docs/react-use-will-change
+ */
+export const useWillChange = (): WillChangeMotionValue => {
+    const value = motionValue<string>('auto')
+    $effect(() => () => value.destroy())
+
+    const willChange = augmentMotionValue(value) as WillChangeMotionValue
+    let isEnabled = false
+
+    willChange.add = (name: string) => {
+        if (isEnabled) return
+        if (transformProps.has(name) || acceleratedValues.has(name)) {
+            isEnabled = true
+            willChange.set('transform')
+        }
+    }
+
+    return willChange
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -88,6 +88,14 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/will-change') + searchParams}
+                    >
+                        useWillChange
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/layout-dependency') + searchParams}
                     >
                         layoutDependency

--- a/src/routes/tests/will-change/+page.svelte
+++ b/src/routes/tests/will-change/+page.svelte
@@ -1,0 +1,235 @@
+<script lang="ts">
+    import { motion, useWillChange } from '$lib'
+
+    // Auto-managed will-change: starts "auto", flips to "transform" once a
+    // transform/accelerated prop animates on the element it's attached to.
+    const transformWillChange = useWillChange()
+    const colorWillChange = useWillChange()
+
+    let started = $state(false)
+    let moved = $state(false)
+    let recolored = $state(false)
+
+    // Stay at "auto" (no transform key) until the first interaction, then
+    // toggle x back and forth so the box animates both directions. will-change
+    // latches to "transform" on the first animation and stays there (upstream
+    // useWillChange is one-way).
+    const transformTarget = $derived(started ? { x: moved ? 220 : 0 } : {})
+
+    const toggleMove = () => {
+        started = true
+        moved = !moved
+    }
+</script>
+
+<svelte:head>
+    <title>useWillChange</title>
+</svelte:head>
+
+<main>
+    <section class="intro">
+        <p class="kicker">useWillChange (#327)</p>
+        <h1>Promote only while it animates.</h1>
+        <p>
+            <code>useWillChange()</code> returns a MotionValue you assign to
+            <code>style.willChange</code>. It stays <code>auto</code> until a transform or
+            accelerated property animates, then flips to <code>transform</code> — so the element only
+            gets its own compositor layer while it actually needs one.
+        </p>
+    </section>
+
+    <section class="grid">
+        <article>
+            <h2>Transform animation</h2>
+            <p class="expectation">
+                Animating <code>x</code> flips will-change to <code>transform</code>. It
+                <strong>stays</strong> <code>transform</code> after the first animation — useWillChange
+                is a one-way latch (matches upstream).
+            </p>
+            <p class="readout" data-testid="transform-value">
+                value: {transformWillChange.current}
+            </p>
+            <div class="track">
+                <motion.div
+                    class="orb cyan"
+                    data-testid="transform-box"
+                    style={{ willChange: transformWillChange }}
+                    initial={false}
+                    animate={transformTarget}
+                    transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+                >
+                    T
+                </motion.div>
+            </div>
+            <button type="button" data-testid="move" onclick={toggleMove}>
+                {moved ? 'Return' : 'Animate x'}
+            </button>
+        </article>
+
+        <article>
+            <h2>Non-transform animation</h2>
+            <p class="expectation">
+                Animating only <code>backgroundColor</code> leaves will-change at
+                <code>auto</code>.
+            </p>
+            <p class="readout" data-testid="color-value">value: {colorWillChange.current}</p>
+            <div class="track">
+                <motion.div
+                    class="orb"
+                    data-testid="color-box"
+                    style={{ willChange: colorWillChange }}
+                    initial={false}
+                    animate={{ backgroundColor: recolored ? '#f0abfc' : '#67e8f9' }}
+                    transition={{ duration: 0.5 }}
+                >
+                    C
+                </motion.div>
+            </div>
+            <button type="button" data-testid="recolor" onclick={() => (recolored = !recolored)}>
+                {recolored ? 'Reset' : 'Animate color'}
+            </button>
+        </article>
+    </section>
+</main>
+
+<style>
+    :global(html),
+    :global(body) {
+        background: #071012;
+        color: #ecfdf5;
+        font-family:
+            Inter,
+            ui-sans-serif,
+            system-ui,
+            -apple-system,
+            BlinkMacSystemFont,
+            'Segoe UI',
+            sans-serif;
+    }
+
+    main {
+        min-height: 100vh;
+        width: min(1000px, calc(100vw - 32px));
+        display: grid;
+        align-content: center;
+        gap: 28px;
+        margin: 0 auto;
+        padding: 48px 0;
+    }
+
+    .intro {
+        max-width: 720px;
+    }
+
+    .kicker {
+        margin: 0 0 8px;
+        color: #67e8f9;
+        font-size: 13px;
+        font-weight: 850;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    h1 {
+        margin: 0;
+        font-size: clamp(34px, 5vw, 56px);
+        line-height: 0.95;
+    }
+
+    .intro p:not(.kicker) {
+        margin: 14px 0 0;
+        color: #b7d4d8;
+        font-size: 16px;
+        line-height: 1.65;
+    }
+
+    code {
+        color: #f0abfc;
+    }
+
+    .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 18px;
+    }
+
+    article {
+        display: grid;
+        align-content: start;
+        gap: 14px;
+        padding: 24px;
+        border: 1px solid rgba(125, 211, 252, 0.3);
+        background: #0b171a;
+        overflow: hidden;
+    }
+
+    h2 {
+        margin: 0;
+        color: #dff8ff;
+        font-size: 18px;
+    }
+
+    .expectation {
+        margin: 0;
+        color: #a9c9cf;
+        font-size: 13px;
+        line-height: 1.45;
+    }
+
+    .readout {
+        margin: 0;
+        color: #67e8f9;
+        font-family: 'SFMono-Regular', Consolas, monospace;
+        font-size: 15px;
+        font-weight: 800;
+    }
+
+    .track {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        padding: 12px;
+        border: 1px dashed rgba(125, 211, 252, 0.24);
+        min-height: 120px;
+    }
+
+    :global(.orb) {
+        width: 88px;
+        height: 88px;
+        display: grid;
+        place-items: center;
+        border-radius: 22px;
+        background: #67e8f9;
+        color: #031316;
+        font-size: 22px;
+        font-weight: 900;
+    }
+
+    :global(.orb.cyan) {
+        background: linear-gradient(135deg, #67e8f9, #2dd4bf);
+    }
+
+    button {
+        justify-self: start;
+        min-width: 120px;
+        border: 1px solid rgba(125, 211, 252, 0.45);
+        border-radius: 6px;
+        background: #102332;
+        color: #ecfeff;
+        padding: 10px 14px;
+        font: inherit;
+        font-weight: 850;
+        cursor: pointer;
+    }
+
+    button:hover {
+        border-color: #67e8f9;
+        background: #153247;
+    }
+
+    @media (max-width: 760px) {
+        .grid {
+            grid-template-columns: 1fr;
+        }
+    }
+</style>

--- a/src/routes/tests/will-change/+page.svelte
+++ b/src/routes/tests/will-change/+page.svelte
@@ -1,10 +1,20 @@
 <script lang="ts">
-    import { motion, useWillChange } from '$lib'
+    import { motion, useAnimationControls, useWillChange } from '$lib'
 
     // Auto-managed will-change: starts "auto", flips to "transform" once a
     // transform/accelerated prop animates on the element it's attached to.
     const transformWillChange = useWillChange()
     const colorWillChange = useWillChange()
+    const controlsWillChange = useWillChange()
+
+    // Imperative animation controls path: animating a transform via
+    // controls.start() should flip will-change just like declarative animate.
+    const controls = useAnimationControls()
+    let controlsMoved = false
+    const runControls = () => {
+        controlsMoved = !controlsMoved
+        controls.start({ x: controlsMoved ? 220 : 0 }, { duration: 0.5 })
+    }
 
     let started = $state(false)
     let moved = $state(false)
@@ -87,6 +97,31 @@
             </div>
             <button type="button" data-testid="recolor" onclick={() => (recolored = !recolored)}>
                 {recolored ? 'Reset' : 'Animate color'}
+            </button>
+        </article>
+
+        <article>
+            <h2>Imperative controls</h2>
+            <p class="expectation">
+                Animating <code>x</code> through <code>useAnimationControls()</code> flips
+                will-change to <code>transform</code> too.
+            </p>
+            <p class="readout" data-testid="controls-value">
+                value: {controlsWillChange.current}
+            </p>
+            <div class="track">
+                <motion.div
+                    class="orb cyan"
+                    data-testid="controls-box"
+                    style={{ willChange: controlsWillChange }}
+                    initial={false}
+                    animate={controls}
+                >
+                    I
+                </motion.div>
+            </div>
+            <button type="button" data-testid="run-controls" onclick={runControls}>
+                Run controls
             </button>
         </article>
     </section>


### PR DESCRIPTION
## Summary

Adds `useWillChange` (#327) — a Framer Motion–compatible hook returning a
`MotionValue` for `style.willChange`. It starts at `auto` and **latches** to
`transform` the first time a transform or accelerated property animates on the
attached element, promoting it to its own compositor layer only once it's
needed (the latch is one-way, matching upstream). Wired into both the
declarative `animate` path and the imperative `useAnimationControls`/`useAnimate`
controls path. Gesture coverage (whileHover/tap/focus/pan) is intentionally
deferred as a follow-up.

## Changes

✨ **New feature**
- `useWillChange()` + `WillChangeMotionValue` (and `isWillChangeMotionValue`),
  exported from the package; faithful to framer-motion's one-way latch.
- `_MotionContainer`: `notifyWillChange` flips the attached value when a
  transform/accelerated key animates — covers the declarative `animate` path
  **and** the imperative controls path.

🧪 **Testing**
- Unit coverage for the latch + type guard.
- Playwright e2e: the flip, the one-way latch on return, non-transform
  animations never promoting (incl. repeated toggle), the imperative
  controls path, and keyboard (Enter) activation.

📚 **Docs & demo**
- `/docs/use-will-change` page + `/examples/use-will-change` with a
  **theme-aware** two-box demo (transform promotes → `transform`; paint stays
  `auto`), nav entry, and `WillChangeMotionValue` added to the API reference.
- Demo built on the `--color-brand-*` scale with `html.dark` overrides so it
  reads correctly in light and dark; explanatory copy lives in the example
  frame's themed description/notes rather than inside the demo.

## Commits

- [`76e3da4`](https://github.com/humanspeak/svelte-motion/commit/76e3da42c71a36f7da523b80d4916512496be019) feat(motion-values): add useWillChange hook (#327)
- [`6cf49df`](https://github.com/humanspeak/svelte-motion/commit/6cf49dff68ed7c6bf0931fc22fb4e7ba6fbff972) fix(motion-values): cover controls path and clarify latch in useWillChange
- [`4d205d7`](https://github.com/humanspeak/svelte-motion/commit/4d205d79299960e4a9a109b7ef993ef089e0e483) docs(use-will-change): theme-aware two-box demo + api-reference type

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)
