### PR TITLE
feat(reorder): Reorder.Group + Reorder.Item drag-to-reorder

### DIFF
--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -47,7 +47,8 @@ export const docsSections: NavSection[] = [
                 icon: ArrowUpDown
             },
             { title: 'LazyMotion', href: '/docs/lazy-motion', icon: Zap },
-            { title: 'MotionConfig', href: '/docs/motion-config', icon: Settings }
+            { title: 'MotionConfig', href: '/docs/motion-config', icon: Settings },
+            { title: 'Reorder', href: '/docs/reorder', icon: ArrowUpDown }
         ]
     },
     {

--- a/docs/src/lib/examples/ReorderExample.svelte
+++ b/docs/src/lib/examples/ReorderExample.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+    import { Reorder } from '@humanspeak/svelte-motion'
+
+    let items = $state(['🍅 Tomato', '🥒 Cucumber', '🧀 Cheese', '🥬 Lettuce'])
+</script>
+
+<div class="flex flex-col items-center gap-4">
+    <p class="text-text-muted text-sm">Drag items to reorder the list</p>
+    <Reorder.Group
+        axis="y"
+        values={items}
+        onReorder={(next: string[]) => (items = next)}
+        class="m-0 w-64 list-none p-0"
+    >
+        {#each items as item (item)}
+            <Reorder.Item
+                value={item}
+                whileDrag={{ scale: 1.03 }}
+                class="mb-2 flex h-11 cursor-grab items-center rounded-lg bg-white px-4 text-sm font-medium text-neutral-900 shadow select-none"
+            >
+                {item}
+            </Reorder.Item>
+        {/each}
+    </Reorder.Group>
+</div>

--- a/docs/src/lib/examples/reorder/demos/Default.svelte
+++ b/docs/src/lib/examples/reorder/demos/Default.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+    import { Reorder } from '@humanspeak/svelte-motion'
+
+    // The motion.dev Reorder demo: drag items vertically to reorder the
+    // list. Dragged items pin under the cursor while siblings FLIP out
+    // of the way; releasing springs the item into its new slot.
+
+    let items = $state(['🍅 Tomato', '🥒 Cucumber', '🧀 Cheese', '🥬 Lettuce'])
+</script>
+
+<!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
+<div class="dk-demo-shell">
+    <Reorder.Group
+        axis="y"
+        values={items}
+        onReorder={(next: string[]) => (items = next)}
+        style="list-style: none; padding: 0; margin: 0; width: 260px;"
+    >
+        {#each items as item (item)}
+            <Reorder.Item
+                value={item}
+                whileDrag={{ scale: 1.03, boxShadow: '0 6px 16px rgba(0,0,0,0.25)' }}
+                style="display: flex; align-items: center; height: 44px; padding: 0 16px; margin-bottom: 10px; background: white; color: #0f1115; border-radius: 10px; box-shadow: 0 1px 3px rgba(0,0,0,0.2); cursor: grab; user-select: none; -webkit-user-select: none; font-weight: 500;"
+            >
+                {item}
+            </Reorder.Item>
+        {/each}
+    </Reorder.Group>
+</div>
+
+<style>
+    .dk-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 320px;
+    }
+</style>

--- a/docs/src/lib/examples/reorder/demos/Scrollable.svelte
+++ b/docs/src/lib/examples/reorder/demos/Scrollable.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+    import { motion, Reorder } from '@humanspeak/svelte-motion'
+
+    // A long list inside a fixed-height scroll container. `layoutScroll`
+    // keeps layout measurements correct while the container scrolls, and
+    // dragging an item near the top or bottom edge auto-scrolls the list
+    // so the whole thing can be traversed in one gesture.
+
+    let items = $state([
+        'Aardvark',
+        'Beaver',
+        'Capybara',
+        'Dingo',
+        'Echidna',
+        'Fennec',
+        'Gecko',
+        'Hedgehog',
+        'Iguana',
+        'Jackal'
+    ])
+</script>
+
+<!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
+<div class="dk-demo-shell">
+    <motion.div
+        layoutScroll
+        style="height: 280px; width: 260px; overflow-y: scroll; padding: 10px; border-radius: 12px; background: rgba(120, 120, 140, 0.12);"
+    >
+        <Reorder.Group
+            axis="y"
+            values={items}
+            onReorder={(next: string[]) => (items = next)}
+            style="list-style: none; padding: 0; margin: 0;"
+        >
+            {#each items as item (item)}
+                <Reorder.Item
+                    value={item}
+                    whileDrag={{ scale: 1.03, boxShadow: '0 6px 16px rgba(0,0,0,0.25)' }}
+                    style="display: flex; align-items: center; height: 42px; padding: 0 16px; margin-bottom: 8px; background: white; color: #0f1115; border-radius: 10px; box-shadow: 0 1px 3px rgba(0,0,0,0.2); cursor: grab; user-select: none; -webkit-user-select: none; font-weight: 500;"
+                >
+                    {item}
+                </Reorder.Item>
+            {/each}
+        </Reorder.Group>
+    </motion.div>
+</div>
+
+<style>
+    .dk-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 340px;
+    }
+</style>

--- a/docs/src/routes/docs/reorder/+page.svx
+++ b/docs/src/routes/docs/reorder/+page.svx
@@ -1,0 +1,188 @@
+---
+title: Reorder
+description: Drag-to-reorder lists with automatic layout animations, axis locking, and edge auto-scroll
+---
+
+<script>
+  import Example from '$lib/components/general/Example.svelte'
+  import ReorderExample from '$lib/examples/ReorderExample.svelte'
+  import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+  const seo = getSeoContext()
+  if (seo) {
+      seo.title = 'Reorder | Docs | Svelte Motion'
+      seo.description = 'Drag-to-reorder lists with automatic layout animations using Svelte Motion. Framer Motion-compatible Reorder.Group and Reorder.Item components.'
+      seo.ogTitle = 'Reorder'
+      seo.ogTagline = 'Drag-to-reorder lists with automatic layout animations'
+      seo.ogFeatures = ['Drag To Reorder', 'FLIP Siblings', 'Axis Locking', 'Edge Auto-Scroll']
+      seo.ogSlug = 'docs-reorder'
+  }
+</script>
+
+# Reorder
+
+`Reorder.Group` and `Reorder.Item` create drag-to-reorder lists — sortable tabs, to-do items, playlists — with a couple of lines of markup. Dragged items lock to the list axis and stay pinned under the cursor while their siblings spring out of the way.
+
+```svelte
+<script lang="ts">
+    import { Reorder } from '@humanspeak/svelte-motion'
+
+    let items = $state([0, 1, 2, 3])
+</script>
+
+<Reorder.Group axis="y" values={items} onReorder={(next) => (items = next)}>
+    {#each items as item (item)}
+        <Reorder.Item value={item}>{item}</Reorder.Item>
+    {/each}
+</Reorder.Group>
+```
+
+<Example isSmall>
+  <ReorderExample />
+</Example>
+
+## Usage
+
+Every reorderable list needs three things wired together:
+
+1. **`values`** — the array driving the list, passed to `Reorder.Group`.
+2. **`onReorder`** — a callback that receives the new order. Assign it back to the state that renders the list.
+3. **`value`** — each `Reorder.Item` declares which entry it represents. Use the same value as the `{#each}` key.
+
+```svelte
+<script lang="ts">
+    import { Reorder } from '@humanspeak/svelte-motion'
+
+    let tabs = $state(['Home', 'Search', 'Library'])
+</script>
+
+<Reorder.Group axis="x" values={tabs} onReorder={(next) => (tabs = next)}>
+    {#each tabs as tab (tab)}
+        <Reorder.Item value={tab}>{tab}</Reorder.Item>
+    {/each}
+</Reorder.Group>
+```
+
+The group renders a `ul` and items render `li` by default. Change either with `as`:
+
+```svelte
+<Reorder.Group as="div" values={items} onReorder={handleReorder}>
+    <Reorder.Item as="article" value={item} />
+</Reorder.Group>
+```
+
+## Axis
+
+Lists reorder along one axis — `"y"` by default, `"x"` for horizontal lists — and items drag-lock to it. To let an item move freely on both axes while still reordering on the list axis, pass `drag` to the item:
+
+```svelte
+<Reorder.Item value={item} drag>{item}</Reorder.Item>
+```
+
+## Layout animations
+
+Items carry `layout` automatically, so displaced siblings FLIP to their new slots while the drag is live, and the dragged item springs into its new slot on release. If an item changes size while reordering, pass `layout="position"` to skip size projection:
+
+```svelte
+<Reorder.Item value={item} layout="position">{item}</Reorder.Item>
+```
+
+Items float above their siblings while dragging via an automatic `z-index`. To make that work, items default to `position: relative` — override it via `style` if your layout needs something else, but keep items positioned so the floating z-index applies.
+
+## Scrollable lists
+
+Lists taller than their container work out of the box — dragging an item near the container's edge auto-scrolls it, so long lists can be traversed in a single gesture.
+
+Mark the scrollable container with `layoutScroll` so layout measurements stay correct while it scrolls:
+
+```svelte
+<script lang="ts">
+    import { motion, Reorder } from '@humanspeak/svelte-motion'
+
+    let items = $state([...Array(20).keys()])
+</script>
+
+<motion.div layoutScroll style="height: 300px; overflow-y: scroll">
+    <Reorder.Group values={items} onReorder={(next) => (items = next)}>
+        {#each items as item (item)}
+            <Reorder.Item value={item}>{item}</Reorder.Item>
+        {/each}
+    </Reorder.Group>
+</motion.div>
+```
+
+The window works as the scroll container too — lists below the fold reorder correctly at any scroll position, and dragging near the viewport edge scrolls the page.
+
+## Observing the drag offset
+
+Items accept external MotionValues for `x`/`y` through `style`, so you can observe or drive the live drag offset — for example to fade a shadow in while an item is lifted:
+
+```svelte
+<script lang="ts">
+    import { Reorder, useMotionValue, useTransform } from '@humanspeak/svelte-motion'
+
+    const y = useMotionValue(0)
+    const boxShadow = useTransform(y, (latest) =>
+        `0 ${Math.min(Math.abs(latest) / 4, 8)}px 16px rgba(0,0,0,0.2)`
+    )
+</script>
+
+<Reorder.Item value={item} style={{ y, boxShadow }}>{item}</Reorder.Item>
+```
+
+## Drag props and callbacks
+
+Items are motion components underneath — every [drag prop](/docs/drag) (`whileDrag`, `dragListener`, `dragControls`, `onDragStart`, …) passes straight through:
+
+```svelte
+<Reorder.Item
+    value={item}
+    whileDrag={{ scale: 1.03 }}
+    onDragStart={() => (grabbed = item)}
+    onDragEnd={() => (grabbed = null)}
+>
+    {item}
+</Reorder.Item>
+```
+
+`dragSnapToOrigin` is managed by Reorder itself — the "origin" an item snaps back to is its current slot, which updates as the order changes.
+
+## Notes
+
+- Reordering swaps values only while the pointer moves — a swap fires when the dragged item's edge crosses the midpoint of its neighbor.
+- `values` can hold any type — strings, numbers, or objects (compared by reference). Keep the `{#each}` key and the item `value` in sync.
+- Wrap-around grids (an `x` drag causing a `y` slot shift) aren't supported yet — reordering is single-axis, matching Framer Motion.
+
+## Props
+
+### Reorder.Group
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `values` | `V[]` | — | The current order of item values (required) |
+| `onReorder` | `(newOrder: V[]) => void` | — | Fires with the new order after a swap (required) |
+| `axis` | `'x' \| 'y'` | `'y'` | The axis to reorder along |
+| `as` | `string` | `'ul'` | The HTML element to render |
+
+All other motion props are forwarded to the underlying motion element.
+
+### Reorder.Item
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `V` | — | The entry in `values` this item represents (required) |
+| `as` | `string` | `'li'` | The HTML element to render |
+| `layout` | `true \| 'position'` | `true` | Layout animation mode while slots shuffle |
+| `drag` | `boolean \| 'x' \| 'y'` | group axis | Override the axis lock (e.g. `drag` frees both axes) |
+
+All other motion props — including every drag prop and callback — are forwarded to the underlying motion element.
+
+## Related
+
+- [Drag](/docs/drag) — The gesture system Reorder builds on
+- [Layout Animations](/docs/layout-animations) — How siblings FLIP between slots
+- [Motion values](/docs/motion-values) — Observe the live drag offset
+
+---
+
+Based on [Motion's Reorder](https://motion.dev/docs/react-reorder) API.

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -104,6 +104,11 @@ const EXAMPLES: Record<string, ExampleEntry> = {
         title: 'Path Morphing',
         description: 'Interactive path morphing animation example using Svelte Motion.'
     },
+    reorder: {
+        title: 'Reorder',
+        description:
+            'Drag-to-reorder lists with Reorder.Group and Reorder.Item — FLIP siblings and edge auto-scroll.'
+    },
     reordering: {
         title: 'Reordering',
         description: 'Interactive Reordering animation example using Svelte Motion.'

--- a/docs/src/routes/examples/reorder/+page.svelte
+++ b/docs/src/routes/examples/reorder/+page.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        type ExampleSection,
+        formatSheetLabel
+    } from '@humanspeak/docs-kit'
+    import { GripVertical, Hand, Layers, MoveVertical, ScrollText, Zap } from '@lucide/svelte'
+    import { demoCodeSample } from '$lib/demo-loaders'
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import ReorderDefault from '$lib/examples/reorder/demos/Default.svelte'
+    import ReorderScrollable from '$lib/examples/reorder/demos/Scrollable.svelte'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [{ title: 'Examples', href: '/examples' }, { title: 'Reorder' }]
+    }
+    if (seo) {
+        seo.title = 'Reorder | Examples | Svelte Motion'
+        seo.description =
+            'Drag-to-reorder lists with Reorder.Group and Reorder.Item — axis-locked dragging, FLIP siblings, and edge auto-scroll in scrollable containers.'
+        seo.ogTitle = 'Reorder'
+        seo.h1 = { title: 'Reorder', mode: 'sr-only' }
+        seo.ogTagline = 'Drag-to-reorder lists with automatic layout animations'
+        seo.ogFeatures = ['Drag To Reorder', 'FLIP Siblings', 'Axis Locking', 'Edge Auto-Scroll']
+        seo.ogSlug = 'examples-reorder'
+    }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    const sections: ExampleSection[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'GESTURE',
+            title: { prefix: 'drag to ', accent: 'reorder', end: '.' },
+            description:
+                'The motion.dev grocery list. Grab any item and drag it vertically — the dragged item pins under the cursor while its siblings spring out of the way, and releasing snaps it into its new slot.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'reorder-group' }],
+            sourceUrl: `${SOURCE_URL}reorder/demos/Default.svelte`
+        },
+        {
+            figId: 'FIG-002',
+            tag: 'SCROLL',
+            title: { prefix: 'reordering ', accent: 'long lists', end: '.' },
+            description:
+                'Ten items in a 280px scroll container. Drag an item toward the top or bottom edge and hold — the container auto-scrolls beneath the held item so a single gesture can carry it the length of the list.',
+            snippet: scrollableSection,
+            codeSnippet: scrollableCode,
+            notes: scrollableNotes,
+            barCells: [{ k: 'pattern', v: 'auto-scroll' }],
+            sourceUrl: `${SOURCE_URL}reorder/demos/Scrollable.svelte`
+        }
+    ]
+</script>
+
+{#snippet defaultSection()}
+    <ReorderDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <GripVertical />
+            <span>
+                <code>Reorder.Group</code> owns the order: it watches each drag and, when an item's
+                edge crosses the midpoint of a neighbor, calls <code>onReorder</code> with the
+                swapped array. Assigning that back to <code>$state</code> is the whole wiring.
+            </span>
+        </li>
+        <li>
+            <MoveVertical />
+            <span>
+                <code>axis="y"</code> locks item drags vertically. Items key on their own value in
+                the <code>{'{#each}'}</code> block — the same value passed to
+                <code>Reorder.Item</code>'s <code>value</code> prop.
+            </span>
+        </li>
+        <li>
+            <Hand />
+            <span>
+                <code>whileDrag</code> passes straight through to the underlying motion component — the
+                lifted item scales up and gains a shadow while the gesture is active.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample('reorder/demos/Default.svelte', 'reorder-default', 'Default.svelte')
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#snippet scrollableSection()}
+    <ReorderScrollable />
+{/snippet}
+{#snippet scrollableNotes()}
+    <ul>
+        <li>
+            <ScrollText />
+            <span>
+                The scroll container is a <code>motion.div</code> with <code>layoutScroll</code>, so
+                layout measurements are taken in the container's coordinate space and stay correct
+                at any scroll position.
+            </span>
+        </li>
+        <li>
+            <Zap />
+            <span>
+                Holding a dragged item within 50px of the container's edge auto-scrolls it — speed
+                ramps up quadratically as the pointer nears the edge, and scrolling only starts when
+                the gesture is moving toward that edge.
+            </span>
+        </li>
+        <li>
+            <Layers />
+            <span>
+                Items keep reordering while the content scrolls beneath the held pointer, so one
+                gesture can carry an item from the top of the list to the bottom.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet scrollableCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'reorder/demos/Scrollable.svelte',
+                'reorder-scrollable',
+                'Scrollable.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel={formatSheetLabel(i, sections.length)}
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/reorder/+page.ts
+++ b/docs/src/routes/examples/reorder/+page.ts
@@ -1,0 +1,8 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async () => {
+    return {
+        title: 'Reorder',
+        description: 'Drag-to-reorder lists with automatic layout animations and edge auto-scroll.'
+    }
+}

--- a/e2e/reorder/axis-x.spec.ts
+++ b/e2e/reorder/axis-x.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const order = (page: Page) => page.getByTestId('order').textContent()
+
+test.describe('reorder/axis-x', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/reorder/axis-x?@isPlaywright=true')
+        await page.getByTestId('tile-red').waitFor({ state: 'visible' })
+        await page.waitForTimeout(300)
+    })
+
+    test('drags a tile right one slot to reorder', async ({ page }) => {
+        const red = page.getByTestId('tile-red')
+        const box = await red.boundingBox()
+        if (!box) throw new Error('no box')
+        const cx = box.x + box.width / 2
+        const cy = box.y + box.height / 2
+
+        // Tile pitch is 100px (90px tile + 10px gap); 110px crosses the
+        // next tile's center.
+        await page.mouse.move(cx, cy)
+        await page.mouse.down()
+        for (let i = 1; i <= 12; i++) {
+            await page.mouse.move(cx + (i * 110) / 12, cy)
+            await page.waitForTimeout(16)
+        }
+        await page.mouse.up()
+
+        expect(await order(page)).toBe('amber,red,green,blue')
+
+        // Settles one tile pitch to the right of where it started.
+        await page.waitForTimeout(700)
+        const after = await red.boundingBox()
+        if (!after) throw new Error('no after box')
+        expect(Math.abs(after.x - (box.x + 100))).toBeLessThan(2)
+        expect(Math.abs(after.y - box.y)).toBeLessThan(1)
+    })
+
+    test('drags a tile left one slot to reorder', async ({ page }) => {
+        const green = page.getByTestId('tile-green')
+        const box = await green.boundingBox()
+        if (!box) throw new Error('no box')
+        const cx = box.x + box.width / 2
+        const cy = box.y + box.height / 2
+
+        await page.mouse.move(cx, cy)
+        await page.mouse.down()
+        for (let i = 1; i <= 12; i++) {
+            await page.mouse.move(cx - (i * 110) / 12, cy)
+            await page.waitForTimeout(16)
+        }
+        await page.mouse.up()
+
+        expect(await order(page)).toBe('red,green,amber,blue')
+    })
+})

--- a/e2e/reorder/basic.spec.ts
+++ b/e2e/reorder/basic.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const order = (page: Page) => page.getByTestId('order').textContent()
+
+/** Drag a locator vertically by `dy` px in small steps so each move carries velocity. */
+const dragVertically = async (page: Page, testId: string, dy: number) => {
+    const item = page.getByTestId(testId)
+    const box = await item.boundingBox()
+    if (!box) throw new Error(`no bounding box for ${testId}`)
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+    await page.mouse.move(cx, cy)
+    await page.mouse.down()
+    const steps = Math.max(10, Math.round(Math.abs(dy) / 5))
+    for (let i = 1; i <= steps; i++) {
+        await page.mouse.move(cx, cy + (i * dy) / steps)
+        await page.waitForTimeout(16)
+    }
+    await page.mouse.up()
+}
+
+test.describe('reorder/basic', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/reorder/basic?@isPlaywright=true')
+        await page.getByTestId('item-tomato').waitFor({ state: 'visible' })
+        await page.waitForTimeout(300)
+    })
+
+    test('renders the initial order', async ({ page }) => {
+        expect(await order(page)).toBe('tomato,cucumber,cheese,lettuce')
+    })
+
+    test('drags an item down one slot to reorder', async ({ page }) => {
+        // Row pitch is 54px (44px item + 10px margin); 60px crosses the
+        // next item's center.
+        await dragVertically(page, 'item-tomato', 60)
+        expect(await order(page)).toBe('cucumber,tomato,cheese,lettuce')
+    })
+
+    test('drags an item up one slot to reorder', async ({ page }) => {
+        await dragVertically(page, 'item-cheese', -60)
+        expect(await order(page)).toBe('tomato,cheese,cucumber,lettuce')
+    })
+
+    test('crosses multiple positions in one gesture', async ({ page }) => {
+        await dragVertically(page, 'item-tomato', 130)
+        expect(await order(page)).toBe('cucumber,cheese,tomato,lettuce')
+    })
+
+    test('settles into the new slot after release', async ({ page }) => {
+        const tomato = page.getByTestId('item-tomato')
+        const cucumber = page.getByTestId('item-cucumber')
+        const cucumberSlot = await cucumber.boundingBox()
+        if (!cucumberSlot) throw new Error('no cucumber box')
+
+        await dragVertically(page, 'item-tomato', 60)
+
+        // Wait for the snap-to-origin settle animation to finish.
+        let settled: { x: number; y: number } | null = null
+        let lastY = NaN
+        let stable = 0
+        for (let i = 0; i < 30; i++) {
+            await page.waitForTimeout(50)
+            const bb = await tomato.boundingBox()
+            if (!bb) continue
+            if (!Number.isNaN(lastY) && Math.abs(bb.y - lastY) < 0.5) {
+                stable++
+                if (stable >= 3) {
+                    settled = { x: bb.x, y: bb.y }
+                    break
+                }
+            } else {
+                stable = 0
+            }
+            lastY = bb.y
+        }
+
+        if (!settled) throw new Error('item never settled')
+        // Tomato now occupies cucumber's old slot.
+        expect(Math.abs(settled.y - cucumberSlot.y)).toBeLessThan(2)
+        expect(Math.abs(settled.x - cucumberSlot.x)).toBeLessThan(2)
+    })
+
+    test('locks dragging to the group axis', async ({ page }) => {
+        const tomato = page.getByTestId('item-tomato')
+        const box = await tomato.boundingBox()
+        if (!box) throw new Error('no box')
+        const cx = box.x + box.width / 2
+        const cy = box.y + box.height / 2
+
+        await page.mouse.move(cx, cy)
+        await page.mouse.down()
+        for (let i = 1; i <= 10; i++) {
+            await page.mouse.move(cx + i * 8, cy)
+            await page.waitForTimeout(16)
+        }
+        const mid = await tomato.boundingBox()
+        await page.mouse.up()
+
+        if (!mid) throw new Error('no mid box')
+        expect(Math.abs(mid.x - box.x)).toBeLessThan(1)
+        expect(await order(page)).toBe('tomato,cucumber,cheese,lettuce')
+    })
+})

--- a/e2e/reorder/custom-drag.spec.ts
+++ b/e2e/reorder/custom-drag.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('reorder/custom-drag', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/reorder/custom-drag?@isPlaywright=true')
+        await page.getByTestId('item-one').waitFor({ state: 'visible' })
+        await page.waitForTimeout(300)
+    })
+
+    test('`drag` on the item unlocks both axes and still reorders', async ({ page }) => {
+        const one = page.getByTestId('item-one')
+        const box = await one.boundingBox()
+        if (!box) throw new Error('no box')
+        const cx = box.x + box.width / 2
+        const cy = box.y + box.height / 2
+
+        // Diagonal drag: x moves freely (unlocked) while the y travel
+        // still crosses the next item's center (54px pitch) and reorders.
+        await page.mouse.move(cx, cy)
+        await page.mouse.down()
+        for (let i = 1; i <= 10; i++) {
+            await page.mouse.move(cx + (i * 80) / 10, cy + (i * 60) / 10)
+            await page.waitForTimeout(16)
+        }
+        const mid = await one.boundingBox()
+        if (!mid) throw new Error('no mid box')
+        expect(mid.x - box.x).toBeGreaterThan(40)
+
+        await page.mouse.up()
+        expect(await page.getByTestId('order').textContent()).toBe('two,one,three')
+    })
+})

--- a/e2e/reorder/scrollable.spec.ts
+++ b/e2e/reorder/scrollable.spec.ts
@@ -1,0 +1,181 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const order = (page: Page) => page.getByTestId('order').textContent()
+
+/** All items should sit on an exact slot pitch after any gesture. */
+const expectConsistentPitch = async (page: Page, pitch: number) => {
+    const ids = ((await order(page)) ?? '').split(',')
+    const ys: number[] = []
+    for (const id of ids) {
+        const box = await page.getByTestId(`item-${id}`).boundingBox()
+        if (!box) throw new Error(`no box for ${id}`)
+        ys.push(box.y)
+    }
+    for (let i = 1; i < ys.length; i++) {
+        expect(Math.abs(ys[i] - ys[i - 1] - pitch)).toBeLessThan(1.5)
+    }
+}
+
+test.describe('reorder/scrollable', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/reorder/scrollable?@isPlaywright=true')
+        await page.getByTestId('item-one').waitFor({ state: 'visible' })
+        await page.waitForTimeout(300)
+    })
+
+    test('reorders correctly when the container is pre-scrolled', async ({ page }) => {
+        const scroller = page.getByTestId('scroller')
+        await scroller.evaluate((el) => {
+            el.scrollTop = 120
+        })
+        await page.waitForTimeout(300)
+
+        const four = page.getByTestId('item-four')
+        const box = await four.boundingBox()
+        const fiveSlot = await page.getByTestId('item-five').boundingBox()
+        if (!box || !fiveSlot) throw new Error('missing boxes')
+        const cx = box.x + box.width / 2
+        const cy = box.y + box.height / 2
+
+        await page.mouse.move(cx, cy)
+        await page.mouse.down()
+        for (let i = 1; i <= 12; i++) {
+            await page.mouse.move(cx, cy + (i * 66) / 12)
+            await page.waitForTimeout(16)
+        }
+        await page.mouse.up()
+        await page.waitForTimeout(800)
+
+        expect(await order(page)).toBe('one,two,three,five,four,six,seven,eight')
+        // The gesture must not disturb the scroll position…
+        expect(await page.getByTestId('scroll-top').textContent()).toBe('120')
+        // …and the dragged item settles exactly into the displaced slot.
+        const after = await four.boundingBox()
+        if (!after) throw new Error('no after box')
+        expect(Math.abs(after.y - fiveSlot.y)).toBeLessThan(2)
+        await expectConsistentPitch(page, 60)
+    })
+
+    test('auto-scrolls the container when dragging near its bottom edge', async ({ page }) => {
+        const scroller = page.getByTestId('scroller')
+        const sBox = await scroller.boundingBox()
+        const two = page.getByTestId('item-two')
+        const tBox = await two.boundingBox()
+        if (!sBox || !tBox) throw new Error('missing boxes')
+        const cx = tBox.x + tBox.width / 2
+        const startY = tBox.y + tBox.height / 2
+        const edgeY = sBox.y + sBox.height - 25 // inside the 50px threshold
+
+        await page.mouse.move(cx, startY)
+        await page.mouse.down()
+        for (let i = 1; i <= 20; i++) {
+            await page.mouse.move(cx, startY + ((edgeY - startY) * i) / 20)
+            await page.waitForTimeout(16)
+        }
+        // Hold near the edge (1px jiggle keeps onDrag ticks flowing).
+        for (let i = 0; i < 25; i++) {
+            await page.mouse.move(cx, edgeY + (i % 2))
+            await page.waitForTimeout(30)
+        }
+        const scrolled = await scroller.evaluate((el) => el.scrollTop)
+        await page.mouse.up()
+        await page.waitForTimeout(800)
+
+        expect(scrolled).toBeGreaterThan(50)
+        // The held item kept reordering as content scrolled beneath it.
+        const ids = ((await order(page)) ?? '').split(',')
+        expect(ids.indexOf('two')).toBeGreaterThan(2)
+        await expectConsistentPitch(page, 60)
+    })
+
+    test('does not auto-scroll when dragging away from the edge zone', async ({ page }) => {
+        const scroller = page.getByTestId('scroller')
+        const two = page.getByTestId('item-two')
+        const tBox = await two.boundingBox()
+        if (!tBox) throw new Error('no box')
+        const cx = tBox.x + tBox.width / 2
+        const cy = tBox.y + tBox.height / 2
+
+        // A small mid-container drag must leave scrollTop untouched.
+        await page.mouse.move(cx, cy)
+        await page.mouse.down()
+        for (let i = 1; i <= 10; i++) {
+            await page.mouse.move(cx, cy + i * 3)
+            await page.waitForTimeout(16)
+        }
+        await page.mouse.up()
+        await page.waitForTimeout(400)
+        expect(await scroller.evaluate((el) => el.scrollTop)).toBe(0)
+    })
+})
+
+test.describe('reorder/page-scroll', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/reorder/page-scroll?@isPlaywright=true')
+        await page.getByTestId('item-alpha').waitFor({ state: 'attached' })
+        // Bring the group mid-viewport so the gesture stays clear of the
+        // window's auto-scroll edge zones.
+        await page.evaluate(() => window.scrollTo(0, 750))
+        await page.waitForTimeout(400)
+    })
+
+    test('reorders exactly one slot with a non-zero window scroll', async ({ page }) => {
+        // Regression: the viewport-scroll guard in commitObservedLayout
+        // used to skip the dragged item's origin compensation after any
+        // window scroll, double-firing the swap (beta jumped TWO slots).
+        const beta = page.getByTestId('item-beta')
+        const box = await beta.boundingBox()
+        const gammaSlot = await page.getByTestId('item-gamma').boundingBox()
+        if (!box || !gammaSlot) throw new Error('missing boxes')
+        const cx = box.x + box.width / 2
+        const cy = box.y + box.height / 2
+
+        await page.mouse.move(cx, cy)
+        await page.mouse.down()
+        for (let i = 1; i <= 12; i++) {
+            await page.mouse.move(cx, cy + (i * 66) / 12)
+            await page.waitForTimeout(16)
+        }
+        await page.mouse.up()
+        await page.waitForTimeout(800)
+
+        expect(await order(page)).toBe('alpha,gamma,beta,delta')
+        // The gesture must not move the window…
+        expect(await page.evaluate(() => window.scrollY)).toBe(750)
+        // …and beta settles exactly into gamma's old slot.
+        const after = await beta.boundingBox()
+        if (!after) throw new Error('no after box')
+        expect(Math.abs(after.y - gammaSlot.y)).toBeLessThan(2)
+        await expectConsistentPitch(page, 60)
+    })
+
+    test('keeps positions consistent when the window scrolls mid-drag', async ({ page }) => {
+        const beta = page.getByTestId('item-beta')
+        const box = await beta.boundingBox()
+        if (!box) throw new Error('no box')
+        const cx = box.x + box.width / 2
+        const cy = box.y + box.height / 2
+
+        await page.mouse.move(cx, cy)
+        await page.mouse.down()
+        for (let i = 1; i <= 5; i++) {
+            await page.mouse.move(cx, cy + i * 4)
+            await page.waitForTimeout(16)
+        }
+        // Wheel-scroll the window while the gesture is live.
+        await page.mouse.wheel(0, 80)
+        await page.waitForTimeout(150)
+        for (let i = 1; i <= 10; i++) {
+            await page.mouse.move(cx, cy + 20 + i * 3)
+            await page.waitForTimeout(16)
+        }
+        await page.mouse.up()
+        await page.waitForTimeout(900)
+
+        // The order stays a valid permutation and every item lands on an
+        // exact slot pitch — no scroll-offset "wack" in the positions.
+        const ids = ((await order(page)) ?? '').split(',')
+        expect([...ids].sort()).toEqual(['alpha', 'beta', 'delta', 'gamma'])
+        await expectConsistentPitch(page, 60)
+    })
+})

--- a/e2e/reorder/siblings-flip.spec.ts
+++ b/e2e/reorder/siblings-flip.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('reorder/siblings-flip', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/reorder/siblings-flip?@isPlaywright=true')
+        await page.getByTestId('item-a').waitFor({ state: 'visible' })
+        await page.waitForTimeout(300)
+    })
+
+    test('displaced sibling animates to its new slot during a live drag', async ({ page }) => {
+        const a = page.getByTestId('item-a')
+        const b = page.getByTestId('item-b')
+        const aBox = await a.boundingBox()
+        const bStart = await b.boundingBox()
+        if (!aBox || !bStart) throw new Error('missing boxes')
+        const cx = aBox.x + aBox.width / 2
+        const cy = aBox.y + aBox.height / 2
+
+        // Drag item A down past B's center (72px pitch), then HOLD.
+        await page.mouse.move(cx, cy)
+        await page.mouse.down()
+        for (let i = 1; i <= 8; i++) {
+            await page.mouse.move(cx, cy + (i * 50) / 8)
+            await page.waitForTimeout(16)
+        }
+
+        // While still holding, B FLIPs up into A's old slot: its box must
+        // move over several frames (an animation), not jump in one.
+        const samples: number[] = []
+        for (let i = 0; i < 12; i++) {
+            await page.waitForTimeout(40)
+            const bb = await b.boundingBox()
+            if (bb) samples.push(bb.y)
+        }
+        await page.mouse.up()
+
+        expect(await page.getByTestId('order').textContent()).toBe('b,a,c')
+        // B ends up at A's old slot...
+        expect(Math.abs(samples[samples.length - 1] - aBox.y)).toBeLessThan(2)
+        // ...and passed through intermediate positions on the way (≥4
+        // distinct y values means it animated rather than teleporting).
+        expect(new Set(samples.map((y) => Math.round(y))).size).toBeGreaterThanOrEqual(4)
+    })
+
+    test('dragged item paints above the sibling it displaces when dragged upward', async ({
+        page
+    }) => {
+        const c = page.getByTestId('item-c')
+        const cBox = await c.boundingBox()
+        if (!cBox) throw new Error('no box')
+        const cx = cBox.x + cBox.width / 2
+        const cy = cBox.y + cBox.height / 2
+
+        // Drag C up past B's center and HOLD. The swap moves C EARLIER in
+        // the DOM, so without a working z-index the later-in-DOM B paints
+        // over the dragged item while it FLIPs down through C's track.
+        await page.mouse.move(cx, cy)
+        await page.mouse.down()
+        let pointerY = cy
+        for (let i = 1; i <= 12; i++) {
+            pointerY = cy - (i * 50) / 12
+            await page.mouse.move(cx, pointerY)
+            await page.waitForTimeout(16)
+        }
+        await page.waitForTimeout(100)
+
+        expect(await page.getByTestId('order').textContent()).toBe('a,c,b')
+        // The dragged item must be the one under the pointer.
+        const topAtPointer = await page.evaluate(
+            ([x, y]) =>
+                document
+                    .elementFromPoint(x as number, y as number)
+                    ?.closest('[data-testid]')
+                    ?.getAttribute('data-testid'),
+            [cx, pointerY]
+        )
+        await page.mouse.up()
+        expect(topAtPointer).toBe('item-c')
+    })
+
+    test('dragged item stays pinned under the cursor through a swap', async ({ page }) => {
+        const a = page.getByTestId('item-a')
+        const aBox = await a.boundingBox()
+        if (!aBox) throw new Error('no box')
+        const cx = aBox.x + aBox.width / 2
+        const cy = aBox.y + aBox.height / 2
+
+        // Drag down through B's slot while sampling A's visual position:
+        // the swap moves A's DOM node, and without origin compensation it
+        // would teleport by a full slot pitch between frames.
+        const samples: number[] = []
+        await page.mouse.move(cx, cy)
+        await page.mouse.down()
+        for (let i = 1; i <= 24; i++) {
+            const pointerY = cy + (i * 100) / 24
+            await page.mouse.move(cx, pointerY)
+            await page.waitForTimeout(16)
+            const bb = await a.boundingBox()
+            if (bb) {
+                // Drift between pointer and item center stays ~0 when pinned.
+                samples.push(Math.abs(pointerY - (bb.y + bb.height / 2)))
+            }
+        }
+        await page.mouse.up()
+
+        expect(await page.getByTestId('order').textContent()).toBe('b,a,c')
+        const maxDrift = Math.max(...samples)
+        expect(maxDrift).toBeLessThan(10)
+    })
+})

--- a/src/lib/components/Reorder/Group.svelte
+++ b/src/lib/components/Reorder/Group.svelte
@@ -1,0 +1,103 @@
+<script lang="ts" generics="V">
+    /**
+     * Drag-to-reorder list container. Port of framer-motion's
+     * `Reorder.Group` (`Reorder/Group.tsx`).
+     *
+     * Owns the measured working order of its `Reorder.Item` children
+     * and, when a live drag carries an item past a sibling's center,
+     * fires `onReorder` with the swapped `values` copy. The consumer
+     * assigns that back to state; the resulting keyed-each DOM move is
+     * FLIP-animated by the items' `layout` prop.
+     *
+     * @prop as - Element to render. Defaults to `'ul'`.
+     * @prop axis - Axis to reorder along. Defaults to `'y'`.
+     * @prop values - The current order of item values.
+     * @prop onReorder - Receives the new order after a swap.
+     */
+    import MotionContainer from '$lib/html/_MotionContainer.svelte'
+    import { isMotionValueChild } from '$lib/utils/motionValueChild'
+    import { checkReorder } from './checkReorder'
+    import { setReorderContext, type ItemData } from './context'
+    import { applyOrderSwap, removeOrderEntry, upsertOrderEntry } from './order'
+    import type { ReorderGroupProps } from './types'
+
+    let {
+        children,
+        as = 'ul',
+        axis = 'y',
+        values,
+        onReorder,
+        style,
+        ref = $bindable(),
+        ...rest
+    }: ReorderGroupProps<V> = $props()
+
+    // svelte-ignore state_referenced_locally
+    if (!values) {
+        throw new Error('Reorder.Group must be provided a values prop')
+    }
+
+    const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
+    const childSnippet = $derived(typeof children === 'function' ? children : undefined)
+
+    /**
+     * Measured slots, sorted by axis start. A single persistent array
+     * (upstream rebuilds per React render); `registerItem` upserts and
+     * `unregisterItem` removes, so it tracks the mounted items.
+     */
+    const order: ItemData<V>[] = []
+
+    /**
+     * Swap-in-flight guard: set when `onReorder` fires, released one
+     * frame after the new `values` reach us, by which point the
+     * MutationObserver-driven re-measure has refreshed `order`. Blocks
+     * `checkReorder` from running against stale slots mid-swap.
+     */
+    let isReordering = false
+
+    setReorderContext<V>({
+        get axis() {
+            return axis
+        },
+        registerItem: (value, layout) => {
+            upsertOrderEntry(order, value, layout[axis])
+        },
+        unregisterItem: (value) => {
+            removeOrderEntry(order, value)
+        },
+        updateOrder: (value, offset, velocity) => {
+            if (isReordering) return
+
+            const newOrder = checkReorder(order, value, offset, velocity)
+
+            if (order !== newOrder) {
+                isReordering = true
+                onReorder(applyOrderSwap(values, order, newOrder))
+            }
+        },
+        getGroupElement: () => ref ?? null
+    })
+
+    $effect(() => {
+        void values
+        const frame = requestAnimationFrame(() => {
+            isReordering = false
+        })
+        return () => cancelAnimationFrame(frame)
+    })
+
+    /**
+     * Browser scroll anchoring reacts to items moving and adjusts the
+     * scroll position, which corrupts drag position math mid-gesture —
+     * disable it on the container (upstream `Group.tsx` `groupStyle`).
+     */
+    const groupStyle = $derived(
+        typeof style === 'string'
+            ? `overflow-anchor: none; ${style}`
+            : { overflowAnchor: 'none', ...(style ?? {}) }
+    )
+</script>
+
+<MotionContainer bind:ref tag={as} {...rest} style={groupStyle} {motionValueChild}>
+    {@render childSnippet?.()}
+</MotionContainer>

--- a/src/lib/components/Reorder/Item.svelte
+++ b/src/lib/components/Reorder/Item.svelte
@@ -1,0 +1,112 @@
+<script lang="ts" generics="V">
+    /**
+     * A draggable entry inside a `Reorder.Group`. Port of
+     * framer-motion's `Reorder.Item` (`Reorder/Item.tsx`).
+     *
+     * Renders a motion element that drag-locks to the group's axis,
+     * snaps back to its (possibly new) slot on release, and reports
+     * its live drag offset to the group each frame so the order can
+     * update mid-gesture. While dragging, the item floats above its
+     * siblings via a transform-driven `zIndex`.
+     *
+     * @prop as - Element to render. Defaults to `'li'`.
+     * @prop value - The entry in the group's `values` this item represents.
+     * @prop layout - Layout animation mode. Defaults to `true`; pass `'position'` to skip size projection.
+     */
+    import { isMotionValue } from 'motion-dom'
+    import MotionContainer from '$lib/html/_MotionContainer.svelte'
+    import type { DragInfo } from '$lib/types'
+    import { useMotionValue } from '$lib/utils/motionValue.svelte'
+    import { isMotionValueChild } from '$lib/utils/motionValueChild'
+    import { parseStyleString } from '$lib/utils/style'
+    import { useTransform } from '$lib/utils/transform.svelte'
+    import { autoScrollIfNeeded, resetAutoScrollState } from './autoScroll'
+    import { getReorderContext } from './context'
+    import type { ReorderItemProps } from './types'
+
+    let {
+        children,
+        style,
+        value,
+        as = 'li',
+        onDrag,
+        onDragEnd,
+        layout = true,
+        ref = $bindable(),
+        ...rest
+    }: ReorderItemProps<V> = $props()
+
+    const context = getReorderContext<V>()
+    if (!context) {
+        throw new Error('Reorder.Item must be a child of Reorder.Group')
+    }
+
+    const motionValueChild = $derived(isMotionValueChild(children) ? children : undefined)
+    const childSnippet = $derived(typeof children === 'function' ? children : undefined)
+
+    /**
+     * Reuse consumer-provided `x`/`y` MotionValues so external code can
+     * observe or drive the drag offset (upstream `useDefaultMotionValue`).
+     * Captured from the initial style — the values' identity must stay
+     * stable for the lifetime of the gesture wiring.
+     */
+    // svelte-ignore state_referenced_locally
+    const initialStyle = typeof style === 'string' ? parseStyleString(style) : (style ?? {})
+    const x = isMotionValue(initialStyle.x) ? initialStyle.x : useMotionValue(0)
+    const y = isMotionValue(initialStyle.y) ? initialStyle.y : useMotionValue(0)
+    const point = { x, y }
+
+    const zIndex = useTransform([x, y], ([latestX, latestY]) => (latestX || latestY ? 1 : 'unset'))
+
+    const handleDrag = (event: PointerEvent, info: DragInfo) => {
+        const { axis } = context
+        // The bound style MotionValue is dual-written by the drag
+        // gesture, so it reads as the live offset from the item's slot.
+        context.updateOrder(value, point[axis].get() as number, info.velocity[axis])
+        autoScrollIfNeeded(context.getGroupElement(), info.point[axis], axis, info.velocity[axis])
+        onDrag?.(event, info)
+    }
+
+    const handleDragEnd = (event: PointerEvent, info: DragInfo) => {
+        resetAutoScrollState()
+        onDragEnd?.(event, info)
+    }
+
+    $effect(() => {
+        return () => context.unregisterItem(value)
+    })
+
+    // `position: relative` (overridable) makes the floating `zIndex`
+    // actually apply — z-index is ignored on statically positioned
+    // elements, and an upward swap moves the dragged item EARLIER in
+    // the DOM, where the displaced (later-in-DOM) sibling would
+    // otherwise paint over it.
+    const itemStyle = $derived({
+        position: 'relative',
+        ...(typeof style === 'string' ? parseStyleString(style) : (style ?? {})),
+        x,
+        y,
+        zIndex
+    })
+</script>
+
+<!--
+    Prop order mirrors upstream Item.tsx: `drag` before the spread so a
+    consumer's `drag` prop can unlock both axes; everything after the
+    spread is enforced by Reorder and wraps or overrides consumer props.
+-->
+<MotionContainer
+    bind:ref
+    tag={as}
+    drag={context.axis}
+    {...rest}
+    dragSnapToOrigin
+    style={itemStyle}
+    {layout}
+    onDrag={handleDrag}
+    onDragEnd={handleDragEnd}
+    onLayoutMeasure={(box) => context.registerItem(value, box)}
+    {motionValueChild}
+>
+    {@render childSnippet?.()}
+</MotionContainer>

--- a/src/lib/components/Reorder/__tests__/ItemMotionValueProbe.svelte
+++ b/src/lib/components/Reorder/__tests__/ItemMotionValueProbe.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import type { RawMotionValue } from '$lib/utils/motionValue.svelte'
+    import { Reorder } from '$lib/reorder'
+
+    let { x }: { x: RawMotionValue<number> } = $props()
+</script>
+
+<Reorder.Group values={[0]} onReorder={() => {}}>
+    <Reorder.Item value={0} style={{ x }} data-testid="probe-item">zero</Reorder.Item>
+</Reorder.Group>

--- a/src/lib/components/Reorder/__tests__/ItemOutsideGroup.svelte
+++ b/src/lib/components/Reorder/__tests__/ItemOutsideGroup.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+    import { Reorder } from '$lib/reorder'
+</script>
+
+<Reorder.Item value={0}>orphan</Reorder.Item>

--- a/src/lib/components/Reorder/__tests__/ReorderHarness.svelte
+++ b/src/lib/components/Reorder/__tests__/ReorderHarness.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+    import { Reorder } from '$lib/reorder'
+    import type { ReorderElementTag } from '../types'
+
+    let {
+        values = [0, 1, 2],
+        axis = 'y',
+        as = 'ul' as ReorderElementTag,
+        itemAs = 'li' as ReorderElementTag,
+        groupStyle,
+        onReorder = () => {}
+    }: {
+        values?: number[]
+        axis?: 'x' | 'y'
+        as?: ReorderElementTag
+        itemAs?: ReorderElementTag
+        groupStyle?: string
+        onReorder?: (next: number[]) => void
+    } = $props()
+</script>
+
+<Reorder.Group {as} {axis} {values} {onReorder} style={groupStyle} data-testid="group">
+    {#each values as item (item)}
+        <Reorder.Item as={itemAs} value={item} data-testid={`item-${item}`}>
+            {item}
+        </Reorder.Item>
+    {/each}
+</Reorder.Group>

--- a/src/lib/components/Reorder/autoScroll.spec.ts
+++ b/src/lib/components/Reorder/autoScroll.spec.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { autoScrollIfNeeded, resetAutoScrollState } from './autoScroll'
+
+/**
+ * jsdom performs no layout, so the scroll container's geometry and
+ * overflow style are stubbed directly on the elements under test.
+ */
+const makeScrollableList = () => {
+    const scroller = document.createElement('div')
+    scroller.style.overflowY = 'scroll'
+    Object.defineProperty(scroller, 'clientHeight', { value: 200, configurable: true })
+    Object.defineProperty(scroller, 'scrollHeight', { value: 600, configurable: true })
+    scroller.getBoundingClientRect = () =>
+        ({ top: 0, bottom: 200, left: 0, right: 100, width: 100, height: 200 }) as DOMRect
+
+    const group = document.createElement('ul')
+    scroller.appendChild(group)
+    document.body.appendChild(scroller)
+    return { scroller, group }
+}
+
+describe('autoScrollIfNeeded', () => {
+    beforeEach(() => {
+        document.body.innerHTML = ''
+    })
+
+    afterEach(() => {
+        resetAutoScrollState()
+    })
+
+    it('does nothing without a scrollable ancestor', () => {
+        const group = document.createElement('ul')
+        document.body.appendChild(group)
+        expect(() => autoScrollIfNeeded(group, 195, 'y', 5)).not.toThrow()
+    })
+
+    it('scrolls toward the end edge when velocity points at it', () => {
+        const { scroller, group } = makeScrollableList()
+        autoScrollIfNeeded(group, 195, 'y', 5)
+        expect(scroller.scrollTop).toBeGreaterThan(0)
+    })
+
+    it('does not start scrolling when velocity points away from the edge', () => {
+        const { scroller, group } = makeScrollableList()
+        autoScrollIfNeeded(group, 195, 'y', -5)
+        expect(scroller.scrollTop).toBe(0)
+    })
+
+    it('keeps scrolling an activated edge even after velocity fades', () => {
+        const { scroller, group } = makeScrollableList()
+        autoScrollIfNeeded(group, 195, 'y', 5)
+        const afterActivation = scroller.scrollTop
+        autoScrollIfNeeded(group, 195, 'y', 0)
+        expect(scroller.scrollTop).toBeGreaterThan(afterActivation)
+    })
+
+    it('caps forward scrolling at the limit captured on activation', () => {
+        const { scroller, group } = makeScrollableList()
+        scroller.scrollTop = 400 // already at scrollHeight - clientHeight
+        autoScrollIfNeeded(group, 195, 'y', 5)
+        expect(scroller.scrollTop).toBe(400)
+    })
+
+    it('resets edge activation once the pointer leaves the threshold zone', () => {
+        const { scroller, group } = makeScrollableList()
+        autoScrollIfNeeded(group, 195, 'y', 5)
+        expect(scroller.scrollTop).toBeGreaterThan(0)
+        const scrolled = scroller.scrollTop
+        // Middle of the container: no zone → clears state.
+        autoScrollIfNeeded(group, 100, 'y', 5)
+        expect(scroller.scrollTop).toBe(scrolled)
+        // Back at the edge but moving away: the velocity gate applies again.
+        autoScrollIfNeeded(group, 195, 'y', -5)
+        expect(scroller.scrollTop).toBe(scrolled)
+    })
+})

--- a/src/lib/components/Reorder/autoScroll.ts
+++ b/src/lib/components/Reorder/autoScroll.ts
@@ -1,0 +1,192 @@
+/**
+ * Edge auto-scroll for drag-to-reorder.
+ *
+ * While a `Reorder.Item` drags within `threshold` px of a scrollable
+ * ancestor's start/end edge, the ancestor scrolls in that direction so
+ * long lists can be traversed in a single gesture.
+ *
+ * Port of framer-motion `Reorder/utils/auto-scroll.ts` with one
+ * deliberate difference: our `DragInfo.point` carries CLIENT
+ * coordinates (see `drag.ts`, which reads `clientX`/`clientY`), while
+ * upstream's gesture point is page coordinates — so the upstream
+ * `window.scrollX/Y` subtraction is omitted here.
+ */
+
+const threshold = 50
+const maxSpeed = 25
+
+const overflowStyles = new Set(['auto', 'scroll'])
+
+/**
+ * Scroll limits captured when an edge first activates, so a gesture
+ * can't grow the scroll range it started with (e.g. when scrolling
+ * itself triggers layout that extends the scrollable area).
+ */
+const initialScrollLimits = new WeakMap<HTMLElement, number>()
+
+/** Which edge is currently auto-scrolling: "start" (top/left) or "end" (bottom/right). */
+type ActiveEdge = 'start' | 'end' | null
+const activeScrollEdge = new WeakMap<HTMLElement, ActiveEdge>()
+
+/** Group element of the in-flight drag, so `resetAutoScrollState` can clear per-ancestor state. */
+let currentGroupElement: Element | null = null
+
+/**
+ * Clear all auto-scroll bookkeeping for the group involved in the
+ * gesture that just ended. Called from `Reorder.Item`'s `onDragEnd`.
+ */
+export const resetAutoScrollState = (): void => {
+    if (currentGroupElement) {
+        const scrollableAncestor = findScrollableAncestor(currentGroupElement, 'y')
+        if (scrollableAncestor) {
+            activeScrollEdge.delete(scrollableAncestor)
+            initialScrollLimits.delete(scrollableAncestor)
+        }
+        const scrollableAncestorX = findScrollableAncestor(currentGroupElement, 'x')
+        if (scrollableAncestorX && scrollableAncestorX !== scrollableAncestor) {
+            activeScrollEdge.delete(scrollableAncestorX)
+            initialScrollLimits.delete(scrollableAncestorX)
+        }
+        currentGroupElement = null
+    }
+}
+
+const isScrollableElement = (element: Element, axis: 'x' | 'y'): boolean => {
+    const style = getComputedStyle(element)
+    const overflow = axis === 'x' ? style.overflowX : style.overflowY
+
+    const isDocumentScroll = element === document.body || element === document.documentElement
+
+    return overflowStyles.has(overflow) || isDocumentScroll
+}
+
+const findScrollableAncestor = (element: Element | null, axis: 'x' | 'y'): HTMLElement | null => {
+    let current = element?.parentElement
+    while (current) {
+        if (isScrollableElement(current, axis)) {
+            return current
+        }
+        current = current.parentElement
+    }
+    return null
+}
+
+/**
+ * Quadratic ease into `maxSpeed` as the pointer approaches the edge:
+ * zero at `threshold` px away, full speed at the edge itself.
+ */
+const getScrollAmount = (
+    pointerPosition: number,
+    scrollElement: HTMLElement,
+    axis: 'x' | 'y'
+): { amount: number; edge: ActiveEdge } => {
+    const rect = scrollElement.getBoundingClientRect()
+
+    const start = axis === 'x' ? Math.max(0, rect.left) : Math.max(0, rect.top)
+    const end =
+        axis === 'x'
+            ? Math.min(window.innerWidth, rect.right)
+            : Math.min(window.innerHeight, rect.bottom)
+
+    const distanceFromStart = pointerPosition - start
+    const distanceFromEnd = end - pointerPosition
+
+    if (distanceFromStart < threshold) {
+        const intensity = 1 - distanceFromStart / threshold
+        return { amount: -maxSpeed * intensity * intensity, edge: 'start' }
+    } else if (distanceFromEnd < threshold) {
+        const intensity = 1 - distanceFromEnd / threshold
+        return { amount: maxSpeed * intensity * intensity, edge: 'end' }
+    }
+
+    return { amount: 0, edge: null }
+}
+
+/**
+ * Scroll the group's nearest scrollable ancestor when a drag pointer
+ * is inside the edge threshold and travelling toward that edge.
+ * Called from `Reorder.Item`'s `onDrag` on every gesture frame.
+ *
+ * @param groupElement - The `Reorder.Group` element the item belongs to.
+ * @param pointerPosition - Pointer position on `axis`, in client coordinates.
+ * @param axis - The group's reorder axis.
+ * @param velocity - Pointer velocity on `axis`; scrolling only starts when it points at the edge.
+ */
+export const autoScrollIfNeeded = (
+    groupElement: Element | null,
+    pointerPosition: number,
+    axis: 'x' | 'y',
+    velocity: number
+): void => {
+    if (!groupElement) return
+
+    currentGroupElement = groupElement
+
+    const scrollableAncestor = findScrollableAncestor(groupElement, axis)
+    if (!scrollableAncestor) return
+
+    const { amount: scrollAmount, edge } = getScrollAmount(
+        pointerPosition,
+        scrollableAncestor,
+        axis
+    )
+
+    // Outside both threshold zones: clear state so re-entering an edge
+    // re-runs the velocity gate below.
+    if (edge === null) {
+        activeScrollEdge.delete(scrollableAncestor)
+        initialScrollLimits.delete(scrollableAncestor)
+        return
+    }
+
+    const currentActiveEdge = activeScrollEdge.get(scrollableAncestor)
+
+    const isDocumentScroll =
+        scrollableAncestor === document.body || scrollableAncestor === document.documentElement
+
+    if (currentActiveEdge !== edge) {
+        // Only start scrolling when the gesture is moving toward the
+        // edge — hovering near it after dragging away shouldn't scroll.
+        const shouldStart = (edge === 'start' && velocity < 0) || (edge === 'end' && velocity > 0)
+        if (!shouldStart) return
+
+        activeScrollEdge.set(scrollableAncestor, edge)
+
+        const maxScroll =
+            axis === 'x'
+                ? scrollableAncestor.scrollWidth -
+                  (isDocumentScroll ? window.innerWidth : scrollableAncestor.clientWidth)
+                : scrollableAncestor.scrollHeight -
+                  (isDocumentScroll ? window.innerHeight : scrollableAncestor.clientHeight)
+
+        initialScrollLimits.set(scrollableAncestor, maxScroll)
+    }
+
+    // Cap forward scrolling at the limit captured on activation.
+    if (scrollAmount > 0) {
+        const initialLimit = initialScrollLimits.get(scrollableAncestor)!
+        const currentScroll =
+            axis === 'x'
+                ? isDocumentScroll
+                    ? window.scrollX
+                    : scrollableAncestor.scrollLeft
+                : isDocumentScroll
+                  ? window.scrollY
+                  : scrollableAncestor.scrollTop
+        if (currentScroll >= initialLimit) return
+    }
+
+    if (axis === 'x') {
+        if (isDocumentScroll) {
+            window.scrollBy({ left: scrollAmount })
+        } else {
+            scrollableAncestor.scrollLeft += scrollAmount
+        }
+    } else {
+        if (isDocumentScroll) {
+            window.scrollBy({ top: scrollAmount })
+        } else {
+            scrollableAncestor.scrollTop += scrollAmount
+        }
+    }
+}

--- a/src/lib/components/Reorder/checkReorder.spec.ts
+++ b/src/lib/components/Reorder/checkReorder.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { checkReorder, moveItem } from './checkReorder'
+import type { ItemData } from './context'
+
+const item = <V>(value: V, min: number, max: number): ItemData<V> => ({
+    value,
+    layout: { min, max }
+})
+
+/** Three 100px slots stacked at 0, 100 and 200. */
+const makeOrder = () => [item('a', 0, 100), item('b', 100, 200), item('c', 200, 300)]
+
+describe('moveItem', () => {
+    it('moves an item forward without mutating the input', () => {
+        const source = ['a', 'b', 'c']
+        expect(moveItem(source, 0, 1)).toEqual(['b', 'a', 'c'])
+        expect(source).toEqual(['a', 'b', 'c'])
+    })
+
+    it('moves an item backward', () => {
+        expect(moveItem(['a', 'b', 'c'], 2, 0)).toEqual(['c', 'a', 'b'])
+    })
+
+    it('supports negative target indices', () => {
+        expect(moveItem(['a', 'b', 'c'], 0, -1)).toEqual(['b', 'c', 'a'])
+    })
+
+    it('returns an unchanged copy for an out-of-range source index', () => {
+        expect(moveItem(['a', 'b'], 5, 0)).toEqual(['a', 'b'])
+    })
+})
+
+describe('checkReorder', () => {
+    it('returns the same array when velocity is zero', () => {
+        const order = makeOrder()
+        expect(checkReorder(order, 'a', 500, 0)).toBe(order)
+    })
+
+    it('returns the same array for an unknown value', () => {
+        const order = makeOrder()
+        expect(checkReorder(order, 'z', 500, 1)).toBe(order)
+    })
+
+    it('swaps forward once the leading edge passes the next item center', () => {
+        const order = makeOrder()
+        // Item a: max=100. Item b center=150. Offset 51 → 151 > 150.
+        const next = checkReorder(order, 'a', 51, 1)
+        expect(next).not.toBe(order)
+        expect(next.map((entry) => entry.value)).toEqual(['b', 'a', 'c'])
+    })
+
+    it('does not swap forward before the next item center', () => {
+        const order = makeOrder()
+        // 100 + 49 = 149 < 150 → no swap.
+        expect(checkReorder(order, 'a', 49, 1)).toBe(order)
+    })
+
+    it('swaps backward once the leading edge passes the previous item center', () => {
+        const order = makeOrder()
+        // Item c: min=200. Item b center=150. Offset -51 → 149 < 150.
+        const next = checkReorder(order, 'c', -51, -1)
+        expect(next.map((entry) => entry.value)).toEqual(['a', 'c', 'b'])
+    })
+
+    it('does not swap backward before the previous item center', () => {
+        const order = makeOrder()
+        expect(checkReorder(order, 'c', -49, -1)).toBe(order)
+    })
+
+    it('ignores boundary items with no neighbour in the travel direction', () => {
+        const order = makeOrder()
+        expect(checkReorder(order, 'c', 500, 1)).toBe(order)
+        expect(checkReorder(order, 'a', -500, -1)).toBe(order)
+    })
+
+    it('requires velocity direction and offset direction to agree', () => {
+        const order = makeOrder()
+        // Positive velocity looks forward even with a negative offset.
+        expect(checkReorder(order, 'c', -500, 1)).toBe(order)
+    })
+})

--- a/src/lib/components/Reorder/checkReorder.ts
+++ b/src/lib/components/Reorder/checkReorder.ts
@@ -1,0 +1,69 @@
+import { mixNumber } from 'motion-dom'
+import type { ItemData } from './context'
+
+/**
+ * Return a copy of `arr` with the element at `fromIndex` moved to
+ * `toIndex`. Out-of-range `fromIndex` returns the copy unchanged;
+ * negative indices count from the end.
+ *
+ * Inline port of `moveItem` from `motion-utils` (not a direct
+ * dependency of this package — it's bundled away inside `motion-dom`).
+ */
+export const moveItem = <T>([...arr]: T[], fromIndex: number, toIndex: number): T[] => {
+    const startIndex = fromIndex < 0 ? arr.length + fromIndex : fromIndex
+
+    if (startIndex >= 0 && startIndex < arr.length) {
+        const endIndex = toIndex < 0 ? arr.length + toIndex : toIndex
+        const [item] = arr.splice(fromIndex, 1)
+        arr.splice(endIndex, 0, item)
+    }
+
+    return arr
+}
+
+/**
+ * Decide whether a live drag should swap the dragged item with its
+ * neighbour in the travel direction.
+ *
+ * The dragged item's leading edge (`layout.max + offset` when moving
+ * forward, `layout.min + offset` when moving backward) must cross the
+ * neighbour's center before a swap fires — so a swap happens exactly
+ * when the dragged item covers more than half of its neighbour.
+ * Velocity supplies the direction; a stationary pointer (`velocity ===
+ * 0`) never reorders.
+ *
+ * Returns the same `order` array reference when nothing changes, so
+ * callers can detect a swap with an identity check.
+ *
+ * Direct port of framer-motion `Reorder/utils/check-reorder.ts`.
+ */
+export const checkReorder = <V>(
+    order: ItemData<V>[],
+    value: V,
+    offset: number,
+    velocity: number
+): ItemData<V>[] => {
+    if (!velocity) return order
+
+    const index = order.findIndex((item) => item.value === value)
+
+    if (index === -1) return order
+
+    const nextOffset = velocity > 0 ? 1 : -1
+    const nextItem = order[index + nextOffset]
+
+    if (!nextItem) return order
+
+    const item = order[index]
+    const nextLayout = nextItem.layout
+    const nextItemCenter = mixNumber(nextLayout.min, nextLayout.max, 0.5)
+
+    if (
+        (nextOffset === 1 && item.layout.max + offset > nextItemCenter) ||
+        (nextOffset === -1 && item.layout.min + offset < nextItemCenter)
+    ) {
+        return moveItem(order, index, index + nextOffset)
+    }
+
+    return order
+}

--- a/src/lib/components/Reorder/context.ts
+++ b/src/lib/components/Reorder/context.ts
@@ -1,0 +1,68 @@
+import type { Axis, Box } from '$lib/utils/projection'
+import { getContext, setContext } from 'svelte'
+
+/**
+ * A measured entry in a `Reorder.Group`'s working order.
+ *
+ * `layout` is the item's slot on the group's reorder axis (the `x` or
+ * `y` half of the measured {@link Box}), captured with motion-applied
+ * transforms stripped — i.e. where the item *lives*, not where a live
+ * drag has visually carried it.
+ *
+ * Mirrors framer-motion `Reorder/types.ts` `ItemData<T>`.
+ */
+export interface ItemData<V> {
+    value: V
+    layout: Axis
+}
+
+/**
+ * Contract between `Reorder.Group` (provider) and `Reorder.Item`
+ * (consumer). Mirrors framer-motion's `ReorderContextProps<T>`
+ * (`context/ReorderContext.ts`), with two Svelte-specific adaptations:
+ *
+ * - `axis` is a getter-backed property so items observe prop changes
+ *   without re-creating the context (Svelte context is set once).
+ * - `unregisterItem` exists because our order registry persists across
+ *   renders — React rebuilds `order` from scratch every render, so
+ *   unmounted items vanish for free; here they must deregister.
+ */
+export interface ReorderContextProps<V> {
+    /** The group's reorder axis. Items drag-lock to this by default. */
+    readonly axis: 'x' | 'y'
+    /**
+     * Record (or refresh) an item's measured layout slot. Called from
+     * the item's `onLayoutMeasure`, so entries stay current as
+     * siblings FLIP into new slots.
+     */
+    registerItem: (value: V, layout: Box) => void
+    /** Remove an item's entry when it unmounts. */
+    unregisterItem: (value: V) => void
+    /**
+     * Ask the group to re-evaluate the order for a live drag. `offset`
+     * is the dragged item's current axis offset from its slot and
+     * `velocity` its axis velocity; the group runs `checkReorder` and
+     * fires `onReorder` when a swap is due.
+     */
+    updateOrder: (value: V, offset: number, velocity: number) => void
+    /** The group's rendered element, for edge auto-scrolling. */
+    getGroupElement: () => HTMLElement | null
+}
+
+const REORDER_CONTEXT_KEY = Symbol('reorder-group')
+
+/**
+ * Publish a group's reorder contract for descendant `Reorder.Item`s.
+ * Called once by `Reorder.Group` during component init.
+ */
+export const setReorderContext = <V>(context: ReorderContextProps<V>): void => {
+    setContext<ReorderContextProps<V>>(REORDER_CONTEXT_KEY, context)
+}
+
+/**
+ * Read the nearest `Reorder.Group` contract, or `undefined` when not
+ * inside one — `Reorder.Item` treats that as a usage error.
+ */
+export const getReorderContext = <V>(): ReorderContextProps<V> | undefined => {
+    return getContext<ReorderContextProps<V> | undefined>(REORDER_CONTEXT_KEY)
+}

--- a/src/lib/components/Reorder/itemMotionValue.component.spec.ts
+++ b/src/lib/components/Reorder/itemMotionValue.component.spec.ts
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/svelte'
+import { motionValue } from 'motion-dom'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import ItemMotionValueProbe from './__tests__/ItemMotionValueProbe.svelte'
+
+// jsdom has no ResizeObserver; the items' `layout` prop observes one.
+class FakeResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+}
+
+beforeAll(() => {
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver as unknown as typeof ResizeObserver)
+})
+
+afterAll(() => {
+    vi.unstubAllGlobals()
+})
+
+// Isolated in its own file: it drives motion-dom's shared frame loop
+// through fake timers, and frame-loop state left behind by other
+// renders in the same worker makes the propagation timing unreliable.
+describe('Reorder.Item MotionValue reuse', () => {
+    it('reuses a consumer x MotionValue and floats the item while offset', async () => {
+        const x = motionValue(0)
+        render(ItemMotionValueProbe, { props: { x } })
+        const item = await screen.findByTestId('probe-item')
+        // Let the container finish loading — the live style effect (and
+        // its MotionValue subscriptions) only attach once it's ready.
+        await vi.advanceTimersByTimeAsync(1000)
+        expect(item.style.zIndex).toBe('unset')
+
+        x.set(50)
+        await vi.advanceTimersByTimeAsync(500)
+        expect(item.style.zIndex).toBe('1')
+        expect(item.style.transform).toContain('translateX(50px)')
+
+        x.set(0)
+        await vi.advanceTimersByTimeAsync(500)
+        expect(item.style.zIndex).toBe('unset')
+    })
+})

--- a/src/lib/components/Reorder/order.spec.ts
+++ b/src/lib/components/Reorder/order.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import type { ItemData } from './context'
+import { applyOrderSwap, removeOrderEntry, upsertOrderEntry } from './order'
+
+const axis = (min: number, max: number) => ({ min, max })
+
+describe('upsertOrderEntry', () => {
+    it('inserts new entries sorted by slot start', () => {
+        const order: ItemData<string>[] = []
+        upsertOrderEntry(order, 'b', axis(100, 200))
+        upsertOrderEntry(order, 'a', axis(0, 100))
+        upsertOrderEntry(order, 'c', axis(200, 300))
+        expect(order.map((entry) => entry.value)).toEqual(['a', 'b', 'c'])
+    })
+
+    it('updates an existing entry in place and re-sorts', () => {
+        const order: ItemData<string>[] = []
+        upsertOrderEntry(order, 'a', axis(0, 100))
+        upsertOrderEntry(order, 'b', axis(100, 200))
+        // 'a' moves to the last slot after a reorder re-measure.
+        upsertOrderEntry(order, 'a', axis(200, 300))
+        expect(order).toHaveLength(2)
+        expect(order.map((entry) => entry.value)).toEqual(['b', 'a'])
+        expect(order[1].layout).toEqual(axis(200, 300))
+    })
+})
+
+describe('removeOrderEntry', () => {
+    it('removes the matching entry', () => {
+        const order: ItemData<string>[] = []
+        upsertOrderEntry(order, 'a', axis(0, 100))
+        upsertOrderEntry(order, 'b', axis(100, 200))
+        removeOrderEntry(order, 'a')
+        expect(order.map((entry) => entry.value)).toEqual(['b'])
+    })
+
+    it('is a no-op for unknown values', () => {
+        const order: ItemData<string>[] = []
+        upsertOrderEntry(order, 'a', axis(0, 100))
+        removeOrderEntry(order, 'z')
+        expect(order).toHaveLength(1)
+    })
+})
+
+describe('applyOrderSwap', () => {
+    const entry = <V>(value: V, min: number): ItemData<V> => ({
+        value,
+        layout: axis(min, min + 100)
+    })
+
+    it('applies the swapped pair to the full values array', () => {
+        const order = [entry('a', 0), entry('b', 100), entry('c', 200)]
+        const newOrder = [entry('b', 100), entry('a', 0), entry('c', 200)]
+        expect(applyOrderSwap(['a', 'b', 'c'], order, newOrder)).toEqual(['b', 'a', 'c'])
+    })
+
+    it('preserves unmeasured values (virtualized list support)', () => {
+        // Values 1 and 5 were never measured — only 2, 3, 4 registered.
+        const order = [entry(2, 0), entry(3, 100), entry(4, 200)]
+        const newOrder = [entry(3, 100), entry(2, 0), entry(4, 200)]
+        expect(applyOrderSwap([1, 2, 3, 4, 5], order, newOrder)).toEqual([1, 3, 2, 4, 5])
+    })
+
+    it('returns an equal copy when nothing swapped', () => {
+        const order = [entry('a', 0), entry('b', 100)]
+        const values = ['a', 'b']
+        const result = applyOrderSwap(values, order, order)
+        expect(result).toEqual(values)
+        expect(result).not.toBe(values)
+    })
+})

--- a/src/lib/components/Reorder/order.ts
+++ b/src/lib/components/Reorder/order.ts
@@ -1,0 +1,60 @@
+import type { Axis } from '$lib/utils/projection'
+import type { ItemData } from './context'
+
+const compareMin = <V>(a: ItemData<V>, b: ItemData<V>): number => a.layout.min - b.layout.min
+
+/**
+ * Record or refresh an item's measured slot in the group's working
+ * order, keeping the array sorted by slot start. Mutates `order` in
+ * place — the group owns a single persistent array (unlike upstream
+ * React, which rebuilds it every render; see `Group.tsx` `registerItem`).
+ */
+export const upsertOrderEntry = <V>(order: ItemData<V>[], value: V, layout: Axis): void => {
+    const index = order.findIndex((entry) => entry.value === value)
+    if (index !== -1) {
+        order[index].layout = layout
+    } else {
+        order.push({ value, layout })
+    }
+    order.sort(compareMin)
+}
+
+/**
+ * Drop an item's entry from the working order when it unmounts.
+ * Svelte-specific counterpart to the rebuild-per-render behaviour that
+ * makes this implicit upstream.
+ */
+export const removeOrderEntry = <V>(order: ItemData<V>[], value: V): void => {
+    const index = order.findIndex((entry) => entry.value === value)
+    if (index !== -1) {
+        order.splice(index, 1)
+    }
+}
+
+/**
+ * Translate a swap detected between `order` and `newOrder` (the
+ * `checkReorder` result) onto the full `values` array.
+ *
+ * Only the measured items appear in `order`, so applying the single
+ * swapped pair — rather than mapping `newOrder` back to values —
+ * preserves unmeasured entries, e.g. offscreen rows in a virtualized
+ * list. Direct port of the swap loop in framer-motion `Group.tsx`.
+ */
+export const applyOrderSwap = <V>(
+    values: V[],
+    order: ItemData<V>[],
+    newOrder: ItemData<V>[]
+): V[] => {
+    const newValues = [...values]
+    for (let i = 0; i < newOrder.length; i++) {
+        if (order[i].value !== newOrder[i].value) {
+            const a = values.indexOf(order[i].value)
+            const b = values.indexOf(newOrder[i].value)
+            if (a !== -1 && b !== -1) {
+                ;[newValues[a], newValues[b]] = [newValues[b], newValues[a]]
+            }
+            break
+        }
+    }
+    return newValues
+}

--- a/src/lib/components/Reorder/reorder.component.spec.ts
+++ b/src/lib/components/Reorder/reorder.component.spec.ts
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/svelte'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import ItemOutsideGroup from './__tests__/ItemOutsideGroup.svelte'
+import ReorderHarness from './__tests__/ReorderHarness.svelte'
+
+// jsdom has no ResizeObserver; the items' `layout` prop observes one.
+class FakeResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+}
+
+beforeAll(() => {
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver as unknown as typeof ResizeObserver)
+})
+
+afterAll(() => {
+    vi.unstubAllGlobals()
+})
+
+describe('Reorder.Group / Reorder.Item', () => {
+    it('renders a ul with li items by default', async () => {
+        render(ReorderHarness)
+        const group = await screen.findByTestId('group')
+        expect(group.tagName).toBe('UL')
+        expect(group.querySelectorAll('li')).toHaveLength(3)
+    })
+
+    it('respects the `as` prop on both group and item', async () => {
+        render(ReorderHarness, { props: { as: 'article', itemAs: 'section' } })
+        const group = await screen.findByTestId('group')
+        expect(group.tagName).toBe('ARTICLE')
+        expect(group.querySelectorAll('section')).toHaveLength(3)
+    })
+
+    it('disables scroll anchoring on the group', async () => {
+        render(ReorderHarness)
+        const group = await screen.findByTestId('group')
+        expect(group.style.overflowAnchor).toBe('none')
+    })
+
+    it('keeps scroll anchoring disabled when a string style is passed', async () => {
+        render(ReorderHarness, { props: { groupStyle: 'background: red' } })
+        const group = await screen.findByTestId('group')
+        expect(group.style.overflowAnchor).toBe('none')
+        expect(group.style.background).toBe('red')
+    })
+
+    it('positions items relatively by default so the drag zIndex applies', async () => {
+        render(ReorderHarness)
+        const item = await screen.findByTestId('item-0')
+        // z-index is ignored on static elements; without this default an
+        // upward drag paints the dragged item UNDER the sibling it displaces.
+        expect(item.style.position).toBe('relative')
+        expect(item.style.zIndex).toBe('unset')
+    })
+
+    it('throws when an Item renders outside a Group', () => {
+        expect(() => render(ItemOutsideGroup)).toThrow(
+            'Reorder.Item must be a child of Reorder.Group'
+        )
+    })
+})

--- a/src/lib/components/Reorder/types.ts
+++ b/src/lib/components/Reorder/types.ts
@@ -1,0 +1,49 @@
+import type { HTMLElementProps } from '$lib/types'
+import type { SvelteHTMLElements } from 'svelte/elements'
+
+/** Element tags a Reorder component can render as, via the `as` prop. */
+export type ReorderElementTag = keyof SvelteHTMLElements
+
+/**
+ * Props for `Reorder.Group`. Mirrors framer-motion's `Reorder.Group`
+ * (`Reorder/Group.tsx`): all motion props are accepted and forwarded
+ * to the underlying motion element.
+ */
+export type ReorderGroupProps<V> = HTMLElementProps & {
+    /** The HTML element to render. @default 'ul' */
+    as?: ReorderElementTag
+    /**
+     * The axis to reorder along. Items drag-lock to this axis by
+     * default; pass `drag` on an item to free both axes.
+     * @default 'y'
+     */
+    axis?: 'x' | 'y'
+    /**
+     * The current order of values. Each `Reorder.Item` inside the
+     * group must appear here via its `value` prop.
+     */
+    values: V[]
+    /**
+     * Fires with the new value order when a drag carries an item past
+     * a sibling. Assign the result back to the state driving `values`.
+     */
+    onReorder: (newOrder: V[]) => void
+}
+
+/**
+ * Props for `Reorder.Item`. Mirrors framer-motion's `Reorder.Item`
+ * (`Reorder/Item.tsx`): renders a draggable motion element whose
+ * `layout` defaults to `true`.
+ */
+export type ReorderItemProps<V> = HTMLElementProps & {
+    /** The HTML element to render. @default 'li' */
+    as?: ReorderElementTag
+    /** The entry in the group's `values` array this item represents. */
+    value: V
+    /**
+     * Layout animation mode for the item — `'position'` disables size
+     * projection while slots shuffle.
+     * @default true
+     */
+    layout?: true | 'position'
+}

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -76,7 +76,7 @@
         setPresenceDepth
     } from '$lib/utils/presence'
     import { getInitialKeyframes } from '$lib/utils/initial'
-    import { attachDrag } from '$lib/utils/drag'
+    import { attachDrag, type AttachDragCleanup } from '$lib/utils/drag'
     import { attachPan, type AttachPanCleanup } from '$lib/utils/pan'
     import { ProjectionNode } from '$lib/utils/projection'
     import { getProjectionParent, setProjectionParent } from '$lib/components/projection.context'
@@ -196,6 +196,7 @@
         layoutScroll: layoutScrollProp,
         layoutDependency: layoutDependencyProp,
         onProjectionUpdate: onProjectionUpdateProp,
+        onLayoutMeasure: onLayoutMeasureProp,
         // trunk-ignore(eslint/no-useless-assignment): `ref` is write-only here — mirrored from the internal `element` node via the effect below
         ref = $bindable(),
         ...rest
@@ -1524,7 +1525,7 @@
     //   overwriting transforms (check computed style for `transform`).
     // - If second drags "jump", ensure `attachDrag` syncs the internal `applied` origin
     //   after any non-zero duration settle animation.
-    let teardownDrag: (() => void) | null = null
+    let teardownDrag: AttachDragCleanup | null = null
     $effect(() => {
         if (!(element && isLoaded === 'ready' && hasDragFeatures)) return
         // Only attach if drag enabled
@@ -2210,6 +2211,27 @@
         }
     })
 
+    // Subscribe the consumer's `onLayoutMeasure` callback to projection
+    // `measure` events. The mount effect above runs first in source
+    // order and already seeded `latestLayout`, so that seed measurement
+    // is replayed here — otherwise a subscriber would only hear about
+    // the element's slot after its first layout CHANGE, and consumers
+    // like `Reorder.Item` need the initial slot too.
+    $effect(() => {
+        if (!(element && onLayoutMeasureProp)) return
+        const off = projection.addEventListener('measure', (box) => onLayoutMeasureProp(box))
+        const seed = projection.latestLayout
+        if (seed) {
+            onLayoutMeasureProp({
+                x: { min: seed.x.min, max: seed.x.max },
+                y: { min: seed.y.min, max: seed.y.max }
+            })
+        }
+        return () => {
+            off()
+        }
+    })
+
     // Upstream layout projection via motion-dom. Svelte runes mode doesn't
     // expose the React-style pre/post render hook pair used upstream, so the
     // component snapshots committed layout changes through DOM observers while
@@ -2262,10 +2284,20 @@
                 return
             }
 
+            // An actively dragged element must NOT take the viewport-scroll
+            // early-out: its slot change still needs the `adjustOrigin`
+            // compensation below (measurements are page-coordinate, so the
+            // delta is scroll-clean). Skipping it leaves the gesture's
+            // transform uncompensated, which re-triggers Reorder's
+            // checkReorder and double-fires the swap after any scroll.
+            const isDragActiveElement =
+                element!.dataset.svelteMotionDragActive === 'true' && !!teardownDrag
+
             if (
-                wasViewportScrolledSinceLastLayout ||
-                wasViewportOffscreenSinceLastLayout ||
-                isViewportOffscreen(element!.getBoundingClientRect())
+                !isDragActiveElement &&
+                (wasViewportScrolledSinceLastLayout ||
+                    wasViewportOffscreenSinceLastLayout ||
+                    isViewportOffscreen(element!.getBoundingClientRect()))
             ) {
                 lastRect = measureLayoutRect()
                 motionDomProjection?.finishAnimation()
@@ -2280,6 +2312,26 @@
                 const previous = lastRect
                 const shouldCommitMotionDomLayout = hasRectChanged(lastRect, next)
                 if (shouldCommitMotionDomLayout) {
+                    // A live drag whose layout slot just moved (e.g. Reorder
+                    // swapped the dragged item's DOM position): a FLIP here
+                    // would fight the gesture, so instead shift the drag
+                    // origin by the slot delta — the element stays pinned
+                    // under the cursor and `dragSnapToOrigin` settles into
+                    // the NEW slot on release. `seedLayout` re-syncs the
+                    // motion-dom projection cache so the skipped commit
+                    // can't replay as a stale delta later.
+                    if (isDragActiveElement && teardownDrag) {
+                        teardownDrag.adjustOrigin(
+                            previous.left - next.left,
+                            previous.top - next.top
+                        )
+                        motionDomProjection?.seedLayout()
+                        lastRect = next
+                        wasViewportScrolledSinceLastLayout = false
+                        wasViewportOffscreenSinceLastLayout = false
+                        return
+                    }
+
                     const transforms = computeFlipTransforms(previous, next, flipLayoutMode)
                     const shouldUseSizeCorrectedFallback =
                         transforms.shouldScale && hasSizeCorrectionTarget

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,12 +4,18 @@ import LazyMotion from '$lib/components/LazyMotion.svelte'
 import MotionConfig from '$lib/components/MotionConfig.svelte'
 import PresenceChild from '$lib/components/PresenceChild.svelte'
 
+export type {
+    ReorderElementTag,
+    ReorderGroupProps,
+    ReorderItemProps
+} from '$lib/components/Reorder/types'
 export type { FeatureBundle, LazyFeatureBundle } from '$lib/features'
 export { domAnimation } from '$lib/features/domAnimation'
 export { domMax } from '$lib/features/domMax'
 export { domMin } from '$lib/features/domMin'
 export { m } from '$lib/m'
 export { motion } from '$lib/motion'
+export { Reorder } from '$lib/reorder'
 
 // Re-export core animation functions from motion
 export { animate, delay, hover, inView, press, resize, scroll, stagger, transform } from 'motion'

--- a/src/lib/reorder.ts
+++ b/src/lib/reorder.ts
@@ -1,0 +1,25 @@
+import Group from '$lib/components/Reorder/Group.svelte'
+import Item from '$lib/components/Reorder/Item.svelte'
+
+/**
+ * Drag-to-reorder components, mirroring framer-motion's `Reorder`
+ * namespace (`Reorder/namespace.ts`).
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *     import { Reorder } from '@humanspeak/svelte-motion'
+ *     let items = $state([0, 1, 2, 3])
+ * </script>
+ *
+ * <Reorder.Group axis="y" values={items} onReorder={(next) => (items = next)}>
+ *     {#each items as item (item)}
+ *         <Reorder.Item value={item}>{item}</Reorder.Item>
+ *     {/each}
+ * </Reorder.Group>
+ * ```
+ */
+export const Reorder = {
+    Group,
+    Item
+} as const

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -437,10 +437,29 @@ export type ProjectionUpdatePayload = {
 /**
  * Fires after each layout change to a `motion.*` element that has
  * `layout` enabled, with the FLIP delta between the pre- and
- * post-change layout boxes. Mirrors framer-motion's `onLayoutMeasure`
- * surface. Wired through the element's internal `ProjectionNode`.
+ * post-change layout boxes. Wired through the element's internal
+ * `ProjectionNode`.
  */
 export type MotionOnProjectionUpdate = ((data: ProjectionUpdatePayload) => void) | undefined
+
+/**
+ * Layout box delivered to `onLayoutMeasure` — the element's viewport
+ * position with motion-applied transforms (drag offset, in-flight FLIP)
+ * stripped, i.e. its layout slot. Structurally identical to the
+ * `layout`/`snapshot` halves of {@link ProjectionUpdatePayload}.
+ */
+export type LayoutMeasurePayload = {
+    x: { min: number; max: number }
+    y: { min: number; max: number }
+}
+
+/**
+ * Fires every time the element's projection node (re)measures its
+ * layout box: once at mount to seed the baseline, then on every
+ * observed layout change. Mirrors framer-motion's `onLayoutMeasure`.
+ * `Reorder.Item` uses this to keep its slot registered with the group.
+ */
+export type MotionOnLayoutMeasure = ((box: LayoutMeasurePayload) => void) | undefined
 
 export type DragAxis = boolean | 'x' | 'y'
 export type DragConstraints =
@@ -609,10 +628,16 @@ export type MotionProps = {
     layout?: boolean | 'position' | 'size' | 'preserve-aspect'
     /**
      * Fires after each `layout`-driven change with the FLIP delta from
-     * the element's internal projection node. Mirrors framer-motion's
-     * `onLayoutMeasure`. Requires `layout` to be enabled.
+     * the element's internal projection node. Requires `layout` to be
+     * enabled.
      */
     onProjectionUpdate?: MotionOnProjectionUpdate
+    /**
+     * Fires with the element's layout box on every projection
+     * (re)measure — at mount and after each observed layout change.
+     * Mirrors framer-motion's `onLayoutMeasure`.
+     */
+    onLayoutMeasure?: MotionOnLayoutMeasure
     /** Shared layout animation identifier. Elements with matching layoutId animate between positions. */
     layoutId?: string
     /**

--- a/src/lib/utils/style.ts
+++ b/src/lib/utils/style.ts
@@ -332,7 +332,13 @@ const mergeRenderStateIntoStyle = (base: Record<string, string>, state: HTMLRend
     }
 }
 
-const parseStyleString = (style: string): Record<string, string> => {
+/**
+ * Parse an inline CSS string into a property → value record. Property
+ * names are kept verbatim (kebab-case stays kebab-case), which is a
+ * valid object-form style — `Reorder.Item` uses this to merge its
+ * `x`/`y`/`zIndex` MotionValues into a consumer's string `style`.
+ */
+export const parseStyleString = (style: string): Record<string, string> => {
     const out: Record<string, string> = {}
     style
         .split(';')

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -224,6 +224,59 @@
             </ul>
         </div>
         <div>
+            <h2 class="mb-3 text-xl font-medium">Reorder</h2>
+            <ul class="list-disc space-y-2 pl-5">
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/reorder/basic') + searchParams}
+                    >
+                        Reorder Basic (motion.dev parity)
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/reorder/axis-x') + searchParams}
+                    >
+                        Reorder Axis X
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/reorder/siblings-flip') + searchParams}
+                    >
+                        Reorder Siblings FLIP (live drag)
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/reorder/custom-drag') + searchParams}
+                    >
+                        Reorder Custom Drag (both axes)
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/reorder/scrollable') + searchParams}
+                    >
+                        Reorder in Scrollable Container (layoutScroll + auto-scroll)
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/reorder/page-scroll') + searchParams}
+                    >
+                        Reorder with Window Scroll (below the fold)
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <div>
             <h2 class="mb-3 text-xl font-medium">Drag</h2>
             <ul class="list-disc space-y-2 pl-5">
                 <li>

--- a/src/routes/tests/reorder/axis-x/+page.svelte
+++ b/src/routes/tests/reorder/axis-x/+page.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+    import { Reorder } from '$lib'
+
+    type Tile = { id: string; color: string }
+
+    let tiles = $state<Tile[]>([
+        { id: 'red', color: '#f87171' },
+        { id: 'amber', color: '#fbbf24' },
+        { id: 'green', color: '#4ade80' },
+        { id: 'blue', color: '#60a5fa' }
+    ])
+</script>
+
+<div class="page">
+    <h1>Reorder — axis x</h1>
+    <p>Drag tiles horizontally to reorder the row. Items lock to the x axis.</p>
+
+    <Reorder.Group
+        axis="x"
+        values={tiles}
+        onReorder={(next: Tile[]) => (tiles = next)}
+        data-testid="reorder-group"
+        style="list-style: none; padding: 0; margin: 0; display: flex; gap: 10px;"
+    >
+        {#each tiles as tile (tile.id)}
+            <Reorder.Item
+                value={tile}
+                data-testid={`tile-${tile.id}`}
+                style={`width: 90px; height: 90px; border-radius: 12px; background: ${tile.color}; cursor: grab; user-select: none; -webkit-user-select: none;`}
+            />
+        {/each}
+    </Reorder.Group>
+
+    <div data-testid="order">{tiles.map((tile) => tile.id).join(',')}</div>
+</div>
+
+<style>
+    .page {
+        min-height: 100vh;
+        padding: 48px;
+        background: #0f1115;
+        color: #e5e7eb;
+        font-family: system-ui, sans-serif;
+    }
+
+    h1 {
+        font-size: 20px;
+        margin-bottom: 8px;
+    }
+
+    p {
+        margin-bottom: 24px;
+        color: #9ca3af;
+    }
+
+    [data-testid='order'] {
+        margin-top: 24px;
+        font-family: monospace;
+        color: #6b7280;
+    }
+</style>

--- a/src/routes/tests/reorder/basic/+page.svelte
+++ b/src/routes/tests/reorder/basic/+page.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+    import { Reorder } from '$lib'
+
+    const slug = (item: string) => item.split(' ')[1].toLowerCase()
+
+    let items = $state(['🍅 Tomato', '🥒 Cucumber', '🧀 Cheese', '🥬 Lettuce'])
+</script>
+
+<div class="page">
+    <h1>Reorder — basic (motion.dev/docs/react-reorder)</h1>
+    <p>Drag items vertically to reorder the list. Items lock to the y axis.</p>
+
+    <Reorder.Group
+        axis="y"
+        values={items}
+        onReorder={(next: string[]) => (items = next)}
+        data-testid="reorder-group"
+        style="list-style: none; padding: 0; margin: 0; width: 320px;"
+    >
+        {#each items as item (item)}
+            <Reorder.Item
+                value={item}
+                data-testid={`item-${slug(item)}`}
+                style="display: flex; align-items: center; height: 44px; padding: 0 16px; margin-bottom: 10px; background: white; color: #0f1115; border-radius: 10px; box-shadow: 0 1px 3px rgba(0,0,0,0.25); cursor: grab; user-select: none; -webkit-user-select: none;"
+            >
+                {item}
+            </Reorder.Item>
+        {/each}
+    </Reorder.Group>
+
+    <div data-testid="order">{items.map(slug).join(',')}</div>
+</div>
+
+<style>
+    .page {
+        min-height: 100vh;
+        padding: 48px;
+        background: #0f1115;
+        color: #e5e7eb;
+        font-family: system-ui, sans-serif;
+    }
+
+    h1 {
+        font-size: 20px;
+        margin-bottom: 8px;
+    }
+
+    p {
+        margin-bottom: 24px;
+        color: #9ca3af;
+    }
+
+    [data-testid='order'] {
+        margin-top: 24px;
+        font-family: monospace;
+        color: #6b7280;
+    }
+</style>

--- a/src/routes/tests/reorder/custom-drag/+page.svelte
+++ b/src/routes/tests/reorder/custom-drag/+page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+    import { Reorder } from '$lib'
+
+    let items = $state(['one', 'two', 'three'])
+</script>
+
+<div class="page">
+    <h1>Reorder — custom drag override</h1>
+    <p>
+        The group reorders on the y axis, but each item passes <code>drag</code> so the gesture is
+        free on both axes (upstream: “To make draggable on both axes, set
+        <code>&lt;Reorder.Item drag /&gt;</code>”).
+    </p>
+
+    <Reorder.Group
+        axis="y"
+        values={items}
+        onReorder={(next: string[]) => (items = next)}
+        data-testid="reorder-group"
+        style="list-style: none; padding: 0; margin: 0; width: 320px;"
+    >
+        {#each items as item (item)}
+            <Reorder.Item
+                value={item}
+                drag
+                data-testid={`item-${item}`}
+                style="display: flex; align-items: center; height: 44px; padding: 0 16px; margin-bottom: 10px; background: white; color: #0f1115; border-radius: 10px; cursor: grab; user-select: none; -webkit-user-select: none;"
+            >
+                {item}
+            </Reorder.Item>
+        {/each}
+    </Reorder.Group>
+
+    <div data-testid="order">{items.join(',')}</div>
+</div>
+
+<style>
+    .page {
+        min-height: 100vh;
+        padding: 48px;
+        background: #0f1115;
+        color: #e5e7eb;
+        font-family: system-ui, sans-serif;
+    }
+
+    h1 {
+        font-size: 20px;
+        margin-bottom: 8px;
+    }
+
+    p {
+        margin-bottom: 24px;
+        max-width: 480px;
+        color: #9ca3af;
+    }
+
+    code {
+        color: #93c5fd;
+    }
+
+    [data-testid='order'] {
+        margin-top: 24px;
+        font-family: monospace;
+        color: #6b7280;
+    }
+</style>

--- a/src/routes/tests/reorder/page-scroll/+page.svelte
+++ b/src/routes/tests/reorder/page-scroll/+page.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+    import { Reorder } from '$lib'
+
+    let items = $state(['alpha', 'beta', 'gamma', 'delta'])
+</script>
+
+<div class="page">
+    <h1>Reorder — below the fold (window scroll)</h1>
+    <p data-testid="spacer-note">
+        The list sits below an 800px spacer, so the window must scroll before dragging. Reordering
+        and settling must stay correct with a non-zero window scroll offset.
+    </p>
+
+    <div class="spacer" aria-hidden="true"></div>
+
+    <Reorder.Group
+        axis="y"
+        values={items}
+        onReorder={(next: string[]) => (items = next)}
+        data-testid="reorder-group"
+        style="list-style: none; padding: 0; margin: 0; width: 320px;"
+    >
+        {#each items as item (item)}
+            <Reorder.Item
+                value={item}
+                data-testid={`item-${item}`}
+                style="display: flex; align-items: center; height: 50px; padding: 0 16px; margin-bottom: 10px; background: white; color: #0f1115; border-radius: 10px; cursor: grab; user-select: none; -webkit-user-select: none;"
+            >
+                {item}
+            </Reorder.Item>
+        {/each}
+    </Reorder.Group>
+
+    <div data-testid="order">{items.join(',')}</div>
+
+    <div class="spacer" aria-hidden="true"></div>
+</div>
+
+<style>
+    .page {
+        padding: 48px;
+        background: #0f1115;
+        color: #e5e7eb;
+        font-family: system-ui, sans-serif;
+    }
+
+    h1 {
+        font-size: 20px;
+        margin-bottom: 8px;
+    }
+
+    p {
+        margin-bottom: 24px;
+        max-width: 480px;
+        color: #9ca3af;
+    }
+
+    .spacer {
+        height: 800px;
+        background: repeating-linear-gradient(180deg, transparent 0 99px, #1f2937 99px 100px)
+            border-box;
+    }
+
+    [data-testid='order'] {
+        margin-top: 16px;
+        font-family: monospace;
+        color: #6b7280;
+    }
+</style>

--- a/src/routes/tests/reorder/scrollable/+page.svelte
+++ b/src/routes/tests/reorder/scrollable/+page.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+    import { motion, Reorder } from '$lib'
+
+    let items = $state(['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight'])
+
+    let scroller = $state<HTMLElement | null>(null)
+    let scrollTop = $state(0)
+
+    const handleScroll = () => {
+        scrollTop = scroller?.scrollTop ?? 0
+    }
+</script>
+
+<div class="page">
+    <h1>Reorder — inside a scrollable container</h1>
+    <p>
+        The list lives in a 300px <code>overflow-y: scroll</code> container marked with
+        <code>layoutScroll</code>. Reordering must stay correct when the container is pre-scrolled,
+        and dragging near its edges auto-scrolls it.
+    </p>
+
+    <motion.div
+        bind:ref={scroller}
+        layoutScroll
+        onscroll={handleScroll}
+        data-testid="scroller"
+        style="height: 300px; width: 340px; overflow-y: scroll; border: 1px solid #374151; border-radius: 12px; padding: 10px; background: #111827;"
+    >
+        <Reorder.Group
+            axis="y"
+            values={items}
+            onReorder={(next: string[]) => (items = next)}
+            data-testid="reorder-group"
+            style="list-style: none; padding: 0; margin: 0;"
+        >
+            {#each items as item (item)}
+                <Reorder.Item
+                    value={item}
+                    data-testid={`item-${item}`}
+                    style="display: flex; align-items: center; height: 50px; padding: 0 16px; margin-bottom: 10px; background: white; color: #0f1115; border-radius: 10px; cursor: grab; user-select: none; -webkit-user-select: none;"
+                >
+                    {item}
+                </Reorder.Item>
+            {/each}
+        </Reorder.Group>
+    </motion.div>
+
+    <div data-testid="order">{items.join(',')}</div>
+    <div data-testid="scroll-top">{Math.round(scrollTop)}</div>
+</div>
+
+<style>
+    .page {
+        min-height: 100vh;
+        padding: 48px;
+        background: #0f1115;
+        color: #e5e7eb;
+        font-family: system-ui, sans-serif;
+    }
+
+    h1 {
+        font-size: 20px;
+        margin-bottom: 8px;
+    }
+
+    p {
+        margin-bottom: 24px;
+        max-width: 480px;
+        color: #9ca3af;
+    }
+
+    code {
+        color: #93c5fd;
+    }
+
+    [data-testid='order'],
+    [data-testid='scroll-top'] {
+        margin-top: 16px;
+        font-family: monospace;
+        color: #6b7280;
+    }
+</style>

--- a/src/routes/tests/reorder/siblings-flip/+page.svelte
+++ b/src/routes/tests/reorder/siblings-flip/+page.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+    import { Reorder } from '$lib'
+
+    let items = $state(['a', 'b', 'c'])
+</script>
+
+<div class="page">
+    <h1>Reorder — siblings FLIP during live drag</h1>
+    <p>
+        While an item is being dragged, the displaced sibling should animate into its new slot (not
+        teleport) and the dragged item should stay pinned under the cursor when the swap moves its
+        DOM position.
+    </p>
+
+    <Reorder.Group
+        axis="y"
+        values={items}
+        onReorder={(next: string[]) => (items = next)}
+        data-testid="reorder-group"
+        style="list-style: none; padding: 0; margin: 0; width: 320px;"
+    >
+        {#each items as item (item)}
+            <Reorder.Item
+                value={item}
+                data-testid={`item-${item}`}
+                transition={{ duration: 0.4 }}
+                style="display: flex; align-items: center; height: 60px; padding: 0 16px; margin-bottom: 12px; background: white; color: #0f1115; border-radius: 10px; cursor: grab; user-select: none; -webkit-user-select: none;"
+            >
+                Item {item.toUpperCase()}
+            </Reorder.Item>
+        {/each}
+    </Reorder.Group>
+
+    <div data-testid="order">{items.join(',')}</div>
+</div>
+
+<style>
+    .page {
+        min-height: 100vh;
+        padding: 48px;
+        background: #0f1115;
+        color: #e5e7eb;
+        font-family: system-ui, sans-serif;
+    }
+
+    h1 {
+        font-size: 20px;
+        margin-bottom: 8px;
+    }
+
+    p {
+        margin-bottom: 24px;
+        max-width: 480px;
+        color: #9ca3af;
+    }
+
+    [data-testid='order'] {
+        margin-top: 24px;
+        font-family: monospace;
+        color: #6b7280;
+    }
+</style>


### PR DESCRIPTION
## Summary

Adds a Framer Motion-compatible `Reorder` namespace — `Reorder.Group` + `Reorder.Item` — for drag-to-reorder lists: axis-locked dragging with mid-gesture swaps, siblings that FLIP out of the way while the pointer is down, snap-into-new-slot release, and edge auto-scroll for long lists. The dragged item stays pinned under the cursor with **0px measured drift** through multi-slot swaps, including with scrolled containers and a scrolled window.

Closes #310
Closes #395

## Upstream fidelity

Ported line-for-line from `framer-motion` (`~/Github/motion`), with Svelte-specific adaptations called out in code comments:

- `Reorder/Group.tsx` → `src/lib/components/Reorder/Group.svelte` — `order` registry sorted by `min`, `isReordering` guard, swap-two-values application preserving unmeasured (virtualized) entries, `overflow-anchor: none` group style, `values` invariant
- `Reorder/Item.tsx` → `src/lib/components/Reorder/Item.svelte` — `drag={axis}` before prop spread (consumer `drag` override), `dragSnapToOrigin` after, x/y MotionValue reuse (`useDefaultMotionValue`), `zIndex = useTransform([x, y], …)`, `onLayoutMeasure → registerItem`
- `Reorder/utils/check-reorder.ts` → `checkReorder.ts` — byte-equivalent logic; `mixNumber` from `motion-dom`, `moveItem` inlined (`motion-utils` isn't a direct dep)
- `Reorder/utils/auto-scroll.ts` → `autoScroll.ts` — one deliberate divergence: our `DragInfo.point` is client coords, so the upstream `window.scrollX/Y` subtraction is dropped
- Svelte adaptations: persistent order registry needs `unregisterItem` (React rebuilds per render); `isReordering` reset via rAF-deferred `$effect` on `values` (React resets in `useEffect`); items default `position: relative` so the floating `zIndex` applies (z-index is ignored on static elements — without it an upward swap paints the dragged item under the sibling it displaces)

## Changes

- ✨ `Reorder.Group` / `Reorder.Item` exported from the package root, with `ReorderGroupProps` / `ReorderItemProps` / `ReorderElementTag` types
- ✨ New public `onLayoutMeasure(box)` motion prop — subscribes to projection `measure` events with immediate seed replay (framer-motion API parity)
- 🔧 Wired the pre-built `adjustOrigin` drag handle (#379) into `commitObservedLayout`: when a live drag's DOM slot moves, skip the FLIP and shift the gesture origin by the slot delta — the item stays pinned under the cursor and `dragSnapToOrigin` settles into the new slot
- 🐛 Actively dragged elements now bypass the viewport-scroll early-out in `commitObservedLayout` — measurements are page-coordinate so the delta is scroll-clean; skipping compensation double-fired the first swap after any window scroll (repro: window scrolled 750px, one-slot drag moved the item two slots)
- 🧪 6 test pages under `src/routes/tests/reorder/` (basic motion.dev parity list, axis-x, siblings-flip, custom-drag, scrollable container, page-scroll) linked from the test index
- 🧪 22 Playwright specs in `e2e/reorder/`, incl. cursor-pinning drift sampling, `elementFromPoint` paint-order, auto-scroll progression, pre-scrolled + mid-drag-scroll cases, and slot-pitch consistency assertions
- 🧪 33 unit specs (checkReorder port cases, order registry, auto-scroll with mocked layout, component rendering, MotionValue reuse)
- 📚 Docs page `/docs/reorder` (nav under Components) + examples page `/examples/reorder` with two live demos (default + scrollable `layoutScroll` auto-scroll)

## Related issues

- Partial progress on #394 — the "active dragged item wins the paint/hit stack" criterion is covered (`elementFromPoint` e2e + `position: relative` fix); the nested-children-inside-parent harness remains
- Partial progress on #396 — the reorder-swap layout mutation is solved via `adjustOrigin` (0px-drift e2e); insertion/expand-collapse/AnimatePresence-during-drag harnesses remain
- #397 (upstream parity cleanup) and #415 (page-space measurement replacing the scroll heuristic — this PR narrowly bypasses the heuristic for drag-active elements rather than removing it) are follow-ups

## Verification

- Full Playwright suite: **285 passed, 0 failed** (9.0m); vitest: **669 passed**; `svelte-check`: 0 errors; `trunk check`: clean; docs production build passes
- Live-driven sign-off on the dev server, including the upward-drag paint bug found in manual testing (fixed test-first)

## Commits

- [`d3b1d4e`](https://github.com/humanspeak/svelte-motion/commit/d3b1d4e3080a90ba767fa6b09905da874bad067f) feat(reorder): add Reorder.Group + Reorder.Item drag-to-reorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)
