### PR TITLE
fix(html): default ref to $bindable() so bind:ref={$state()} works

### DIFF
--- a/scripts/_template.template
+++ b/scripts/_template.template
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/scripts/_template_void.template
+++ b/scripts/_template_void.template
@@ -2,7 +2,7 @@
     import MotionContainer from '$lib/html/_MotionContainer.svelte'
     import type { HTMLVoidElementProps } from '$lib/types'
 
-    let { ref = $bindable(null), ...rest }: HTMLVoidElementProps = $props()
+    let { ref = $bindable(), ...rest }: HTMLVoidElementProps = $props()
 </script>
 
 <MotionContainer bind:ref tag="{{tag}}" {...rest} />

--- a/src/lib/__tests__/flushTimers.ts
+++ b/src/lib/__tests__/flushTimers.ts
@@ -1,0 +1,35 @@
+import { tick } from 'svelte'
+import { vi } from 'vitest'
+
+/**
+ * Drains the async work that motion components schedule during mount and
+ * updates so assertions run against a settled DOM.
+ *
+ * Specs that mount motion elements stub `requestAnimationFrame` onto fake
+ * timers, so the RAF callbacks that promote a component from `mounting` →
+ * `ready` (and the chained promises/Svelte updates they kick off) only run
+ * once flushed. This helper unwinds all three layers in order:
+ *
+ * 1. `vi.runAllTimers()` — fire queued RAF/`setTimeout` callbacks.
+ * 2. two microtask turns — drain the promise chains those callbacks start
+ *    (the second turn settles promises that were themselves awaited).
+ * 3. `await tick()` — let Svelte apply the resulting reactive DOM updates.
+ *
+ * Shared by the motion specs that previously each declared their own copy
+ * (`_MotionContainer`, `LazyMotion`, `refBind`).
+ *
+ * @returns A promise that resolves once queued timers, microtasks, and Svelte
+ *   DOM updates have settled.
+ * @example
+ * ```ts
+ * render(MotionDiv, { props })
+ * await flushTimers()
+ * expect(container.firstElementChild).toBeTruthy()
+ * ```
+ */
+export async function flushTimers(): Promise<void> {
+    vi.runAllTimers()
+    await Promise.resolve()
+    await Promise.resolve()
+    await tick()
+}

--- a/src/lib/components/LazyMotion.spec.ts
+++ b/src/lib/components/LazyMotion.spec.ts
@@ -1,6 +1,6 @@
 import { domAnimation, domMin } from '$lib'
+import { flushTimers } from '$lib/__tests__/flushTimers'
 import { render, screen } from '@testing-library/svelte'
-import { tick } from 'svelte'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import LazyMotionProbe from './__tests__/LazyMotionProbe.svelte'
 
@@ -21,13 +21,6 @@ afterEach(() => {
     vi.useRealTimers()
     vi.unstubAllGlobals()
 })
-
-const flushTimers = async () => {
-    vi.runAllTimers()
-    await Promise.resolve()
-    await Promise.resolve()
-    await tick()
-}
 
 const createDeferred = <T>() => {
     let resolve!: (value: T) => void

--- a/src/lib/html/A.svelte
+++ b/src/lib/html/A.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Abbr.svelte
+++ b/src/lib/html/Abbr.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Address.svelte
+++ b/src/lib/html/Address.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Animate.svelte
+++ b/src/lib/html/Animate.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Animatemotion.svelte
+++ b/src/lib/html/Animatemotion.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Animatetransform.svelte
+++ b/src/lib/html/Animatetransform.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Area.svelte
+++ b/src/lib/html/Area.svelte
@@ -2,7 +2,7 @@
     import MotionContainer from '$lib/html/_MotionContainer.svelte'
     import type { HTMLVoidElementProps } from '$lib/types'
 
-    let { ref = $bindable(null), ...rest }: HTMLVoidElementProps = $props()
+    let { ref = $bindable(), ...rest }: HTMLVoidElementProps = $props()
 </script>
 
 <MotionContainer bind:ref tag="area" {...rest} />

--- a/src/lib/html/Article.svelte
+++ b/src/lib/html/Article.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Aside.svelte
+++ b/src/lib/html/Aside.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Audio.svelte
+++ b/src/lib/html/Audio.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/B.svelte
+++ b/src/lib/html/B.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Base.svelte
+++ b/src/lib/html/Base.svelte
@@ -2,7 +2,7 @@
     import MotionContainer from '$lib/html/_MotionContainer.svelte'
     import type { HTMLVoidElementProps } from '$lib/types'
 
-    let { ref = $bindable(null), ...rest }: HTMLVoidElementProps = $props()
+    let { ref = $bindable(), ...rest }: HTMLVoidElementProps = $props()
 </script>
 
 <MotionContainer bind:ref tag="base" {...rest} />

--- a/src/lib/html/Bdi.svelte
+++ b/src/lib/html/Bdi.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Bdo.svelte
+++ b/src/lib/html/Bdo.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Blockquote.svelte
+++ b/src/lib/html/Blockquote.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Br.svelte
+++ b/src/lib/html/Br.svelte
@@ -2,7 +2,7 @@
     import MotionContainer from '$lib/html/_MotionContainer.svelte'
     import type { HTMLVoidElementProps } from '$lib/types'
 
-    let { ref = $bindable(null), ...rest }: HTMLVoidElementProps = $props()
+    let { ref = $bindable(), ...rest }: HTMLVoidElementProps = $props()
 </script>
 
 <MotionContainer bind:ref tag="br" {...rest} />

--- a/src/lib/html/Button.svelte
+++ b/src/lib/html/Button.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Canvas.svelte
+++ b/src/lib/html/Canvas.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Caption.svelte
+++ b/src/lib/html/Caption.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Circle.svelte
+++ b/src/lib/html/Circle.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Cite.svelte
+++ b/src/lib/html/Cite.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Clippath.svelte
+++ b/src/lib/html/Clippath.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Code.svelte
+++ b/src/lib/html/Code.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Col.svelte
+++ b/src/lib/html/Col.svelte
@@ -2,7 +2,7 @@
     import MotionContainer from '$lib/html/_MotionContainer.svelte'
     import type { HTMLVoidElementProps } from '$lib/types'
 
-    let { ref = $bindable(null), ...rest }: HTMLVoidElementProps = $props()
+    let { ref = $bindable(), ...rest }: HTMLVoidElementProps = $props()
 </script>
 
 <MotionContainer bind:ref tag="col" {...rest} />

--- a/src/lib/html/Colgroup.svelte
+++ b/src/lib/html/Colgroup.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Cursor.svelte
+++ b/src/lib/html/Cursor.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Data.svelte
+++ b/src/lib/html/Data.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Datalist.svelte
+++ b/src/lib/html/Datalist.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Dd.svelte
+++ b/src/lib/html/Dd.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Defs.svelte
+++ b/src/lib/html/Defs.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Del.svelte
+++ b/src/lib/html/Del.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Desc.svelte
+++ b/src/lib/html/Desc.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Details.svelte
+++ b/src/lib/html/Details.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Dfn.svelte
+++ b/src/lib/html/Dfn.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Dialog.svelte
+++ b/src/lib/html/Dialog.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Div.svelte
+++ b/src/lib/html/Div.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Dl.svelte
+++ b/src/lib/html/Dl.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Dt.svelte
+++ b/src/lib/html/Dt.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Ellipse.svelte
+++ b/src/lib/html/Ellipse.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Em.svelte
+++ b/src/lib/html/Em.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Embed.svelte
+++ b/src/lib/html/Embed.svelte
@@ -2,7 +2,7 @@
     import MotionContainer from '$lib/html/_MotionContainer.svelte'
     import type { HTMLVoidElementProps } from '$lib/types'
 
-    let { ref = $bindable(null), ...rest }: HTMLVoidElementProps = $props()
+    let { ref = $bindable(), ...rest }: HTMLVoidElementProps = $props()
 </script>
 
 <MotionContainer bind:ref tag="embed" {...rest} />

--- a/src/lib/html/Feblend.svelte
+++ b/src/lib/html/Feblend.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fecolormatrix.svelte
+++ b/src/lib/html/Fecolormatrix.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fecomponenttransfer.svelte
+++ b/src/lib/html/Fecomponenttransfer.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fecomposite.svelte
+++ b/src/lib/html/Fecomposite.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Feconvolvematrix.svelte
+++ b/src/lib/html/Feconvolvematrix.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fediffuselighting.svelte
+++ b/src/lib/html/Fediffuselighting.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fedisplacementmap.svelte
+++ b/src/lib/html/Fedisplacementmap.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fedistantlight.svelte
+++ b/src/lib/html/Fedistantlight.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Feflood.svelte
+++ b/src/lib/html/Feflood.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fefunca.svelte
+++ b/src/lib/html/Fefunca.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fefuncb.svelte
+++ b/src/lib/html/Fefuncb.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fefuncg.svelte
+++ b/src/lib/html/Fefuncg.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fefuncr.svelte
+++ b/src/lib/html/Fefuncr.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fegaussianblur.svelte
+++ b/src/lib/html/Fegaussianblur.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Feimage.svelte
+++ b/src/lib/html/Feimage.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Femerge.svelte
+++ b/src/lib/html/Femerge.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Femergenode.svelte
+++ b/src/lib/html/Femergenode.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Femorphology.svelte
+++ b/src/lib/html/Femorphology.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Feoffset.svelte
+++ b/src/lib/html/Feoffset.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fepointlight.svelte
+++ b/src/lib/html/Fepointlight.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fespecularlighting.svelte
+++ b/src/lib/html/Fespecularlighting.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fespotlight.svelte
+++ b/src/lib/html/Fespotlight.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fetile.svelte
+++ b/src/lib/html/Fetile.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Feturbulence.svelte
+++ b/src/lib/html/Feturbulence.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Fieldset.svelte
+++ b/src/lib/html/Fieldset.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Figcaption.svelte
+++ b/src/lib/html/Figcaption.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Figure.svelte
+++ b/src/lib/html/Figure.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Filter.svelte
+++ b/src/lib/html/Filter.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Footer.svelte
+++ b/src/lib/html/Footer.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Foreignobject.svelte
+++ b/src/lib/html/Foreignobject.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Form.svelte
+++ b/src/lib/html/Form.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/G.svelte
+++ b/src/lib/html/G.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/H1.svelte
+++ b/src/lib/html/H1.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/H2.svelte
+++ b/src/lib/html/H2.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/H3.svelte
+++ b/src/lib/html/H3.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/H4.svelte
+++ b/src/lib/html/H4.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/H5.svelte
+++ b/src/lib/html/H5.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/H6.svelte
+++ b/src/lib/html/H6.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Header.svelte
+++ b/src/lib/html/Header.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Hgroup.svelte
+++ b/src/lib/html/Hgroup.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Hr.svelte
+++ b/src/lib/html/Hr.svelte
@@ -2,7 +2,7 @@
     import MotionContainer from '$lib/html/_MotionContainer.svelte'
     import type { HTMLVoidElementProps } from '$lib/types'
 
-    let { ref = $bindable(null), ...rest }: HTMLVoidElementProps = $props()
+    let { ref = $bindable(), ...rest }: HTMLVoidElementProps = $props()
 </script>
 
 <MotionContainer bind:ref tag="hr" {...rest} />

--- a/src/lib/html/I.svelte
+++ b/src/lib/html/I.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Iframe.svelte
+++ b/src/lib/html/Iframe.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Image.svelte
+++ b/src/lib/html/Image.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Img.svelte
+++ b/src/lib/html/Img.svelte
@@ -2,7 +2,7 @@
     import MotionContainer from '$lib/html/_MotionContainer.svelte'
     import type { HTMLVoidElementProps } from '$lib/types'
 
-    let { ref = $bindable(null), ...rest }: HTMLVoidElementProps = $props()
+    let { ref = $bindable(), ...rest }: HTMLVoidElementProps = $props()
 </script>
 
 <MotionContainer bind:ref tag="img" {...rest} />

--- a/src/lib/html/Input.svelte
+++ b/src/lib/html/Input.svelte
@@ -2,7 +2,7 @@
     import MotionContainer from '$lib/html/_MotionContainer.svelte'
     import type { HTMLVoidElementProps } from '$lib/types'
 
-    let { ref = $bindable(null), ...rest }: HTMLVoidElementProps = $props()
+    let { ref = $bindable(), ...rest }: HTMLVoidElementProps = $props()
 </script>
 
 <MotionContainer bind:ref tag="input" {...rest} />

--- a/src/lib/html/Ins.svelte
+++ b/src/lib/html/Ins.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Kbd.svelte
+++ b/src/lib/html/Kbd.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Label.svelte
+++ b/src/lib/html/Label.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Legend.svelte
+++ b/src/lib/html/Legend.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Li.svelte
+++ b/src/lib/html/Li.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Line.svelte
+++ b/src/lib/html/Line.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Lineargradient.svelte
+++ b/src/lib/html/Lineargradient.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Main.svelte
+++ b/src/lib/html/Main.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Map.svelte
+++ b/src/lib/html/Map.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Mark.svelte
+++ b/src/lib/html/Mark.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Marker.svelte
+++ b/src/lib/html/Marker.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Mask.svelte
+++ b/src/lib/html/Mask.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Math.svelte
+++ b/src/lib/html/Math.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Menu.svelte
+++ b/src/lib/html/Menu.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Metadata.svelte
+++ b/src/lib/html/Metadata.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Meter.svelte
+++ b/src/lib/html/Meter.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Mpath.svelte
+++ b/src/lib/html/Mpath.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Nav.svelte
+++ b/src/lib/html/Nav.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Noscript.svelte
+++ b/src/lib/html/Noscript.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Object.svelte
+++ b/src/lib/html/Object.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Ol.svelte
+++ b/src/lib/html/Ol.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Optgroup.svelte
+++ b/src/lib/html/Optgroup.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Option.svelte
+++ b/src/lib/html/Option.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Output.svelte
+++ b/src/lib/html/Output.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/P.svelte
+++ b/src/lib/html/P.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Path.svelte
+++ b/src/lib/html/Path.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Pattern.svelte
+++ b/src/lib/html/Pattern.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Picture.svelte
+++ b/src/lib/html/Picture.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Polygon.svelte
+++ b/src/lib/html/Polygon.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Polyline.svelte
+++ b/src/lib/html/Polyline.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Pre.svelte
+++ b/src/lib/html/Pre.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Progress.svelte
+++ b/src/lib/html/Progress.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Q.svelte
+++ b/src/lib/html/Q.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Radialgradient.svelte
+++ b/src/lib/html/Radialgradient.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Rect.svelte
+++ b/src/lib/html/Rect.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Rp.svelte
+++ b/src/lib/html/Rp.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Rt.svelte
+++ b/src/lib/html/Rt.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Ruby.svelte
+++ b/src/lib/html/Ruby.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/S.svelte
+++ b/src/lib/html/S.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Samp.svelte
+++ b/src/lib/html/Samp.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Script.svelte
+++ b/src/lib/html/Script.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Search.svelte
+++ b/src/lib/html/Search.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Section.svelte
+++ b/src/lib/html/Section.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Select.svelte
+++ b/src/lib/html/Select.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Selectedcontent.svelte
+++ b/src/lib/html/Selectedcontent.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/SetElement.svelte
+++ b/src/lib/html/SetElement.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Slot.svelte
+++ b/src/lib/html/Slot.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Small.svelte
+++ b/src/lib/html/Small.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Source.svelte
+++ b/src/lib/html/Source.svelte
@@ -2,7 +2,7 @@
     import MotionContainer from '$lib/html/_MotionContainer.svelte'
     import type { HTMLVoidElementProps } from '$lib/types'
 
-    let { ref = $bindable(null), ...rest }: HTMLVoidElementProps = $props()
+    let { ref = $bindable(), ...rest }: HTMLVoidElementProps = $props()
 </script>
 
 <MotionContainer bind:ref tag="source" {...rest} />

--- a/src/lib/html/Span.svelte
+++ b/src/lib/html/Span.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Stop.svelte
+++ b/src/lib/html/Stop.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Strong.svelte
+++ b/src/lib/html/Strong.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Style.svelte
+++ b/src/lib/html/Style.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Sub.svelte
+++ b/src/lib/html/Sub.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Summary.svelte
+++ b/src/lib/html/Summary.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Sup.svelte
+++ b/src/lib/html/Sup.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Svg.svelte
+++ b/src/lib/html/Svg.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Switch.svelte
+++ b/src/lib/html/Switch.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Symbol.svelte
+++ b/src/lib/html/Symbol.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Table.svelte
+++ b/src/lib/html/Table.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Tbody.svelte
+++ b/src/lib/html/Tbody.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Td.svelte
+++ b/src/lib/html/Td.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Template.svelte
+++ b/src/lib/html/Template.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Text.svelte
+++ b/src/lib/html/Text.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Textarea.svelte
+++ b/src/lib/html/Textarea.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Textpath.svelte
+++ b/src/lib/html/Textpath.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Tfoot.svelte
+++ b/src/lib/html/Tfoot.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Th.svelte
+++ b/src/lib/html/Th.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Thead.svelte
+++ b/src/lib/html/Thead.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Time.svelte
+++ b/src/lib/html/Time.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Title.svelte
+++ b/src/lib/html/Title.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Tr.svelte
+++ b/src/lib/html/Tr.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Track.svelte
+++ b/src/lib/html/Track.svelte
@@ -2,7 +2,7 @@
     import MotionContainer from '$lib/html/_MotionContainer.svelte'
     import type { HTMLVoidElementProps } from '$lib/types'
 
-    let { ref = $bindable(null), ...rest }: HTMLVoidElementProps = $props()
+    let { ref = $bindable(), ...rest }: HTMLVoidElementProps = $props()
 </script>
 
 <MotionContainer bind:ref tag="track" {...rest} />

--- a/src/lib/html/Tref.svelte
+++ b/src/lib/html/Tref.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Tspan.svelte
+++ b/src/lib/html/Tspan.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/U.svelte
+++ b/src/lib/html/U.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Ul.svelte
+++ b/src/lib/html/Ul.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Use.svelte
+++ b/src/lib/html/Use.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Var.svelte
+++ b/src/lib/html/Var.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Video.svelte
+++ b/src/lib/html/Video.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/View.svelte
+++ b/src/lib/html/View.svelte
@@ -3,7 +3,7 @@
     import type { HTMLElementProps } from '$lib/types'
     import { isMotionValueChild } from '$lib/utils/motionValueChild'
 
-    let { children, ref = $bindable(null), ...rest }: HTMLElementProps = $props()
+    let { children, ref = $bindable(), ...rest }: HTMLElementProps = $props()
     const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
     const childSnippet = $derived(typeof children === 'function' ? children : undefined)
 </script>

--- a/src/lib/html/Wbr.svelte
+++ b/src/lib/html/Wbr.svelte
@@ -2,7 +2,7 @@
     import MotionContainer from '$lib/html/_MotionContainer.svelte'
     import type { HTMLVoidElementProps } from '$lib/types'
 
-    let { ref = $bindable(null), ...rest }: HTMLVoidElementProps = $props()
+    let { ref = $bindable(), ...rest }: HTMLVoidElementProps = $props()
 </script>
 
 <MotionContainer bind:ref tag="wbr" {...rest} />

--- a/src/lib/html/_MotionContainer.spec.ts
+++ b/src/lib/html/_MotionContainer.spec.ts
@@ -1,3 +1,4 @@
+import { flushTimers } from '$lib/__tests__/flushTimers'
 import { animationControls } from '$lib/utils/animationControls.svelte'
 import { fireEvent, render } from '@testing-library/svelte'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -63,13 +64,6 @@ beforeEach(() => {
 afterEach(() => {
     vi.unstubAllGlobals()
 })
-
-async function flushTimers() {
-    // Run any queued RAF timeouts
-    vi.runAllTimers()
-    // Flush microtasks
-    await Promise.resolve()
-}
 
 describe('_MotionContainer', () => {
     it('does not add tabindex when element is natively focusable', async () => {

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -195,9 +195,31 @@
         layoutScroll: layoutScrollProp,
         layoutDependency: layoutDependencyProp,
         onProjectionUpdate: onProjectionUpdateProp,
-        ref: element = $bindable(null),
+        // trunk-ignore(eslint/no-useless-assignment): `ref` is write-only here — mirrored from the internal `element` node via the effect below
+        ref = $bindable(),
         ...rest
     }: Props = $props()
+    // The public `ref` bindable defaults to `undefined` so consumers can bind a
+    // freshly-declared `$state()` (the idiomatic element ref, initially
+    // `undefined`) without tripping Svelte's `props_invalid_value` (#417).
+    //
+    // Internally we keep a separate `element` ref that defaults to `null`. The
+    // animate effects below rely on the exact reactive update timing of this
+    // node going `null → element`; defaulting it to `undefined` instead subtly
+    // reorders effect runs and breaks re-running animations on prop change. We
+    // therefore decouple the internal node from the public bindable and mirror
+    // one into the other.
+    let element = $state<HTMLElement | null>(null)
+    $effect(() => {
+        ref = element
+        // Reset on teardown so `bind:ref` consumers see `null` when the element
+        // unmounts (matching native `bind:this`). The mirror effect is disposed
+        // before `element` itself goes null, so without this the consumer would
+        // otherwise keep a stale node reference after unmount.
+        return () => {
+            ref = null
+        }
+    })
     let isLoaded = $state<'mounting' | 'initial' | 'ready' | 'animated'>('mounting')
     // True once the enter/animate animation has COMPLETED. Until then the
     // WAAPI animation owns the transform; flipping the inline baseline to

--- a/src/lib/html/__tests__/RefBindHarness.svelte
+++ b/src/lib/html/__tests__/RefBindHarness.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+    import MotionContainer from '$lib/html/_MotionContainer.svelte'
+    import { motion } from '$lib/motion'
+
+    /**
+     * Test harness reproducing the idiomatic Svelte 5 ref pattern from #417:
+     * a freshly-declared `$state()` (initially `undefined`) bound via
+     * `bind:ref`. This exercises a regular element (`motion.div`), a void
+     * element (`motion.source`), and `_MotionContainer` directly — the three
+     * surfaces called out in the issue. Before the fix these threw
+     * `props_invalid_value` at mount because `ref` defaulted to `$bindable(null)`.
+     *
+     * `show` toggles the bound elements so the teardown side of the contract
+     * (refs reset when the element unmounts) can be asserted too.
+     */
+    let {
+        show = true,
+        onRefs
+    }: {
+        show?: boolean
+        onRefs?: (refs: {
+            div?: HTMLElement | null
+            source?: HTMLElement | null
+            container?: HTMLElement | null
+        }) => void
+    } = $props()
+
+    // Idiomatic refs: `$state()` is `undefined` until the element mounts.
+    let divEl = $state<HTMLDivElement>()
+    let sourceEl = $state<HTMLSourceElement>()
+    let containerEl = $state<HTMLElement>()
+
+    $effect(() => {
+        onRefs?.({ div: divEl, source: sourceEl, container: containerEl })
+    })
+</script>
+
+{#if show}
+    <motion.div bind:ref={divEl}>hi</motion.div>
+    <motion.source bind:ref={sourceEl} />
+    <MotionContainer bind:ref={containerEl} tag="span">hi</MotionContainer>
+{/if}

--- a/src/lib/html/__tests__/refBind.svelte.spec.ts
+++ b/src/lib/html/__tests__/refBind.svelte.spec.ts
@@ -1,0 +1,48 @@
+import { flushTimers } from '$lib/__tests__/flushTimers'
+import { render } from '@testing-library/svelte'
+import { describe, expect, it, vi } from 'vitest'
+
+import RefBindHarness from './RefBindHarness.svelte'
+
+vi.mock('motion', () => ({
+    animate: vi.fn(() => ({ finished: Promise.resolve(), stop: vi.fn() }))
+}))
+
+describe('bind:ref={$state()} (#417)', () => {
+    it('mounts a motion element, void element, and _MotionContainer without throwing props_invalid_value', async () => {
+        const onRefs = vi.fn()
+
+        // Before the fix this threw synchronously at mount because `ref`
+        // defaulted to `$bindable(null)`; binding a `$state()` (undefined)
+        // against a non-undefined fallback trips Svelte's `props_invalid_value`.
+        expect(() => render(RefBindHarness, { props: { onRefs } })).not.toThrow()
+
+        await flushTimers()
+
+        // The harness emits the latest ref snapshot whenever a bound `$state()`
+        // updates; the final emission proves each bindable propagated the node
+        // back to the consumer (not just that the element rendered).
+        const refs = onRefs.mock.lastCall?.[0] ?? {}
+        expect(refs.div?.tagName).toBe('DIV')
+        expect(refs.source?.tagName).toBe('SOURCE')
+        expect(refs.container?.tagName).toBe('SPAN')
+    })
+
+    it('resets each bound ref to null when the element unmounts', async () => {
+        const onRefs = vi.fn()
+        const { rerender } = render(RefBindHarness, { props: { show: true, onRefs } })
+        await flushTimers()
+        expect(onRefs.mock.lastCall?.[0]?.div?.tagName).toBe('DIV')
+
+        // Unmount the bound elements. The teardown side of the contract must
+        // reset the consumer's `$state()` back to null (matching native
+        // `bind:this`) rather than leave a stale node reference behind.
+        await rerender({ show: false, onRefs })
+        await flushTimers()
+
+        const refs = onRefs.mock.lastCall?.[0] ?? {}
+        expect(refs.div).toBeNull()
+        expect(refs.source).toBeNull()
+        expect(refs.container).toBeNull()
+    })
+})


### PR DESCRIPTION
## Summary

Fixes #417: binding a freshly-declared `$state()` ref to any motion element (`let el = $state()` → `bind:ref={el}`, the idiomatic Svelte 5 pattern) crashed at mount with `props_invalid_value`. Svelte rejects a `bind:` target that resolves to `undefined` when the prop has a non-`undefined` fallback, and `ref` defaulted to `$bindable(null)`. The fix defaults `ref` to `$bindable()` everywhere, with a careful decouple inside `_MotionContainer` to preserve animation timing and unmount semantics.

## Changes

🐛 **Fix the crash**
- Default `ref` to `$bindable()` in `scripts/_template.template` and `scripts/_template_void.template`, and regenerate the ~170 generated `motion.*` components.

🔧 **`_MotionContainer` decouple (the subtle part)**
- The public `ref` bindable now defaults to `$bindable()` (undefined), but the internal node keeps a separate `element = $state<HTMLElement | null>(null)` and mirrors into `ref` via an effect.
- Why: the animate effects depend on the exact `null → element` reactive timing. Defaulting the internal node to `undefined` reorders effect runs and silently breaks re-running animations on `animate`-prop change (caught by the existing `_MotionContainer` suite).
- The mirror effect resets `ref` to `null` on teardown, so `bind:ref` consumers get the same unmount semantics as native `bind:this` (no stale node reference left behind).

🧪 **Tests**
- New regression coverage for `bind:ref={$state()}` on a regular element, a void element, and `_MotionContainer` directly — including the unmount path that resets each bound ref to `null`.
- Extracted the duplicated `flushTimers` test helper into a shared `src/lib/__tests__/flushTimers.ts` (adopting the most thorough variant) and reused it across the motion specs.

## Notes

- `ref` type stays `HTMLElement | null | undefined` (optional prop), matching `bind:this` semantics. No change for consumers omitting `ref` or passing `null`.
- Full unit suite green (631 tests); CodeRabbit review applied (incl. the teardown-reset fix it surfaced).

## Commits

- [`b749f13`](https://github.com/humanspeak/svelte-motion/commit/b749f13bf4efbf2b96a6aa93772b97c2c199554b) fix(html): default ref to $bindable() so bind:ref={$state()} works

Closes #417
