### PR TITLE
fix(transform-template): stop & optimized-appear lifecycle parity

### DIFF
--- a/e2e/utilities/transform-template-optimized-appear.spec.ts
+++ b/e2e/utilities/transform-template-optimized-appear.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const URL = '/tests/transform-template/optimized-appear?@isPlaywright=true'
+
+const readStyle = (page: Page, testId: string) => async () =>
+    (await page.getByTestId(testId).getAttribute('style')) ?? ''
+
+test.describe('transformTemplate — optimized appear suppression page', () => {
+    test('suppresses the SSR appear bootstrap only for the templated transform', async ({
+        page
+    }) => {
+        const response = await page.request.get(URL)
+        const html = await response.text()
+
+        const openingTag = (testId: string): string =>
+            html.match(new RegExp(`<[a-zA-Z]+[^>]*data-testid="${testId}"[^>]*>`))?.[0] ?? ''
+
+        const slateTag = openingTag('appear-slate')
+        expect(slateTag).not.toBe('')
+        // Templated, transform-animating element: no WAAPI bootstrap, so no untemplated
+        // transform can paint before hydration/handoff (#402, gap 2).
+        expect(slateTag).not.toContain('data-framer-appear-id')
+        // First painted frame is already the templated transform.
+        expect(slateTag).toContain('translateY(0px)')
+
+        // Opacity-only template animates no transform → optimized appear stays on.
+        expect(openingTag('appear-mint')).toContain('data-framer-appear-id')
+        // No template at all → accelerated baseline keeps optimized appear.
+        expect(openingTag('appear-blue')).toContain('data-framer-appear-id')
+    })
+
+    test('settles every box on its templated/expected transform', async ({ page }) => {
+        await page.goto(URL)
+
+        // The boxes run a 1.6s enter; allow generous headroom so a cold/loaded
+        // preview server can't push the settle past the default poll timeout.
+        const settle = { timeout: 8000 }
+
+        // Slate: templated transform animates to the resting templated output.
+        await expect.poll(readStyle(page, 'appear-slate'), settle).toContain('translateY(70px)')
+        await expect.poll(readStyle(page, 'appear-slate'), settle).toContain('translateX(70px)')
+        await expect.poll(readStyle(page, 'appear-slate'), settle).toContain('opacity: 1')
+
+        // Mint: opacity-only enter, transform pinned at the fixed template.
+        await expect.poll(readStyle(page, 'appear-mint'), settle).toContain('translateY(24px)')
+        await expect.poll(readStyle(page, 'appear-mint'), settle).toContain('opacity: 1')
+
+        // Blue: accelerated transform settles at the untemplated target.
+        await expect.poll(readStyle(page, 'appear-blue'), settle).toContain('translateX(70px)')
+        await expect.poll(readStyle(page, 'appear-blue'), settle).toContain('opacity: 1')
+    })
+
+    test('counts exactly one optimized-appear transform animation on full load', async ({
+        page
+    }) => {
+        await page.goto(URL)
+
+        // The store only populates on a full server render (the SSR bootstrap script).
+        await expect(page.getByTestId('appear-fully-loaded')).toHaveText('yes')
+        // Blue baseline is the only accelerated transform; slate is suppressed.
+        await expect(page.getByTestId('appear-transform-count')).toContainText('1 (expect 1')
+    })
+
+    test('is linked from the root test index', async ({ page }) => {
+        await page.goto('/?@isPlaywright=true')
+        await expect(
+            page.getByRole('link', { name: /optimized appear suppression/ })
+        ).toHaveAttribute('href', /\/tests\/transform-template\/optimized-appear/)
+    })
+})

--- a/e2e/utilities/transform-template-stop.spec.ts
+++ b/e2e/utilities/transform-template-stop.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const URL = '/tests/transform-template/stop?@isPlaywright=true'
+
+const readOrbX = (page: Page) => async (): Promise<number | null> => {
+    const style = (await page.getByTestId('stop-orb').getAttribute('style')) ?? ''
+    const match = style.match(/translateX\(([-\d.]+)px\)/)
+    return match ? Number.parseFloat(match[1]) : null
+}
+
+test.describe('transformTemplate — controls.stop() freeze page', () => {
+    test('freezes the templated transform instantly on Stop', async ({ page }) => {
+        await page.goto(URL)
+        await expect(page.getByTestId('stop-orb')).toBeVisible()
+
+        const readX = readOrbX(page)
+
+        await page.getByTestId('stop-send').click()
+
+        // The run is a slow 4s linear move to x:320 — catch it mid-track.
+        await expect
+            .poll(
+                async () => {
+                    const x = await readX()
+                    return x !== null && x > 40 && x < 260
+                },
+                { timeout: 3000 }
+            )
+            .toBe(true)
+
+        await page.getByTestId('stop-stop').click()
+        const atStop = await readX()
+        expect(atStop).not.toBeNull()
+
+        await page.waitForTimeout(400)
+        const afterStop = await readX()
+
+        // Still-running linear 4s animation would advance ~32px in 400ms; a stopped
+        // templated-transform MotionValue animation stays put (#402, gap 1).
+        expect(Math.abs((afterStop ?? 0) - (atStop ?? 0))).toBeLessThan(5)
+        // Froze in place rather than snapping to the x:320 target...
+        expect(afterStop).toBeLessThan(300)
+        // ...the on-page status flips to FROZEN...
+        await expect(page.getByTestId('stop-status')).toHaveText('FROZEN')
+        // ...and the transformTemplate is still applied after stopping.
+        const style = (await page.getByTestId('stop-orb').getAttribute('style')) ?? ''
+        expect(style).toContain('translateY(')
+    })
+
+    test('Reset returns the orb to the origin', async ({ page }) => {
+        await page.goto(URL)
+        await expect(page.getByTestId('stop-orb')).toBeVisible()
+
+        await page.getByTestId('stop-send').click()
+        await expect.poll(readOrbX(page), { timeout: 3000 }).toBeGreaterThan(40)
+
+        await page.getByTestId('stop-reset').click()
+        // At the origin the templated transform collapses and translateX may be
+        // omitted entirely — an absent offset means the orb is back at x:0.
+        await expect
+            .poll(async () => (await readOrbX(page)()) ?? 0, { timeout: 3000 })
+            .toBeLessThan(2)
+        await expect(page.getByTestId('stop-status')).toHaveText('FROZEN')
+    })
+
+    test('is linked from the root test index', async ({ page }) => {
+        await page.goto('/?@isPlaywright=true')
+        await expect(page.getByRole('link', { name: /controls\.stop\(\) freeze/ })).toHaveAttribute(
+            'href',
+            /\/tests\/transform-template\/stop/
+        )
+    })
+})

--- a/e2e/utilities/transform-template.spec.ts
+++ b/e2e/utilities/transform-template.spec.ts
@@ -251,6 +251,85 @@ test.describe('transformTemplate', () => {
         expect(templatedIntermediateFrame).toBeTruthy()
     })
 
+    test('controls.stop() freezes an in-flight templated transform animation', async ({ page }) => {
+        await page.goto(URL)
+        await waitForMotionReady(page, 'template-controls-animated')
+
+        const readX = async (): Promise<number | null> => {
+            const style =
+                (await page.getByTestId('template-controls-animated').getAttribute('style')) ?? ''
+            const match = style.match(/translateX\(([-\d.]+)px\)/)
+            return match ? Number.parseFloat(match[1]) : null
+        }
+
+        await page.getByTestId('template-controls-animated-toggle').click()
+
+        // The controls animation is a 2.4s linear run to x:120 — let it reach mid-flight.
+        await expect
+            .poll(
+                async () => {
+                    const x = await readX()
+                    return x !== null && x > 20 && x < 100
+                },
+                { timeout: 3000 }
+            )
+            .toBe(true)
+
+        await page.getByTestId('template-controls-animated-stop').click()
+        const atStop = await readX()
+        expect(atStop).not.toBeNull()
+
+        await page.waitForTimeout(350)
+        const afterStop = await readX()
+
+        // A still-running linear 2.4s animation would advance ~17px in 350ms; a stopped
+        // one stays put. This is the #402 regression: controls.stop() must also stop the
+        // separate templated-transform MotionValue animation, not just DOM animations.
+        expect(Math.abs((afterStop ?? 0) - (atStop ?? 0))).toBeLessThan(5)
+        // It must freeze in place rather than snap to the x:120 target...
+        expect(afterStop).toBeLessThan(110)
+        // ...and the transformTemplate stays applied after stopping.
+        const styleAfter =
+            (await page.getByTestId('template-controls-animated').getAttribute('style')) ?? ''
+        expect(styleAfter).toContain('translateY(')
+    })
+
+    test('suppresses optimized appear for templated transform animations', async ({ page }) => {
+        const response = await page.request.get(URL)
+        const html = await response.text()
+
+        const openingTag = (testId: string): string =>
+            html.match(new RegExp(`<[a-zA-Z]+[^>]*data-testid="${testId}"[^>]*>`))?.[0] ?? ''
+
+        const appearTag = openingTag('template-appear')
+        expect(appearTag).not.toBe('')
+        // Transform-animating appear under a template must skip the WAAPI bootstrap so it
+        // can never paint an untemplated transform before hydration/handoff (#402).
+        expect(appearTag).not.toContain('data-framer-appear-id')
+        // The first painted frame is already the templated transform.
+        expect(appearTag).toContain('translateY(0px)')
+
+        // Opacity-only appear under a template animates no transform, so acceleration stays on.
+        const opacityTag = openingTag('template-appear-opacity')
+        expect(opacityTag).not.toBe('')
+        expect(opacityTag).toContain('data-framer-appear-id')
+    })
+
+    test('settles a templated optimized-appear element on the templated transform', async ({
+        page
+    }) => {
+        await page.goto(URL)
+
+        await waitForMotionReady(page, 'template-appear')
+        await expect
+            .poll(readStyleAttribute(page, 'template-appear'))
+            .toContain('translateY(120px)')
+        await expect
+            .poll(readStyleAttribute(page, 'template-appear'))
+            .toContain('translateX(120px)')
+        await expect.poll(readStyleAttribute(page, 'template-appear')).toContain('opacity: 1')
+    })
+
     test('preserves style transforms during templated target animations', async ({ page }) => {
         await page.goto(URL)
 
@@ -345,9 +424,8 @@ test.describe('transformTemplate', () => {
 
     test('is linked from the root test index', async ({ page }) => {
         await page.goto('/?@isPlaywright=true')
-        await expect(page.getByRole('link', { name: 'transformTemplate' })).toHaveAttribute(
-            'href',
-            /\/tests\/transform-template/
-        )
+        await expect(
+            page.getByRole('link', { name: 'transformTemplate', exact: true })
+        ).toHaveAttribute('href', /\/tests\/transform-template/)
     })
 })

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -755,19 +755,31 @@
             reducedMotion
         )
     )
-    const optimizedAppearId = $derived(
-        effectiveInitialProp !== false &&
-            isNotEmpty(initialKeyframes) &&
-            isNotEmpty(animateKeyframes)
-            ? `svelte-motion-${componentHydrationId}`
-            : undefined
-    )
     const optimizedAppearEntries = $derived(
         createOptimizedAppearData(
             initialKeyframes as Record<string, unknown> | undefined,
             animateKeyframes as Record<string, unknown> | undefined,
             mergedTransition
         )
+    )
+    // Upstream never WAAPI-accelerates `transform` while a `transformTemplate`
+    // is present (motion-dom waapi.ts: `name !== "transform" || !transformTemplate`).
+    // Our optimized-appear handoff is all-or-nothing per element, so when the
+    // appear animation would include a transform under a template we suppress the
+    // bootstrap entirely and let the main-thread enter animation run the templated
+    // transform. That prevents an untemplated transform from painting before
+    // hydration/handoff. Opacity-only appears are unaffected and stay accelerated. (#402)
+    const optimizedAppearSuppressedByTransformTemplate = $derived(
+        !!transformTemplateProp &&
+            optimizedAppearEntries.some((entry) => entry.name === 'transform')
+    )
+    const optimizedAppearId = $derived(
+        effectiveInitialProp !== false &&
+            isNotEmpty(initialKeyframes) &&
+            isNotEmpty(animateKeyframes) &&
+            !optimizedAppearSuppressedByTransformTemplate
+            ? `svelte-motion-${componentHydrationId}`
+            : undefined
     )
     const optimizedAppearScript = $derived(
         createOptimizedAppearScript(optimizedAppearId, optimizedAppearEntries)
@@ -1231,6 +1243,13 @@
     const stopAnimationControlsAnimations = () => {
         animationControlsHasReceivedCommand = true
         animationControlsGeneration += 1
+
+        // The templated-transform path animates MotionValues that are not part of
+        // `activeAnimationControls` and never surface in `element.getAnimations()`,
+        // so a public `controls.stop()` would otherwise leak a running templated
+        // transform animation (and its style-effect cleanup). Upstream stops a
+        // VisualElement by stopping all of its values; mirror that here. (#402)
+        cleanupTemplatedTransformAnimations()
 
         for (const control of activeAnimationControls) {
             if (typeof control.stop === 'function') {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -88,6 +88,22 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/transform-template/stop') + searchParams}
+                    >
+                        transformTemplate — controls.stop() freeze (#402)
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/transform-template/optimized-appear') + searchParams}
+                    >
+                        transformTemplate — optimized appear suppression (#402)
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/conic-gradient') + searchParams}
                     >
                         useTransform (conic gradient / compute form)

--- a/src/routes/tests/transform-template/+page.svelte
+++ b/src/routes/tests/transform-template/+page.svelte
@@ -110,6 +110,10 @@
         )
     }
 
+    function stopControlsAnimation() {
+        controls.stop()
+    }
+
     function toggleStyleAnimation() {
         styleAnimated = !styleAnimated
     }
@@ -320,6 +324,13 @@
                 >
                     {controlsSent ? 'Back' : 'Send'}
                 </button>
+                <button
+                    type="button"
+                    data-testid="template-controls-animated-stop"
+                    onclick={stopControlsAnimation}
+                >
+                    Stop
+                </button>
             </div>
         </article>
 
@@ -412,6 +423,46 @@
                 transformTemplate={perspectiveTemplate}
             >
                 lens
+            </motion.div>
+        </article>
+
+        <article>
+            <h2>Optimized appear under template (transform)</h2>
+            <p class="expectation">
+                Animates <code>x</code> on mount under a template. Optimized appear must be
+                suppressed (no <code>data-framer-appear-id</code>) so the WAAPI bootstrap never
+                paints an untemplated transform. First frame: <code>translateY(0px)</code>; settles
+                at <code>translateY(120px) translateX(120px)</code>.
+            </p>
+            <motion.div
+                class="orb slate"
+                data-testid="template-appear"
+                initial={{ opacity: 0, x: 0 }}
+                animate={{ opacity: 1, x: 120 }}
+                transformTemplate={xMirrorTemplate}
+                transition={{ duration: 0.4, ease: 'linear' }}
+            >
+                appear
+            </motion.div>
+        </article>
+
+        <article>
+            <h2>Optimized appear under template (opacity only)</h2>
+            <p class="expectation">
+                Animates only <code>opacity</code> on mount under a fixed template. No transform is
+                accelerated, so optimized appear stays on (keeps
+                <code>data-framer-appear-id</code>) while the template still renders
+                <code>translateY(20px)</code>.
+            </p>
+            <motion.div
+                class="orb mint"
+                data-testid="template-appear-opacity"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transformTemplate={fixedTemplate}
+                transition={{ duration: 0.4, ease: 'linear' }}
+            >
+                fade
             </motion.div>
         </article>
 

--- a/src/routes/tests/transform-template/optimized-appear/+page.svelte
+++ b/src/routes/tests/transform-template/optimized-appear/+page.svelte
@@ -42,7 +42,7 @@
     onMount(() => {
         // The optimized-appear store only populates on a full server render (the SSR
         // <script> bootstrap). It is empty after client-side (SPA) navigation.
-        fullyLoaded = (window.__SvelteMotionAppear?.started.length ?? 0) > 0
+        fullyLoaded = (window.__SvelteMotionAppear?.started?.length ?? 0) > 0
 
         let raf = 0
         const tick = () => {

--- a/src/routes/tests/transform-template/optimized-appear/+page.svelte
+++ b/src/routes/tests/transform-template/optimized-appear/+page.svelte
@@ -1,0 +1,275 @@
+<script lang="ts">
+    import { onMount } from 'svelte'
+    import { motion } from '$lib'
+    import type { TransformTemplate } from 'motion-dom'
+
+    /**
+     * Isolated failure page for #402, gap 2: optimized appear must never paint an
+     * untemplated transform. Upstream never WAAPI-accelerates `transform` while a
+     * `transformTemplate` is present, so we suppress the SSR appear bootstrap for a
+     * templated, transform-animating element and let the main-thread enter run it.
+     *
+     * Eye-verify: full-reload this route (Cmd/Ctrl+Shift+R). Watch the SLATE box —
+     * the template adds the vertical drop, so it must move down-and-right together as
+     * ONE templated motion, never flashing a bare horizontal slide first. The MINT box
+     * (opacity-only template) and BLUE box (no template) are baselines that keep appear.
+     */
+
+    // translateY(x) wraps the generated transform — every frame stays templated.
+    const liftTemplate: TransformTemplate = ({ x }, generated) =>
+        `translateY(${x ?? '0px'}) ${generated}`.trim()
+
+    // Fixed lift regardless of latest values; used by the opacity-only baseline.
+    const fixedTemplate: TransformTemplate = () => 'translateY(24px)'
+
+    let slateStyle = $state('')
+    let mintStyle = $state('')
+    let blueStyle = $state('')
+    let appearStarted = $state<{ id: string; name: string }[]>([])
+    let fullyLoaded = $state(false)
+
+    const transformAppearCount = $derived(
+        appearStarted.filter((entry) => entry.name === 'transform').length
+    )
+    const opacityAppearCount = $derived(
+        appearStarted.filter((entry) => entry.name === 'opacity').length
+    )
+
+    function reload() {
+        if (typeof location !== 'undefined') location.reload()
+    }
+
+    onMount(() => {
+        // The optimized-appear store only populates on a full server render (the SSR
+        // <script> bootstrap). It is empty after client-side (SPA) navigation.
+        fullyLoaded = (window.__SvelteMotionAppear?.started.length ?? 0) > 0
+
+        let raf = 0
+        const tick = () => {
+            const read = (testId: string) =>
+                document
+                    .querySelector<HTMLElement>(`[data-testid="${testId}"]`)
+                    ?.getAttribute('style') ?? ''
+            slateStyle = read('appear-slate')
+            mintStyle = read('appear-mint')
+            blueStyle = read('appear-blue')
+            appearStarted = [...(window.__SvelteMotionAppear?.started ?? [])]
+            raf = requestAnimationFrame(tick)
+        }
+        raf = requestAnimationFrame(tick)
+        return () => cancelAnimationFrame(raf)
+    })
+</script>
+
+<svelte:head>
+    <title>transformTemplate — optimized appear suppression (#402)</title>
+</svelte:head>
+
+<main class="page">
+    <h1>Optimized appear under a transformTemplate</h1>
+    <p class="expectation">
+        Full-reload this route and watch the <strong>slate</strong> box: the template adds the
+        vertical drop, so it must move <em>down-and-right together</em> as one templated motion —
+        never flashing a bare horizontal slide first. The SSR appear bootstrap is suppressed for it
+        (no <code>data-framer-appear-id</code>) so an untemplated transform can never paint first.
+        The <strong>mint</strong> (opacity-only) and <strong>blue</strong> (no template) boxes are baselines
+        that keep optimized appear.
+    </p>
+
+    <button type="button" class="reload" data-testid="appear-reload" onclick={reload}>
+        ⟳ Full-reload to replay the enter
+    </button>
+
+    <section class="grid">
+        <article>
+            <h2>Templated transform — suppressed</h2>
+            <div class="stage">
+                <motion.div
+                    class="box slate"
+                    data-testid="appear-slate"
+                    initial={{ opacity: 0, x: 0 }}
+                    animate={{ opacity: 1, x: 70 }}
+                    transformTemplate={liftTemplate}
+                    transition={{ duration: 1.6, ease: 'linear' }}
+                >
+                    slate
+                </motion.div>
+            </div>
+            <p class="expect-good">
+                Expect: no appear id · transform stays <code>translateY</code>
+            </p>
+            <p class="mono" data-testid="appear-slate-style">{slateStyle}</p>
+        </article>
+
+        <article>
+            <h2>Opacity-only template — active</h2>
+            <div class="stage">
+                <motion.div
+                    class="box mint"
+                    data-testid="appear-mint"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    transformTemplate={fixedTemplate}
+                    transition={{ duration: 1.6, ease: 'linear' }}
+                >
+                    mint
+                </motion.div>
+            </div>
+            <p class="expect-good">Expect: keeps appear id · <code>translateY(24px)</code> fixed</p>
+            <p class="mono" data-testid="appear-mint-style">{mintStyle}</p>
+        </article>
+
+        <article>
+            <h2>No template — accelerated baseline</h2>
+            <div class="stage">
+                <motion.div
+                    class="box blue"
+                    data-testid="appear-blue"
+                    initial={{ opacity: 0, x: 0 }}
+                    animate={{ opacity: 1, x: 70 }}
+                    transition={{ duration: 1.6, ease: 'linear' }}
+                >
+                    blue
+                </motion.div>
+            </div>
+            <p class="expect-good">Expect: keeps appear id · accelerated transform</p>
+            <p class="mono" data-testid="appear-blue-style">{blueStyle}</p>
+        </article>
+    </section>
+
+    <dl class="stats" data-testid="appear-stats">
+        <dt>Full server render?</dt>
+        <dd data-testid="appear-fully-loaded">{fullyLoaded ? 'yes' : 'no (SPA nav — reload)'}</dd>
+        <dt>Optimized-appear <em>transform</em> animations</dt>
+        <dd data-testid="appear-transform-count" class:good={transformAppearCount === 1}>
+            {transformAppearCount} (expect 1 — blue baseline only; slate suppressed)
+        </dd>
+        <dt>Optimized-appear <em>opacity</em> animations</dt>
+        <dd data-testid="appear-opacity-count">{opacityAppearCount}</dd>
+    </dl>
+</main>
+
+<style>
+    /* Dark backdrop so the light heading/description text stays readable
+       regardless of the app's default (light) page background. */
+    :global(body) {
+        background: #0a0f1c;
+    }
+    .page {
+        margin: 0 auto;
+        min-height: 100vh;
+        max-width: 940px;
+        padding: 2rem 1rem;
+        color: #e5e7eb;
+        font-family: system-ui, sans-serif;
+    }
+    h1 {
+        font-size: 1.4rem;
+        font-weight: 600;
+    }
+    h2 {
+        font-size: 0.95rem;
+        font-weight: 600;
+        margin: 0 0 0.5rem;
+    }
+    .expectation {
+        margin: 0.5rem 0 1rem;
+        color: #cbd5e1;
+        line-height: 1.5;
+    }
+    code {
+        background: #1e293b;
+        padding: 0.05rem 0.3rem;
+        border-radius: 0.25rem;
+    }
+    .reload {
+        background: #1d4ed8;
+        color: white;
+        border: 0;
+        border-radius: 0.4rem;
+        padding: 0.5rem 1rem;
+        font-size: 0.85rem;
+        cursor: pointer;
+        margin-bottom: 1.5rem;
+    }
+    .reload:hover {
+        background: #2563eb;
+    }
+    .grid {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+    article {
+        background: #0b1220;
+        border: 1px solid #1e293b;
+        border-radius: 0.5rem;
+        padding: 1rem;
+    }
+    .stage {
+        position: relative;
+        height: 150px;
+        border-radius: 0.4rem;
+        background: #060b16;
+        overflow: hidden;
+    }
+    /* Scoped classes don't pierce into the <motion.div> component's rendered
+       element, so the box styles must be global to take effect. */
+    :global(.stage .box) {
+        position: absolute;
+        top: 14px;
+        left: 14px;
+        width: 52px;
+        height: 52px;
+        border-radius: 0.5rem;
+        display: grid;
+        place-items: center;
+        font-size: 0.75rem;
+        color: white;
+    }
+    :global(.stage .box.slate) {
+        background: linear-gradient(135deg, #64748b, #334155);
+    }
+    :global(.stage .box.mint) {
+        background: linear-gradient(135deg, #34d399, #059669);
+    }
+    :global(.stage .box.blue) {
+        background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+    }
+    .expect-good {
+        margin: 0.6rem 0 0.3rem;
+        color: #94a3b8;
+        font-size: 0.78rem;
+    }
+    .mono {
+        font-family: ui-monospace, monospace;
+        font-size: 0.7rem;
+        color: #cbd5e1;
+        word-break: break-all;
+        margin: 0;
+        /* Reserve height so cards don't reflow as the live style string changes. */
+        min-height: 2.4em;
+    }
+    .stats {
+        display: grid;
+        grid-template-columns: 22rem 1fr;
+        gap: 0.35rem 1rem;
+        background: #0b1220;
+        border: 1px solid #1e293b;
+        border-radius: 0.5rem;
+        padding: 1rem;
+        margin-top: 1.5rem;
+        font-size: 0.85rem;
+    }
+    .stats dt {
+        color: #94a3b8;
+    }
+    .stats dd {
+        margin: 0;
+        font-variant-numeric: tabular-nums;
+    }
+    .stats dd.good {
+        color: #34d399;
+        font-weight: 700;
+    }
+</style>

--- a/src/routes/tests/transform-template/stop/+page.svelte
+++ b/src/routes/tests/transform-template/stop/+page.svelte
@@ -1,0 +1,251 @@
+<script lang="ts">
+    import { onMount } from 'svelte'
+    import { motion, useAnimationControls } from '$lib'
+    import type { TransformTemplate } from 'motion-dom'
+
+    /**
+     * Isolated failure page for #402, gap 1: `controls.stop()` must stop the
+     * separate templated-transform MotionValue animation, not just DOM animations.
+     *
+     * Eye-verify: click "Send", then "Stop" while the orb is mid-track. With the
+     * fix the orb freezes instantly and keeps its `translateY(...)` template. The
+     * pre-fix bug let the templated transform keep gliding to the target after Stop.
+     */
+    const controls = useAnimationControls()
+
+    // A constant lift is prepended around Motion's generated transform so every
+    // frame is visibly templated, while keeping the orb inside the track (the lift
+    // must NOT scale with x, or a large x would push the orb out of view).
+    const transformTemplate: TransformTemplate = (_latest, generated) =>
+        `translateY(-22px) ${generated}`.trim()
+
+    let sent = $state(false)
+    let inlineStyle = $state('')
+    let currentX = $state<number | null>(null)
+    let capturedAtStop = $state<number | null>(null)
+    let status = $state<'idle' | 'moving' | 'frozen'>('idle')
+
+    const readX = (style: string): number | null => {
+        const match = style.match(/translateX\(([-\d.]+)px\)/)
+        return match ? Number.parseFloat(match[1]) : null
+    }
+
+    function send() {
+        capturedAtStop = null
+        sent = !sent
+        // Slow + linear so there is plenty of track to Stop in the middle of.
+        void controls.start({ x: sent ? 320 : 0 }, { duration: 4, ease: 'linear' })
+    }
+
+    function stop() {
+        controls.stop()
+        capturedAtStop = currentX
+    }
+
+    function reset() {
+        controls.stop()
+        capturedAtStop = null
+        sent = false
+        void controls.start({ x: 0 }, { duration: 0 })
+    }
+
+    onMount(() => {
+        let raf = 0
+        const history: number[] = []
+
+        const tick = () => {
+            const element = document.querySelector<HTMLElement>('[data-testid="stop-orb"]')
+            if (element) {
+                const style = element.getAttribute('style') ?? ''
+                inlineStyle = style
+                const x = readX(style)
+                currentX = x
+
+                // At the origin the templated transform collapses and translateX
+                // is omitted — treat an absent offset as 0 so the status can settle
+                // to "frozen" instead of sticking on its last sampled value.
+                history.push(x ?? 0)
+                if (history.length > 8) history.shift()
+                const spread = Math.max(...history) - Math.min(...history)
+                status = spread > 0.5 ? 'moving' : 'frozen'
+            }
+            raf = requestAnimationFrame(tick)
+        }
+
+        raf = requestAnimationFrame(tick)
+        return () => cancelAnimationFrame(raf)
+    })
+</script>
+
+<svelte:head>
+    <title>transformTemplate — controls.stop() freeze (#402)</title>
+</svelte:head>
+
+<main class="page">
+    <h1>controls.stop() during a templated transform</h1>
+    <p class="expectation">
+        Click <strong>Send</strong> to start a slow 4s linear move to <code>x: 320</code>. Click
+        <strong>Stop</strong> while the orb is mid-track. It must
+        <strong>freeze instantly</strong> and keep <code>translateY(...)</code> in its transform. Bug
+        (#402): without the fix the templated transform keeps gliding to the target after Stop.
+    </p>
+
+    <div class="track">
+        <div class="target" aria-hidden="true">target</div>
+        <motion.div
+            class="orb"
+            data-testid="stop-orb"
+            initial={{ x: 0 }}
+            animate={controls}
+            {transformTemplate}
+            controls
+        >
+            orb
+        </motion.div>
+    </div>
+
+    <div class="controls">
+        <button type="button" data-testid="stop-send" onclick={send}>
+            {sent ? 'Send back' : 'Send →'}
+        </button>
+        <button type="button" data-testid="stop-stop" onclick={stop}>Stop</button>
+        <button type="button" data-testid="stop-reset" onclick={reset}>Reset</button>
+    </div>
+
+    <dl class="readout">
+        <dt>Status</dt>
+        <dd
+            data-testid="stop-status"
+            class:moving={status === 'moving'}
+            class:frozen={status === 'frozen'}
+        >
+            {status.toUpperCase()}
+        </dd>
+        <dt>translateX</dt>
+        <dd data-testid="stop-current-x">{currentX === null ? '—' : `${currentX.toFixed(1)}px`}</dd>
+        <dt>captured at Stop</dt>
+        <dd data-testid="stop-captured-x">
+            {capturedAtStop === null ? '—' : `${capturedAtStop.toFixed(1)}px`}
+        </dd>
+        <dt>inline style</dt>
+        <dd class="mono" data-testid="stop-inline-style">{inlineStyle}</dd>
+    </dl>
+</main>
+
+<style>
+    /* Dark backdrop so the light heading/description text stays readable
+       regardless of the app's default (light) page background. */
+    :global(body) {
+        background: #0a0f1c;
+    }
+    .page {
+        margin: 0 auto;
+        min-height: 100vh;
+        max-width: 720px;
+        padding: 2rem 1rem;
+        color: #e5e7eb;
+        font-family: system-ui, sans-serif;
+    }
+    h1 {
+        font-size: 1.4rem;
+        font-weight: 600;
+    }
+    .expectation {
+        margin: 0.5rem 0 1.5rem;
+        color: #cbd5e1;
+        line-height: 1.5;
+    }
+    code {
+        background: #1e293b;
+        padding: 0.05rem 0.3rem;
+        border-radius: 0.25rem;
+    }
+    .track {
+        position: relative;
+        height: 120px;
+        border: 1px dashed #334155;
+        border-radius: 0.5rem;
+        background: #0b1220;
+        overflow: hidden;
+    }
+    .target {
+        position: absolute;
+        top: 50%;
+        left: 360px;
+        translate: 0 -50%;
+        color: #64748b;
+        font-size: 0.75rem;
+        border-left: 2px dotted #475569;
+        padding-left: 0.4rem;
+        height: 60px;
+        display: flex;
+        align-items: center;
+    }
+    /* Scoped classes don't pierce into the <motion.div> component's rendered
+       element, so the orb styles must be global to take effect. */
+    :global(.track .orb) {
+        position: absolute;
+        top: 50%;
+        left: 16px;
+        translate: 0 -50%;
+        width: 56px;
+        height: 56px;
+        border-radius: 0.6rem;
+        background: linear-gradient(135deg, #ec4899, #8b5cf6);
+        display: grid;
+        place-items: center;
+        font-size: 0.75rem;
+        color: white;
+    }
+    .controls {
+        display: flex;
+        gap: 0.5rem;
+        margin: 1rem 0;
+    }
+    button {
+        background: #1d4ed8;
+        color: white;
+        border: 0;
+        border-radius: 0.4rem;
+        padding: 0.45rem 0.9rem;
+        font-size: 0.85rem;
+        cursor: pointer;
+    }
+    button:hover {
+        background: #2563eb;
+    }
+    .readout {
+        display: grid;
+        grid-template-columns: 10rem 1fr;
+        gap: 0.35rem 1rem;
+        background: #0b1220;
+        border: 1px solid #1e293b;
+        border-radius: 0.5rem;
+        padding: 1rem;
+        font-size: 0.85rem;
+    }
+    .readout dt {
+        color: #94a3b8;
+    }
+    .readout dd {
+        margin: 0;
+        font-variant-numeric: tabular-nums;
+    }
+    .readout dd.mono {
+        font-family: ui-monospace, monospace;
+        font-size: 0.75rem;
+        word-break: break-all;
+        color: #cbd5e1;
+        /* Reserve two lines so the row height never jumps as the live transform
+           string grows/shrinks each frame. */
+        min-height: 2.4em;
+    }
+    .readout dd.moving {
+        color: #f87171;
+        font-weight: 700;
+    }
+    .readout dd.frozen {
+        color: #34d399;
+        font-weight: 700;
+    }
+</style>


### PR DESCRIPTION
## Summary

Closes #402. Closes two `transformTemplate` lifecycle gaps flagged as follow-up to #399/#400, verified against `motion-dom` source. These are correctness fixes in the templated-transform path — no public API changes.

## Changes

🐛 **`controls.stop()` now stops the templated-transform path**
The templated path animates MotionValues that aren't in `activeAnimationControls` and never surface in `element.getAnimations()`, so `controls.stop()` previously leaked a running templated transform (and its style-effect cleanup). It now mirrors upstream's "stop a VisualElement by stopping all its values" via `cleanupTemplatedTransformAnimations()`.

🐛 **Optimized appear no longer paints an untemplated transform**
Upstream never WAAPI-accelerates `transform` under a `transformTemplate` (`motion-dom` `waapi.ts`: `name !== "transform" || !transformTemplate`). Since our handoff is all-or-nothing per element, we suppress the SSR appear bootstrap whenever its data would include a transform under a template, letting the main-thread enter run the templated transform. Opacity-only appears stay accelerated.

🧪 **Tests + eye-verify demo pages**
- Regression coverage in `e2e/utilities/transform-template.spec.ts`, each proven to fail when the fix is reverted.
- Two isolated failure/verify pages — `/tests/transform-template/stop` and `/tests/transform-template/optimized-appear` — with their own e2e specs, linked from the demo index.

## Verification

- All transform-template e2e green (25 across the three specs); full unit suite green (637); `pnpm check` 0 errors; lint clean.
- Each fix proven meaningful by temporarily neutralizing it and confirming the new tests/pages fail.

## Commits

- [`2f7df25`](https://github.com/humanspeak/svelte-motion/commit/2f7df25) fix(transform-template): align stop and optimized-appear lifecycle with upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)
