### PR TITLE
fix(examples): make conic-gradient pivot track the pointer (#418)

### DIFF
--- a/docs/src/lib/examples/conic-gradient/demos/Default.svelte
+++ b/docs/src/lib/examples/conic-gradient/demos/Default.svelte
@@ -1,24 +1,24 @@
 <script lang="ts">
-    import { writable } from 'svelte/store'
-    import { motion, styleString, useTransform } from '@humanspeak/svelte-motion'
+    import { motion, styleString, useMotionValue, useTransform } from '@humanspeak/svelte-motion'
 
-    // Pointer-tracking conic gradient. `useTransform` derives the
-    // background string from two motion values; `styleString` glues
-    // it onto the inline `style` attribute. Move the cursor across the
-    // box and the gradient pivot follows.
-    // Ported from the motion.dev conic-gradient example.
+    // Pointer-tracking conic gradient. Two motion values hold the pivot, and
+    // `useTransform`'s compute form derives the background string from them —
+    // the `.get()` reads are auto-tracked, so the value recomputes whenever a
+    // pointer move updates them; `styleString` glues it onto the inline `style`
+    // attribute. Move the cursor across the box and the gradient pivot follows.
+    // Ported 1:1 from the motion.dev conic-gradient example (useMotionValue +
+    // .get()).
 
     let el: HTMLElement | undefined = $state(undefined)
     let width = $state(400)
     let height = $state(400)
 
-    const gradientX = writable(0.5)
-    const gradientY = writable(0.5)
+    const gradientX = useMotionValue(0.5)
+    const gradientY = useMotionValue(0.5)
 
     const background = useTransform(
         () =>
-            `conic-gradient(at ${$gradientX * 100}% ${$gradientY * 100}%, #0cdcf7, #ff0088, #fff312, #0cdcf7)`,
-        [gradientX, gradientY]
+            `conic-gradient(at ${gradientX.get() * 100}% ${gradientY.get() * 100}%, #0cdcf7, #ff0088, #fff312, #0cdcf7)`
     )
 
     function handlePointerMove(e: PointerEvent) {

--- a/e2e/utilities/conic-gradient.spec.ts
+++ b/e2e/utilities/conic-gradient.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Regression coverage for issue #418: the compute form of `useTransform` must
+ * recompute when the motion values it reads via `.get()` change. The original
+ * example mis-ported the upstream motion.dev demo (Svelte `writable` + `$store`
+ * reads, which `collectMotionValues` can't see), so the derived `background`
+ * froze at its mount-time `at 50% 50%` value. The fix uses `useMotionValue` +
+ * `.get()` (auto-tracked), matching upstream framer-motion.
+ *
+ * Assertions read `data-bg` (the raw computed string from the motion value)
+ * rather than the serialized inline `style`: the browser normalizes the
+ * default `at 50% 50%` position out of `style`, which would mask the freeze.
+ */
+const pivot = (bg: string | null): string => {
+    const match = bg?.match(/at\s+([\d.]+)%\s+([\d.]+)%/)
+    return match ? `${match[1]} ${match[2]}` : ''
+}
+
+test.describe('useTransform compute form (conic gradient)', () => {
+    test('background starts centered at 50% 50%', async ({ page }) => {
+        await page.goto('/tests/conic-gradient')
+
+        const box = page.getByTestId('gradient-box')
+        await expect(box).toBeVisible()
+        // Auto-retrying assertion — avoids reading data-bg before the first
+        // compute frame commits.
+        await expect(box).toHaveAttribute('data-bg', /conic-gradient\(at\s+50%\s+50%/)
+    })
+
+    test('moving the gradientX/Y motion values updates the pivot', async ({ page }) => {
+        await page.goto('/tests/conic-gradient')
+
+        const box = page.getByTestId('gradient-box')
+        await expect(box).toHaveAttribute('data-bg', /at\s+50%\s+50%/)
+
+        // Drive the motion values via the sliders (deterministic), then assert
+        // the recomputed pivot — proving the compute form auto-tracks them.
+        await page.getByTestId('x-slider').fill('0.25')
+        await expect(box).toHaveAttribute('data-bg', /at\s+25%\s+50%/)
+
+        await page.getByTestId('y-slider').fill('0.75')
+        await expect(box).toHaveAttribute('data-bg', /at\s+25%\s+75%/)
+    })
+
+    test('pivot changes between two distinct pointer positions over the swatch', async ({
+        page
+    }) => {
+        await page.goto('/tests/conic-gradient')
+
+        const swatch = page.getByTestId('swatch')
+        const box = page.getByTestId('gradient-box')
+        const rect = await swatch.boundingBox()
+        if (!rect) throw new Error('swatch not found')
+
+        await page.mouse.move(rect.x + rect.width * 0.2, rect.y + rect.height * 0.2)
+        await expect(box).toHaveAttribute('data-bg', /at\s+20%\s+20%/)
+        const bgA = await box.getAttribute('data-bg')
+
+        await page.mouse.move(rect.x + rect.width * 0.8, rect.y + rect.height * 0.8)
+        await expect(box).toHaveAttribute('data-bg', /at\s+80%\s+80%/)
+        const bgB = await box.getAttribute('data-bg')
+
+        expect(pivot(bgA)).not.toBe(pivot(bgB))
+    })
+})

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -88,6 +88,14 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/conic-gradient') + searchParams}
+                    >
+                        useTransform (conic gradient / compute form)
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/will-change') + searchParams}
                     >
                         useWillChange

--- a/src/routes/tests/conic-gradient/+page.svelte
+++ b/src/routes/tests/conic-gradient/+page.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+    import { motion, styleString, useMotionValue, useTransform } from '$lib'
+
+    // Regression coverage for issue #418: the compute form of `useTransform`
+    // must recompute when its sources change. The upstream-faithful shape uses
+    // motion values read via `.get()` inside the compute, which motion-dom's
+    // `collectMotionValues` auto-tracks — so a pointer move (or slider change)
+    // that calls `.set()` recomputes the derived background string.
+
+    const gradientX = useMotionValue(0.5)
+    const gradientY = useMotionValue(0.5)
+
+    const background = useTransform(
+        () =>
+            `conic-gradient(at ${gradientX.get() * 100}% ${gradientY.get() * 100}%, #0cdcf7, #ff0088, #fff312, #0cdcf7)`
+    )
+
+    let el: HTMLElement | undefined = $state(undefined)
+
+    const handlePointerMove = (e: PointerEvent) => {
+        if (!el) return
+        const rect = el.getBoundingClientRect()
+        gradientX.set((e.clientX - rect.left) / rect.width)
+        gradientY.set((e.clientY - rect.top) / rect.height)
+    }
+</script>
+
+<div class="conic-page bg-gray-900 p-8 text-white">
+    <div class="mx-auto max-w-3xl">
+        <h1 class="mb-4 text-center text-3xl font-bold">Conic Gradient (compute form)</h1>
+
+        <p class="mb-8 text-center text-gray-400">
+            <code class="rounded bg-gray-800 px-2 py-1">useTransform(() =&gt; …)</code>
+            auto-tracks the two motion values it reads via
+            <code class="rounded bg-gray-800 px-2 py-1">.get()</code> and recomputes the background.
+        </p>
+
+        <div class="mb-8 flex items-center justify-center">
+            <div
+                data-testid="swatch"
+                bind:this={el}
+                onpointermove={handlePointerMove}
+                role="presentation"
+                style="width: 320px; height: 320px;"
+            >
+                <motion.div
+                    data-testid="gradient-box"
+                    data-bg={$background}
+                    style={styleString(() => ({
+                        background: $background,
+                        width: '320px',
+                        height: '320px',
+                        borderRadius: 30
+                    }))}
+                />
+            </div>
+        </div>
+
+        <!-- Deterministic controls for e2e -->
+        <div class="mx-auto flex max-w-md flex-col gap-4">
+            <label class="flex items-center gap-3">
+                <span class="w-24">gradientX</span>
+                <input
+                    data-testid="x-slider"
+                    type="range"
+                    min="0"
+                    max="1"
+                    step="0.01"
+                    value="0.5"
+                    oninput={(e) => gradientX.set(parseFloat(e.currentTarget.value))}
+                />
+            </label>
+            <label class="flex items-center gap-3">
+                <span class="w-24">gradientY</span>
+                <input
+                    data-testid="y-slider"
+                    type="range"
+                    min="0"
+                    max="1"
+                    step="0.01"
+                    value="0.5"
+                    oninput={(e) => gradientY.set(parseFloat(e.currentTarget.value))}
+                />
+            </label>
+        </div>
+    </div>
+</div>

--- a/src/routes/tests/conic-gradient/+page.ts
+++ b/src/routes/tests/conic-gradient/+page.ts
@@ -1,0 +1,2 @@
+// Disable SSR for this page - motion components use getContext which requires client-side rendering
+export const ssr = false


### PR DESCRIPTION
## Summary

The `/examples/conic-gradient` swatch was dead — moving the cursor did nothing and the gradient pivot stayed frozen at `at 50% 50%`. The demo mis-ported motion.dev's React example: it used Svelte `writable` stores read via `$store` auto-subscription inside `useTransform`'s compute form, plus a deps array. But the compute form has no deps array (matching framer-motion), and `$store` reads are invisible to motion-dom's `collectMotionValues`, so the derived `background` never recomputed.

The fix is upstream-faithful and adds **no new library API**: the demo now uses `useMotionValue` + `.get()`, which `collectMotionValues` auto-tracks — a 1:1 port of how framer-motion expresses this.

## Changes

- 🐛 Fix the conic-gradient demo to use `useMotionValue` + `.get()` so the pivot tracks the pointer (`docs/src/lib/examples/conic-gradient/demos/Default.svelte`)
- 🧪 Add a test page (`src/routes/tests/conic-gradient/`) with slider + pointer controls, linked from the test index, plus Playwright e2e (`e2e/utilities/conic-gradient.spec.ts`) asserting the `at X% Y%` pivot follows both slider and pointer input
- 📚 No library/API changes — `useTransform`'s compute form already auto-tracks `MotionValue` reads; only the example was wrong

## Verification

- Live (Playwright): pointer at 0.2 → `at 20% 20%`, at 0.85 → `at 85% 85%`
- e2e: 3/3 passing
- Pre-commit: format, lint, and svelte-check all pass

## Commits

- [`a97aa81`](https://github.com/humanspeak/svelte-motion/commit/a97aa81) fix(examples): make conic-gradient pivot track the pointer (#418)

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)
