### PR TITLE
fix(drag): write bound style MotionValue during drag (#421)

### DIFF
--- a/docs/src/lib/examples/mobile-drawer/demos/Default.svelte
+++ b/docs/src/lib/examples/mobile-drawer/demos/Default.svelte
@@ -1,0 +1,315 @@
+<script lang="ts">
+    import {
+        animate,
+        createDragControls,
+        motion,
+        useAnimate,
+        useMotionValue,
+        type RawMotionValue
+    } from '@humanspeak/svelte-motion'
+
+    let open = $state(false)
+
+    // `useAnimate` scopes imperative animations to the overlay it attaches to,
+    // so the backdrop can fade on close.
+    const [scope, scopedAnimate] = useAnimate()
+
+    // The sheet element, measured at close time so it slides fully off-screen.
+    let sheetRef = $state<HTMLElement | null>(null)
+
+    // The bound drag offset. `drag` writes this MotionValue (so `y.get()` reads
+    // the live position) and the close animation drives it back — animating the
+    // same value the gesture left off (#421).
+    const y = useMotionValue(0)
+    const controls = createDragControls()
+
+    const handleClose = async () => {
+        // Fade the backdrop out…
+        if (scope.current) scopedAnimate(scope.current, { opacity: [1, 0] })
+
+        // …and slide the sheet down by its own height, continuing from wherever
+        // the drag left it.
+        const height = sheetRef?.offsetHeight ?? 0
+        await animate(y as unknown as RawMotionValue<number>, height, {
+            duration: 0.3,
+            ease: 'easeInOut'
+        })
+
+        open = false
+        // Reset for the next open (the MotionValue outlives the {#if} block).
+        y.set(0)
+    }
+</script>
+
+<!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
+<div class="dk-demo-shell">
+    <section class="drawer-demo" aria-label="Drag to close drawer example">
+        <div class="phone">
+            <div class="screen">
+                <p class="screen-hint">Tap to open the bottom sheet</p>
+                <button class="open-btn" onclick={() => (open = true)}>Open drawer</button>
+            </div>
+
+            {#if open}
+                <motion.div
+                    {@attach scope}
+                    scoped:class="overlay"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    onclick={handleClose}
+                >
+                    <motion.div
+                        bind:ref={sheetRef}
+                        scoped:class="sheet"
+                        style={{ y }}
+                        initial={{ y: '100%' }}
+                        animate={{ y: '0%' }}
+                        transition={{ ease: 'easeInOut' }}
+                        drag="y"
+                        dragControls={controls}
+                        dragListener={false}
+                        dragConstraints={{ top: 0, bottom: 0 }}
+                        dragElastic={{ top: 0, bottom: 0.5 }}
+                        onclick={(e: MouseEvent) => e.stopPropagation()}
+                        onDragEnd={() => {
+                            if (y.get() >= 100) handleClose()
+                        }}
+                    >
+                        <div class="handle-row">
+                            <button
+                                class="handle"
+                                aria-label="Drag to close"
+                                onpointerdown={(e: PointerEvent) => controls.start(e)}
+                            ></button>
+                        </div>
+                        <div class="sheet-body">
+                            <h3>Drag me down to close</h3>
+                            <p>
+                                Grab the handle and pull this sheet down past the threshold to
+                                dismiss it, or tap the backdrop. The drag writes the bound
+                                <code>y</code> MotionValue, and the close animation continues from wherever
+                                you let go.
+                            </p>
+                            <p>
+                                Release before the threshold and it springs back into place with a
+                                little elastic give.
+                            </p>
+                            <div class="rows">
+                                <span></span><span></span><span></span><span></span>
+                            </div>
+                        </div>
+                    </motion.div>
+                </motion.div>
+            {/if}
+        </div>
+    </section>
+</div>
+
+<style>
+    .dk-demo-shell {
+        min-height: 560px;
+        display: grid;
+        place-items: center;
+        padding: clamp(1rem, 4vw, 2.5rem);
+    }
+
+    /* Theme tokens — dark is the default (the docs site toggles `.dark` on
+       <html>); the light overrides live in the `html:not(.dark)` block below. */
+    .drawer-demo {
+        --phone-bg: radial-gradient(circle at 30% 18%, #1e293b, #020617 68%);
+        --phone-border: rgb(148 163 184 / 0.22);
+        --phone-shadow: 0 30px 90px rgb(0 0 0 / 0.45);
+        --screen-text: rgb(226 232 240 / 0.66);
+        --btn-bg: linear-gradient(
+            135deg,
+            var(--color-brand-400, #34d399),
+            var(--color-brand-600, #059669)
+        );
+        --btn-text: #022c22;
+        --btn-shadow: 0 10px 24px
+            color-mix(in oklab, var(--color-brand-500, #10b981) 38%, transparent);
+        --scrim: rgb(2 6 23 / 0.55);
+        --sheet-bg: #0f172a;
+        --sheet-border: rgb(148 163 184 / 0.16);
+        --sheet-title: #f1f5f9;
+        --sheet-text: rgb(203 213 225 / 0.78);
+        --handle: rgb(148 163 184 / 0.5);
+        --row: rgb(148 163 184 / 0.14);
+        --code-bg: rgb(148 163 184 / 0.16);
+        --code-text: #e2e8f0;
+
+        display: grid;
+        place-items: center;
+        width: 100%;
+    }
+
+    :global(html:not(.dark)) .drawer-demo {
+        --phone-bg: radial-gradient(circle at 30% 18%, #ffffff, #eef2ff 70%);
+        --phone-border: rgb(15 23 42 / 0.12);
+        --phone-shadow: 0 24px 70px rgb(15 23 42 / 0.16);
+        --screen-text: rgb(15 23 42 / 0.56);
+        --btn-bg: linear-gradient(
+            135deg,
+            var(--color-brand-400, #34d399),
+            var(--color-brand-600, #059669)
+        );
+        --btn-text: #022c22;
+        --btn-shadow: 0 10px 24px
+            color-mix(in oklab, var(--color-brand-600, #059669) 28%, transparent);
+        --scrim: rgb(15 23 42 / 0.4);
+        --sheet-bg: #ffffff;
+        --sheet-border: rgb(15 23 42 / 0.1);
+        --sheet-title: #0f172a;
+        --sheet-text: rgb(51 65 85 / 0.82);
+        --handle: rgb(15 23 42 / 0.28);
+        --row: rgb(15 23 42 / 0.08);
+        --code-bg: rgb(15 23 42 / 0.08);
+        --code-text: #1e293b;
+    }
+
+    .phone {
+        position: relative;
+        width: min(360px, 92vw);
+        height: 600px;
+        max-height: 70vh;
+        overflow: hidden;
+        border-radius: 28px;
+        border: 1px solid var(--phone-border);
+        background: var(--phone-bg);
+        box-shadow: var(--phone-shadow);
+    }
+
+    .screen {
+        position: absolute;
+        inset: 0;
+        display: grid;
+        place-content: center;
+        justify-items: center;
+        gap: 1rem;
+        text-align: center;
+        padding: 1.5rem;
+    }
+
+    .screen-hint {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--screen-text);
+    }
+
+    .open-btn {
+        appearance: none;
+        border: none;
+        cursor: pointer;
+        border-radius: 9px;
+        padding: 0.6rem 1.1rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: var(--btn-text);
+        background: var(--btn-bg);
+        box-shadow: var(--btn-shadow);
+        transition: transform 0.15s ease;
+    }
+
+    .open-btn:hover {
+        transform: translateY(-1px);
+    }
+
+    .open-btn:active {
+        transform: translateY(0);
+    }
+
+    /* The overlay + sheet are `motion` components. `scoped:class` (a Svelte
+       Motion feature) keeps this component's scope on their rendered elements,
+       so these plain scoped selectors apply without needing `:global()`. */
+    .overlay {
+        position: absolute;
+        inset: 0;
+        z-index: 10;
+        background: var(--scrim);
+        backdrop-filter: blur(2px);
+    }
+
+    .sheet {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 78%;
+        overflow: hidden;
+        border-top-left-radius: 22px;
+        border-top-right-radius: 22px;
+        border: 1px solid var(--sheet-border);
+        border-bottom: none;
+        background: var(--sheet-bg);
+        box-shadow: 0 -18px 50px rgb(0 0 0 / 0.28);
+    }
+
+    .handle-row {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1;
+        display: flex;
+        justify-content: center;
+        padding: 0.85rem;
+        background: var(--sheet-bg);
+    }
+
+    .handle {
+        appearance: none;
+        height: 6px;
+        width: 56px;
+        padding: 0;
+        border: none;
+        border-radius: 999px;
+        background: var(--handle);
+        cursor: grab;
+        touch-action: none;
+    }
+
+    .handle:active {
+        cursor: grabbing;
+    }
+
+    .sheet-body {
+        height: 100%;
+        overflow-y: auto;
+        padding: 3.25rem 1.4rem 1.4rem;
+        color: var(--sheet-text);
+    }
+
+    .sheet-body h3 {
+        margin: 0 0 0.6rem;
+        font-size: 1.35rem;
+        font-weight: 700;
+        color: var(--sheet-title);
+    }
+
+    .sheet-body p {
+        margin: 0 0 0.85rem;
+        font-size: 0.92rem;
+        line-height: 1.5;
+    }
+
+    .sheet-body code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-size: 0.85em;
+        padding: 0.08em 0.34em;
+        border-radius: 4px;
+        background: var(--code-bg);
+        color: var(--code-text);
+    }
+
+    .rows {
+        display: grid;
+        gap: 0.75rem;
+        margin-top: 1.25rem;
+    }
+
+    .rows span {
+        height: 2.5rem;
+        border-radius: 8px;
+        background: var(--row);
+    }
+</style>

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -75,6 +75,11 @@ const EXAMPLES: Record<string, ExampleEntry> = {
         title: 'LazyMotion',
         description: 'Load Svelte Motion feature bundles with LazyMotion and the m namespace.'
     },
+    'mobile-drawer': {
+        title: 'Mobile Drawer',
+        description:
+            'A theme-aware drag-to-close bottom sheet built with drag, a bound y MotionValue, and dragControls.'
+    },
     'motion-path': {
         title: 'Motion Path',
         description: 'Interactive motion path animation example using Svelte Motion.'

--- a/docs/src/routes/examples/mobile-drawer/+page.svelte
+++ b/docs/src/routes/examples/mobile-drawer/+page.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        type ExampleSection,
+        formatSheetLabel
+    } from '@humanspeak/docs-kit'
+    import { Hand, MoveVertical, PanelBottomClose } from '@lucide/svelte'
+    import { demoCodeSample } from '$lib/demo-loaders'
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import MobileDrawerDefault from '$lib/examples/mobile-drawer/demos/Default.svelte'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'Mobile Drawer' }
+        ]
+    }
+    if (seo) {
+        seo.title = 'Mobile Drawer | Examples | Svelte Motion'
+        seo.description =
+            'A theme-aware drag-to-close bottom sheet built with drag, a bound y MotionValue, and dragControls in Svelte Motion.'
+        seo.ogTitle = 'Mobile Drawer'
+        seo.ogTagline = 'Drag-to-close bottom sheet with a bound MotionValue'
+        seo.ogFeatures = ['Drag', 'Drag Controls', 'MotionValue', 'Elasticity']
+        seo.ogSlug = 'examples-mobile-drawer'
+    }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    const sections: ExampleSection[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'DRAG',
+            title: { prefix: 'drag to ', accent: 'close drawer', end: '.' },
+            description:
+                'A mobile bottom sheet you dismiss by dragging the handle down past a threshold. The gesture writes a bound y MotionValue, so the close animation continues from exactly where you let go — and it follows the light/dark theme.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'drag-to-dismiss sheet' }],
+            sourceUrl: `${SOURCE_URL}mobile-drawer/demos/Default.svelte`
+        }
+    ]
+</script>
+
+{#snippet defaultSection()}
+    <MobileDrawerDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Hand />
+            <span>
+                Only the handle starts the drag. <code>dragListener=&#123;false&#125;</code> plus
+                <code>controls.start(e)</code> on <code>pointerdown</code> means the sheet body stays
+                scrollable while the grip drives the gesture.
+            </span>
+        </li>
+        <li>
+            <MoveVertical />
+            <span>
+                <code>drag="y"</code> writes the bound
+                <code>style=&#123;&#123; y &#125;&#125;</code>
+                MotionValue, so <code>onDragEnd</code> can read <code>y.get()</code> for the close
+                threshold and <code>animate(y, …)</code> resumes from the dragged position.
+            </span>
+        </li>
+        <li>
+            <PanelBottomClose />
+            <span>
+                <code>dragConstraints</code> pins the rest position to the top, while
+                <code>dragElastic=&#123;&#123; bottom: 0.5 &#125;&#125;</code> gives a soft downward pull
+                before it either closes or springs back.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'mobile-drawer/demos/Default.svelte',
+                'mobile-drawer-default',
+                'Default.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel={formatSheetLabel(i, sections.length)}
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/mobile-drawer/+page.ts
+++ b/docs/src/routes/examples/mobile-drawer/+page.ts
@@ -1,0 +1,11 @@
+import type { PageLoad } from './$types'
+
+/**
+ * Loads page metadata for the mobile drawer example.
+ * @returns Page metadata with title and description.
+ */
+export const load: PageLoad = () => ({
+    title: 'Mobile Drawer',
+    description:
+        'A theme-aware drag-to-close bottom sheet built with drag, a bound y MotionValue, and dragControls.'
+})

--- a/e2e/drag/mobile-drawer.spec.ts
+++ b/e2e/drag/mobile-drawer.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test, type Page } from '@playwright/test'
+import { readTransform } from '../_helpers/transform'
+
+/**
+ * Framer "drag to close drawer" pattern, ported 1:1 (issue #421).
+ *
+ * The drawer is a `motion.div` with `drag="y"`, `dragControls`, a bound
+ * `style={{ y }}` MotionValue, `dragConstraints={{ top: 0, bottom: 0 }}` and
+ * `dragElastic={{ top: 0, bottom: 0.5 }}`. `onDragEnd` closes the drawer when
+ * `y.get() >= 100`.
+ *
+ * Before #421, `drag` never wrote the bound `style` MotionValue, so `y.get()`
+ * stayed `0` in `onDragEnd` and the drawer could never be dragged closed. These
+ * tests are the regression guard for that fix — and for the double-count bug
+ * the first cut of the fix introduced (the offset being applied via both the
+ * gesture transform and the style MotionValue).
+ */
+test.describe('drag/mobile-drawer', () => {
+    // translateY of the drawer, via the shared matrix parser used across
+    // e2e/drag/*.spec.ts (returns ty=0 on 'none').
+    const readY = async (page: Page) => (await readTransform(page, '#drawer')).ty
+
+    const open = async (page: Page) => {
+        await page.goto('/tests/mobile-drawer?@isPlaywright=true')
+        await page.getByTestId('open-drawer').click()
+        await page.getByTestId('drawer').waitFor({ state: 'visible' })
+        // Let the enter animation (y: 100% → 0%) settle.
+        await page.waitForTimeout(500)
+    }
+
+    const dragHandleBy = async (page: Page, distance: number) => {
+        const handle = page.getByTestId('drag-handle')
+        const box = await handle.boundingBox()
+        if (!box) throw new Error('no drag handle')
+        const cx = box.x + box.width / 2
+        const cy = box.y + box.height / 2
+        await page.mouse.move(cx, cy)
+        await page.mouse.down()
+        const steps = 20
+        for (let i = 1; i <= steps; i++) {
+            await page.mouse.move(cx, cy + (distance * i) / steps, { steps: 2 })
+            await page.waitForTimeout(16)
+        }
+        const yAtRelease = await readY(page)
+        await page.mouse.up()
+        return yAtRelease
+    }
+
+    test('dragging the handle past the threshold closes the drawer', async ({ page }) => {
+        await open(page)
+
+        // 280px down → ~140px after `bottom: 0.5` elastic, which clears the 100px
+        // close threshold. The drawer should animate out and unmount.
+        await dragHandleBy(page, 280)
+
+        await expect(page.getByTestId('drawer')).toBeHidden()
+        await expect(page.getByTestId('open-drawer')).toBeVisible()
+    })
+
+    test('a short drag snaps back and keeps the drawer open', async ({ page }) => {
+        await open(page)
+
+        // 120px down → ~60px after elastic, below the 100px threshold. The drawer
+        // settles back to y≈0 and stays mounted.
+        await dragHandleBy(page, 120)
+        await page.waitForTimeout(700)
+
+        await expect(page.getByTestId('drawer')).toBeVisible()
+        const settledY = await readY(page)
+        expect(settledY).not.toBeNull()
+        expect(Math.abs(settledY as number)).toBeLessThan(5)
+    })
+
+    test('the bound y MotionValue is elastic-damped, not double-applied', async ({ page }) => {
+        await open(page)
+
+        // Regression guard for #421: the gesture must drive the bound `style`
+        // MotionValue without the offset also being composed into the gesture
+        // transform. Dragging 280px with `bottom: 0.5` elastic should render
+        // ~140px (280 * 0.5), NOT 280px (the double-count) and NOT 0px (the
+        // original "value never written" bug).
+        const yAtRelease = await dragHandleBy(page, 280)
+
+        expect(yAtRelease).not.toBeNull()
+        expect(yAtRelease as number).toBeGreaterThan(110)
+        expect(yAtRelease as number).toBeLessThan(180)
+    })
+
+    test('clicking the backdrop closes the drawer', async ({ page }) => {
+        await open(page)
+
+        // Backdrop sits above the 75vh sheet; click near the top to hit it.
+        await page.mouse.click(60, 40)
+        await expect(page.getByTestId('drawer')).toBeHidden()
+    })
+})

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -1528,7 +1528,22 @@
             baselineSources: {
                 initial: (initialKeyframes ?? {}) as Record<string, unknown>,
                 animate: (resolvedAnimate ?? {}) as Record<string, unknown>
-            }
+            },
+            // Bound `style` MotionValues (e.g. `style={{ y }}`) for the dragged
+            // axes, so the gesture writes through to them and `y.get()` /
+            // `animate(y, …)` stay in sync with the drag (#421). Read inside
+            // `untrack` so the drag effect doesn't re-run (re-attaching the
+            // gesture) every time `styleProp` changes — e.g. an object-style
+            // `rotate` derived from a $state updates each frame mid-drag.
+            boundMotionValues: (() => {
+                // collectMotionStyleValues already filters to MotionValues only.
+                const styleValues = collectMotionStyleValues(styleProp)
+                if (!styleValues) return undefined
+                const bound: { x?: MotionValue<number>; y?: MotionValue<number> } = {}
+                if (styleValues.x) bound.x = styleValues.x as MotionValue<number>
+                if (styleValues.y) bound.y = styleValues.y as MotionValue<number>
+                return bound.x || bound.y ? bound : undefined
+            })()
         }))
         const opts = {
             axis,
@@ -1556,7 +1571,8 @@
             baselineSources: dragRuntimeOptions.baselineSources,
             getBaseTransform: () => splitSerializedTransform(serializedStyleProp).transform,
             propagation: !!dragPropagationProp,
-            snapToOrigin: dragSnapToOriginProp as boolean | 'x' | 'y' | undefined
+            snapToOrigin: dragSnapToOriginProp as boolean | 'x' | 'y' | undefined,
+            boundMotionValues: dragRuntimeOptions.boundMotionValues
         }
 
         // Attach and hold teardown so we can re-attach if props change

--- a/src/lib/utils/drag.ts
+++ b/src/lib/utils/drag.ts
@@ -32,7 +32,7 @@ import {
 import { deriveBoundaryPhysics } from '$lib/utils/dragParams'
 import { computeHoverBaseline, splitHoverDefinition } from '$lib/utils/hover'
 import { animate, type AnimationOptions, type DOMKeyframesDefinition } from 'motion'
-import { animateValue, type AnimationPlaybackControlsWithThen } from 'motion-dom'
+import { animateValue, type AnimationPlaybackControlsWithThen, type MotionValue } from 'motion-dom'
 
 type Rect = {
     top: number
@@ -83,6 +83,15 @@ export type AttachDragOptions = {
     getBaseTransform?: () => string
     propagation?: boolean
     snapToOrigin?: boolean | 'x' | 'y'
+    /**
+     * Bound `style` MotionValues for the dragged axes (e.g. `style={{ y }}`).
+     * The gesture dual-writes these alongside the synchronous transform so
+     * `y.get()` / `style={{ y }}` reflect the live drag offset and a follow-up
+     * `animate(y, …)` continues from the dragged position — matching
+     * framer-motion, where the gesture drives the MotionValue and the transform
+     * is derived from it (#421).
+     */
+    boundMotionValues?: { x?: MotionValue<number>; y?: MotionValue<number> }
 }
 
 /**
@@ -391,6 +400,13 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
         propagation: opts.propagation
     })
     const axis = opts.axis
+    const dragX = axis === true || axis === 'x'
+    const dragY = axis === true || axis === 'y'
+    // Bound `style` MotionValues for the dragged axes (e.g. `style={{ y }}`).
+    // Constant for this gesture's lifetime, so resolved once here rather than
+    // per `setXYImmediate` frame (#421).
+    const boundX = dragX ? opts.boundMotionValues?.x : undefined
+    const boundY = dragY ? opts.boundMotionValues?.y : undefined
     const directionLock = !!opts.directionLock
     const listenerEnabled = opts.listener !== false
     const elastic = resolveDragElastic(opts.elastic)
@@ -524,26 +540,43 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
      * `adjustOrigin` hook below.
      */
     const setXYImmediate = (x: number, y: number) => {
+        // An axis backed by a bound MotionValue is rendered through motion-dom's
+        // styleEffect (and reflected in `getBaseTransform()`). Emitting a translate
+        // for it here too would apply the offset twice (#421), so only non-bound
+        // axes get the synchronous, no-lag translate write (#379).
         const parts: string[] = []
-        if (axis === true || axis === 'x') parts.push(`translateX(${x}px)`)
-        if (axis === true || axis === 'y') parts.push(`translateY(${y}px)`)
+        if (dragX && !boundX) parts.push(`translateX(${x}px)`)
+        if (dragY && !boundY) parts.push(`translateY(${y}px)`)
         const scalePart =
             managedScaleActive && Math.abs(managedScale - 1) > 0.0001
                 ? `scale(${managedScale})`
                 : ''
         const liveTransform = [...parts, scalePart].filter(Boolean).join(' ')
-        el.dataset.svelteMotionDragTransform = liveTransform
-        const writeComposedTransform = () => {
-            if (el.dataset.svelteMotionDragTransform !== liveTransform) return
-            const baseTransform = opts.getBaseTransform?.() ?? ''
-            el.style.transform = [liveTransform, baseTransform].filter(Boolean).join(' ')
-        }
 
-        writeComposedTransform()
-        queueMicrotask(writeComposedTransform)
-        requestAnimationFrame(writeComposedTransform)
-        if (axis === true || axis === 'x') applied.x = x
-        if (axis === true || axis === 'y') applied.y = y
+        // `liveTransform` is empty only when every dragged axis is
+        // MotionValue-backed and there's no managed scale — i.e. nothing here to
+        // write, so styleEffect owns the transform and writing an empty/stale
+        // value would clobber it (#421). Otherwise this is the unchanged no-lag
+        // write path (#379) — note a no-bound drag always has a translate, so
+        // `liveTransform` is non-empty and the write always runs.
+        if (liveTransform) {
+            el.dataset.svelteMotionDragTransform = liveTransform
+            const writeComposedTransform = () => {
+                if (el.dataset.svelteMotionDragTransform !== liveTransform) return
+                const baseTransform = opts.getBaseTransform?.() ?? ''
+                el.style.transform = [liveTransform, baseTransform].filter(Boolean).join(' ')
+            }
+
+            writeComposedTransform()
+            queueMicrotask(writeComposedTransform)
+            requestAnimationFrame(writeComposedTransform)
+        }
+        if (dragX) applied.x = x
+        if (dragY) applied.y = y
+        // Dual-write the bound MotionValue(s) so `y.get()`, `style={{ y }}`, and a
+        // follow-up `animate(y, …)` stay in sync with the drag (#421).
+        if (boundX && boundX.get() !== x) boundX.set(x)
+        if (boundY && boundY.get() !== y) boundY.set(y)
         opts.callbacks?.onVisualUpdate?.(liveTransform)
     }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -298,6 +298,14 @@
                         Drag: Brutalist Stage (docs FIG-002 repro)
                     </a>
                 </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/mobile-drawer') + searchParams}
+                    >
+                        Drag Close Drawer (mobile drawer)
+                    </a>
+                </li>
             </ul>
         </div>
         <div>

--- a/src/routes/tests/mobile-drawer/+page.svelte
+++ b/src/routes/tests/mobile-drawer/+page.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+    import DragCloseDrawer from './DragCloseDrawer.svelte'
+
+    let open = $state(false)
+
+    const setOpen = (value: boolean) => {
+        open = value
+    }
+</script>
+
+<svelte:head>
+    <title>Drag Close Drawer</title>
+</svelte:head>
+
+<div class="grid h-screen place-content-center bg-neutral-950">
+    <button
+        data-testid="open-drawer"
+        onclick={() => setOpen(true)}
+        class="rounded bg-indigo-500 px-4 py-2 text-white transition-colors hover:bg-indigo-600"
+    >
+        Open drawer
+    </button>
+
+    <DragCloseDrawer {open} {setOpen}>
+        <div class="mx-auto max-w-2xl space-y-4 text-neutral-400">
+            <h2 class="text-4xl font-bold text-neutral-200">
+                Drag the handle at the top of this modal downwards 100px to close it
+            </h2>
+            <p>
+                Lorem ipsum dolor sit, amet consectetur adipisicing elit. Minima laboriosam quos
+                deleniti veniam est culpa quis nihil enim suscipit nulla aliquid iure optio quaerat
+                deserunt, molestias quasi facere aut quidem reprehenderit maiores.
+            </p>
+            <p>
+                Laudantium corrupti neque rerum labore tempore sapiente. Quos, nobis dolores. Esse
+                fuga, cupiditate rerum soluta magni numquam nemo aliquid voluptate similique
+                deserunt!
+            </p>
+            <p>
+                Rerum inventore provident laboriosam quo facilis nisi voluptatem quam maxime
+                pariatur. Velit reiciendis quasi sit magni numquam quos itaque ratione, fugit
+                adipisci atque est, tenetur officiis explicabo id molestiae aperiam? Expedita quidem
+                inventore magni? Doloremque architecto mollitia, dicta, fugit minima velit explicabo
+                sapiente beatae fugiat accusamus voluptatum, error voluptatem ab asperiores quo modi
+                possimus.
+            </p>
+            <p>
+                Sit laborum molestias ex quisquam molestiae cum fugiat praesentium! Consequatur
+                excepturi quod nemo harum laudantium accusantium nisi odio?
+            </p>
+            <p>
+                Deleniti, animi maiores officiis quos eaque neque voluptas omnis quia error a
+                dolores, pariatur ad obcaecati, vitae nisi perspiciatis fugiat sapiente accusantium.
+                Magnam, a nihil soluta eos vero illo ab sequi, dolores culpa, quia hic?
+            </p>
+            <p>
+                Eos in saepe dignissimos tempore. Laudantium cumque eius, et distinctio illum magnam
+                molestiae doloribus. Fugiat voluptatum necessitatibus vero eligendi quae, similique
+                non debitis qui veniam praesentium rerum labore libero architecto tempore nesciunt
+                est atque animi voluptatibus. Aliquam repellendus provident tempora sequi officia
+                sint voluptates eaque minima suscipit, cum maiores quos possimus. Vero ex porro
+                asperiores voluptas voluptatibus?
+            </p>
+            <p>
+                Debitis eos aut ullam odit fuga. Numquam deleniti libero quas sunt? Exercitationem
+                earum odio aliquam necessitatibus est accusamus consequuntur nisi natus dolore
+                libero voluptatibus odit doloribus laudantium iure, dicta placeat molestias porro
+                quasi amet? Sint, reiciendis tenetur distinctio eaque delectus, maiores, nihil
+                voluptas dolorem necessitatibus consequatur aliquid?
+            </p>
+            <p>
+                Sunt ex, cum culpa vel odio dicta expedita omnis amet debitis inventore
+                necessitatibus quaerat est molestias delectus. Dolorem, eius? Quae, itaque ipsa
+                incidunt nobis repellendus, sunt dolorum aliquam ad culpa repudiandae impedit omnis,
+                expedita illum voluptas delectus similique ducimus saepe pariatur. Molestias
+                similique quam dolore provident doloremque maiores autem ab blanditiis voluptatum
+                dignissimos culpa sed nesciunt laboriosam, in dicta consectetur.
+            </p>
+            <p>
+                Voluptates ea, aspernatur possimus, iusto temporibus non laudantium neque molestias
+                rem tempore eligendi earum nisi dolorum asperiores at rerum!
+            </p>
+            <p>
+                Eaque totam error quia, ut eius perspiciatis unde velit temporibus mollitia. Aperiam
+                ad tempora aliquam est molestias commodi cupiditate quos impedit nostrum accusantium
+                quo fugit eveniet temporibus quam cumque autem porro, id ut debitis itaque et nemo
+                exercitationem voluptatibus? Aspernatur corrupti quas iusto dolores nemo pariatur
+                debitis quae dolorem! Nemo, eius? Dolorem quam nemo magnam ratione deserunt aperiam.
+                Voluptatum ipsa, molestias aspernatur quas distinctio numquam qui laboriosam id ab
+                totam commodi laborum tempora error natus vitae eligendi reiciendis maiores ex illo?
+                Tempore at animi earum vitae enim sunt, dignissimos, mollitia corrupti officia
+                obcaecati error iure vero repudiandae nihil magni molestias quibusdam dolorem
+                aperiam modi. Harum, fugit.
+            </p>
+        </div>
+    </DragCloseDrawer>
+</div>

--- a/src/routes/tests/mobile-drawer/DragCloseDrawer.svelte
+++ b/src/routes/tests/mobile-drawer/DragCloseDrawer.svelte
@@ -1,0 +1,99 @@
+<!--
+    Drag-to-close drawer — a 1:1 port of the Framer Motion "DragCloseDrawer"
+    pattern (issue #421). Visual design credit:
+    https://www.hover.dev/components/modals
+-->
+<script lang="ts">
+    import { motion, useMotionValue, useAnimate, createDragControls } from '$lib'
+    import type { ElementOrSelector } from 'motion'
+    import type { Snippet } from 'svelte'
+
+    let {
+        open,
+        setOpen,
+        children
+    }: {
+        open: boolean
+        setOpen: (value: boolean) => void
+        children: Snippet
+    } = $props()
+
+    const [scope, animate] = useAnimate()
+
+    // react-use-measure → bind:ref + offsetHeight read at close time. We only
+    // need the drawer's measured height to slide it fully off the bottom.
+    let drawerRef = $state<HTMLElement | null>(null)
+
+    const y = useMotionValue(0)
+    const controls = createDragControls()
+
+    const handleClose = async () => {
+        animate(scope.current as ElementOrSelector, {
+            opacity: [1, 0]
+        })
+
+        const yStart = typeof y.get() === 'number' ? y.get() : 0
+        const height = drawerRef?.offsetHeight ?? 0
+
+        await animate('#drawer', {
+            y: [yStart, height]
+        })
+
+        setOpen(false)
+    }
+</script>
+
+{#if open}
+    <motion.div
+        {@attach scope}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        onclick={handleClose}
+        data-testid="drawer-overlay"
+        class="fixed inset-0 z-50 bg-neutral-950/70"
+    >
+        <motion.div
+            id="drawer"
+            data-testid="drawer"
+            bind:ref={drawerRef}
+            onclick={(e: MouseEvent) => e.stopPropagation()}
+            initial={{ y: '100%' }}
+            animate={{ y: '0%' }}
+            transition={{
+                ease: 'easeInOut'
+            }}
+            class="absolute bottom-0 h-[75vh] w-full overflow-hidden rounded-t-3xl bg-neutral-900"
+            style={{ y }}
+            drag="y"
+            dragControls={controls}
+            onDragEnd={() => {
+                if (y.get() >= 100) {
+                    handleClose()
+                }
+            }}
+            dragListener={false}
+            dragConstraints={{
+                top: 0,
+                bottom: 0
+            }}
+            dragElastic={{
+                top: 0,
+                bottom: 0.5
+            }}
+        >
+            <div class="absolute left-0 right-0 top-0 z-10 flex justify-center bg-neutral-900 p-4">
+                <button
+                    aria-label="Drag handle"
+                    data-testid="drag-handle"
+                    onpointerdown={(e: PointerEvent) => {
+                        controls.start(e)
+                    }}
+                    class="h-2 w-14 cursor-grab touch-none rounded-full bg-neutral-700 active:cursor-grabbing"
+                ></button>
+            </div>
+            <div class="relative z-0 h-full overflow-y-scroll p-4 pt-12">
+                {@render children()}
+            </div>
+        </motion.div>
+    </motion.div>
+{/if}


### PR DESCRIPTION
## Summary

Fixes #421. `drag` updated the element's transform directly but never wrote the bound `style={{ y }}` MotionValue. As a result `y.get()` stayed stale (`0`) inside `onDragEnd`, and a follow-up `animate(y, …)` started from the wrong value — breaking the canonical Framer "drag to close drawer" pattern.

## What changed

**Library fix**
- `attachDrag` accepts a new `boundMotionValues` option and dual-writes the dragged axis's MotionValue in `setXYImmediate`, so `y.get()`, `style={{ y }}`, and a subsequent `animate(y, …)` all reflect the live drag offset.
- Bound axes are **excluded** from the synchronous translate write, so the offset isn't applied twice — motion-dom's `styleEffect` renders them. The no-bound path is unchanged (no-lag write preserved, #379).
- `_MotionContainer` extracts the x/y `style` MotionValues and passes them through, resolved inside `untrack()` so a per-frame `styleProp` change (e.g. an object-style `rotate` derived from `$state`) can't re-attach the gesture mid-drag.

**Demos / tests / docs**
- 1:1 Framer port test page at `src/routes/tests/mobile-drawer` (linked from the demos index).
- Playwright coverage at `e2e/drag/mobile-drawer.spec.ts` — drag-to-close, snap-back, the no-double-count regression guard, and backdrop close.
- Theme-aware docs example at `examples/mobile-drawer`. Visual design credit: [hover.dev](https://www.hover.dev/components/modals).

## Testing

- `e2e/drag` full suite: **55 passed, 1 skipped** (incl. the new 4 mobile-drawer tests; `brutalist-stage` 7/7 — guarded against a re-attach regression caught during review).
- `drag` + `dragInertia` unit tests: **6 passed**.
- `svelte-check`: **0 errors**.

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)