### PR TITLE
feat(view): animateView — View Transitions API with Svelte flushSync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ docs/src/lib/sitemap-manifest.json
 mprocs.log
 SEO.md
 .claude/scheduled_tasks.lock
+docs/test-results/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Svelte Motion — Framer Motion API for Svelte 5
 
 [![NPM version](https://img.shields.io/npm/v/@humanspeak/svelte-motion.svg)](https://www.npmjs.com/package/@humanspeak/svelte-motion)
+[![tokenmaxing](https://tokenmaxing.app/badge/humanspeak/svelte-motion)](https://tokenmaxing.app/card/humanspeak/svelte-motion)
 [![Build Status](https://github.com/humanspeak/svelte-motion/actions/workflows/npm-publish.yml/badge.svg)](https://github.com/humanspeak/svelte-motion/actions/workflows/npm-publish.yml)
 [![Coverage Status](https://coveralls.io/repos/github/humanspeak/svelte-motion/badge.svg?branch=main)](https://coveralls.io/github/humanspeak/svelte-motion?branch=main)
 [![License](https://img.shields.io/npm/l/@humanspeak/svelte-motion.svg)](https://github.com/humanspeak/svelte-motion/blob/main/LICENSE)
@@ -45,7 +46,9 @@ Goal: Framer Motion API parity for Svelte where common React examples can be tra
 | `AnimatePresence` (`initial`, `mode`, `onExitComplete`)                | Supported                                  |
 | Layout (`layout`, `layout="position"`)                                 | Supported (single-element FLIP)            |
 | Shared layout (`layoutId`, `LayoutGroup`, `layoutScroll`)              | Supported                                  |
-| Pan gesture API (`whilePan`, `onPan*`)                                 | Not yet supported                          |
+| Reorder (`Reorder.Group`, `Reorder.Item`, edge auto-scroll)            | Supported                                  |
+| View Transitions (`animateView`, shared-element morphs)                | Supported                                  |
+| Pan gesture API (`onPan*`, `onPanSessionStart`)                        | Supported                                  |
 | `MotionConfig` parity beyond `transition`                              | Partial                                    |
 | `reducedMotion`, `features`, `transformPagePoint`                      | Not yet supported                          |
 
@@ -296,18 +299,18 @@ Validated against current source and test suite (local run):
 
 Part of the [Humanspeak](https://humanspeak.com) family of runes-native Svelte 5 packages:
 
-| Package | Description |
-| --- | --- |
-| [@humanspeak/svelte-markdown](https://markdown.svelte.page) | Runtime markdown renderer for Svelte |
-| [@humanspeak/svelte-virtual-list](https://virtuallist.svelte.page) | Virtual scrolling for Svelte |
-| **[@humanspeak/svelte-motion](https://motion.svelte.page)** — _this package_ | Framer Motion for Svelte 5 |
-| [@humanspeak/svelte-headless-table](https://table.svelte.page) | Headless data tables for Svelte |
-| [@humanspeak/svelte-diff-match-patch](https://diff.svelte.page) | Diff comparison for Svelte |
-| [@humanspeak/svelte-purify](https://purify.svelte.page) | HTML sanitisation for Svelte |
-| [@humanspeak/svelte-virtual-chat](https://virtualchat.svelte.page) | Virtual chat viewport for Svelte 5 |
-| [@humanspeak/memory-cache](https://memory.svelte.page) | In-memory cache for TypeScript |
-| [@humanspeak/svelte-json-view-lite](https://jsonview.svelte.page) | JSON tree viewer for Svelte 5 |
-| [@humanspeak/svelte-scoped-props](https://scoped.svelte.page) | Scoped class props for Svelte |
+| Package                                                                      | Description                          |
+| ---------------------------------------------------------------------------- | ------------------------------------ |
+| [@humanspeak/svelte-markdown](https://markdown.svelte.page)                  | Runtime markdown renderer for Svelte |
+| [@humanspeak/svelte-virtual-list](https://virtuallist.svelte.page)           | Virtual scrolling for Svelte         |
+| **[@humanspeak/svelte-motion](https://motion.svelte.page)** — _this package_ | Framer Motion for Svelte 5           |
+| [@humanspeak/svelte-headless-table](https://table.svelte.page)               | Headless data tables for Svelte      |
+| [@humanspeak/svelte-diff-match-patch](https://diff.svelte.page)              | Diff comparison for Svelte           |
+| [@humanspeak/svelte-purify](https://purify.svelte.page)                      | HTML sanitisation for Svelte         |
+| [@humanspeak/svelte-virtual-chat](https://virtualchat.svelte.page)           | Virtual chat viewport for Svelte 5   |
+| [@humanspeak/memory-cache](https://memory.svelte.page)                       | In-memory cache for TypeScript       |
+| [@humanspeak/svelte-json-view-lite](https://jsonview.svelte.page)            | JSON tree viewer for Svelte 5        |
+| [@humanspeak/svelte-scoped-props](https://scoped.svelte.page)                | Scoped class props for Svelte        |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -278,15 +278,14 @@ The package also re-exports core helpers from `motion` (for example `animate`, `
 
 Validated against current source and test suite (local run):
 
-- Unit/component tests: `259 passed`
-- E2E tests: `78 passed`, `1 skipped`
+- Unit/component tests: `676 passed`
+- E2E tests: `290 passed`, `2 skipped`
 
 ## Known gaps vs Framer Motion
 
-- No pan gesture API (`whilePan`, `onPan*`).
 - `whileInView` does not yet expose Framer-style viewport options.
 - `MotionConfig` currently only provides `transition` defaults.
-- `reducedMotion`, `features`, and `transformPagePoint` are not implemented.
+- `reducedMotion`, `features`, and `transformPagePoint` are not implemented as `MotionConfig` props.
 
 ## External dependencies
 

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -22,6 +22,7 @@ import {
     ShieldCheck,
     Signal,
     SlidersHorizontal,
+    Sparkles,
     Timer,
     Wand,
     Zap
@@ -58,7 +59,8 @@ export const docsSections: NavSection[] = [
             { title: 'Layout Animations', href: '/docs/layout-animations', icon: Move },
             { title: 'layoutDependency', href: '/docs/layout-dependency', icon: Gauge },
             { title: 'transformTemplate', href: '/docs/transform-template', icon: Code },
-            { title: 'Variants', href: '/docs/variants', icon: Layers }
+            { title: 'Variants', href: '/docs/variants', icon: Layers },
+            { title: 'View Transitions', href: '/docs/view', icon: Sparkles }
         ]
     },
     {

--- a/docs/src/lib/examples/ViewExample.svelte
+++ b/docs/src/lib/examples/ViewExample.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+    import { animateView } from '@humanspeak/svelte-motion'
+
+    type Tile = { id: string; color: string; title: string }
+
+    const tiles: Tile[] = [
+        { id: 'coral', color: '#f87171', title: 'Coral Dreams' },
+        { id: 'amber', color: '#fbbf24', title: 'Amber Waves' },
+        { id: 'jade', color: '#4ade80', title: 'Jade Motion' }
+    ]
+
+    let selected = $state<Tile | null>(null)
+
+    const open = (tile: Tile) => {
+        animateView(() => {
+            selected = tile
+        }).add(`[data-view-thumb="${tile.id}"]`, '[data-view-hero]')
+    }
+
+    const close = () => {
+        const tile = selected
+        if (!tile) return
+        animateView(() => {
+            selected = null
+        }).add('[data-view-hero]', `[data-view-thumb="${tile.id}"]`)
+    }
+</script>
+
+<!-- Fixed height: the grid and detail states differ in natural height,
+     and a content-driven wrapper makes the docs card jump on swap. -->
+<div class="flex h-64 flex-col items-center justify-center gap-4">
+    {#if selected}
+        <div class="flex flex-col items-center gap-3">
+            <div
+                data-view-hero
+                class="view-radius h-40 w-40"
+                style={`background:${selected.color}`}
+            ></div>
+            <p class="text-sm font-medium">{selected.title}</p>
+            <button
+                class="rounded-lg bg-neutral-700 px-3 py-1.5 text-sm text-white"
+                onclick={close}
+            >
+                Back
+            </button>
+        </div>
+    {:else}
+        <p class="text-text-muted text-sm">Click a tile — it morphs into the hero</p>
+        <div class="flex gap-3">
+            {#each tiles as tile (tile.id)}
+                <button
+                    data-view-thumb={tile.id}
+                    class="view-radius h-16 w-16 cursor-pointer border-none"
+                    style={`background:${tile.color}`}
+                    aria-label={`Open ${tile.title}`}
+                    onclick={() => open(tile)}
+                ></button>
+            {/each}
+        </div>
+    {/if}
+</div>
+
+<style>
+    /* Matching PERCENTAGE radii on both morph endpoints: snapshots bake
+       corner rounding in as transparency, so proportional radii keep the
+       two silhouettes coincident at every scale — no corner ghosting. */
+    .view-radius {
+        border-radius: 12%;
+    }
+</style>

--- a/docs/src/lib/examples/view/demos/FilterGallery.svelte
+++ b/docs/src/lib/examples/view/demos/FilterGallery.svelte
@@ -31,7 +31,11 @@
     <div class="stack">
         <div class="filters">
             {#each ['all', 'circle', 'square'] as const as kind (kind)}
-                <button class:active={filter === kind} onclick={() => setFilter(kind)}>
+                <button
+                    class:active={filter === kind}
+                    aria-pressed={filter === kind}
+                    onclick={() => setFilter(kind)}
+                >
                     {kind}
                 </button>
             {/each}

--- a/docs/src/lib/examples/view/demos/FilterGallery.svelte
+++ b/docs/src/lib/examples/view/demos/FilterGallery.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+    import { animateView } from '@humanspeak/svelte-motion'
+
+    // Filtering inside animateView: survivors morph to their new grid
+    // slots, pure newcomers scale-fade in via .enter(), pure leavers
+    // out via .exit().
+
+    type Item = { id: number; kind: 'circle' | 'square' }
+
+    const all: Item[] = Array.from({ length: 12 }, (_, index) => ({
+        id: index,
+        kind: index % 2 === 0 ? 'circle' : 'square'
+    }))
+
+    let filter = $state<'all' | 'circle' | 'square'>('all')
+    const visible = $derived(filter === 'all' ? all : all.filter((item) => item.kind === filter))
+
+    const setFilter = (next: typeof filter) => {
+        if (next === filter) return
+        animateView(() => {
+            filter = next
+        })
+            .add('[data-view-item]')
+            .enter({ opacity: [0, 1], scale: [0.6, 1] })
+            .exit({ opacity: [1, 0], scale: [1, 0.6] })
+    }
+</script>
+
+<!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
+<div class="dk-demo-shell">
+    <div class="stack">
+        <div class="filters">
+            {#each ['all', 'circle', 'square'] as const as kind (kind)}
+                <button class:active={filter === kind} onclick={() => setFilter(kind)}>
+                    {kind}
+                </button>
+            {/each}
+        </div>
+
+        <div class="grid">
+            {#each visible as item (item.id)}
+                <div class={`item ${item.kind}`} data-view-item aria-hidden="true"></div>
+            {/each}
+        </div>
+    </div>
+</div>
+
+<style>
+    .dk-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 320px;
+    }
+
+    .stack {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .filters {
+        display: flex;
+        gap: 8px;
+    }
+
+    .filters button {
+        padding: 6px 14px;
+        border: none;
+        border-radius: 8px;
+        background: rgba(120, 120, 140, 0.25);
+        cursor: pointer;
+        text-transform: capitalize;
+    }
+
+    .filters button.active {
+        background: #6366f1;
+        color: white;
+    }
+
+    /* Fixed grid height for the 2-row "all" state: filtering down to
+       one row must not shrink the stack, or the filter buttons above
+       jump as the layout recenters. 40px items keep the 6-column row
+       inside narrow mobile viewports. */
+    .grid {
+        display: grid;
+        grid-template-columns: repeat(6, 40px);
+        grid-auto-rows: 40px;
+        gap: 8px;
+        height: 88px;
+        align-content: start;
+    }
+
+    .item {
+        width: 40px;
+        height: 40px;
+    }
+
+    .item.circle {
+        border-radius: 50%;
+        background: #f472b6;
+    }
+
+    .item.square {
+        border-radius: 10px;
+        background: #38bdf8;
+    }
+</style>

--- a/docs/src/lib/examples/view/demos/SharedElement.svelte
+++ b/docs/src/lib/examples/view/demos/SharedElement.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+    import { animateView } from '@humanspeak/svelte-motion'
+
+    // The "now playing" pattern: a thumbnail and a detail hero are two
+    // DIFFERENT elements paired into one view-transition layer with
+    // .add(oldTarget, newTarget), so the browser morphs between them.
+
+    type Album = { id: string; color: string; title: string }
+
+    const albums: Album[] = [
+        { id: 'coral', color: '#f87171', title: 'Coral Dreams' },
+        { id: 'amber', color: '#fbbf24', title: 'Amber Waves' },
+        { id: 'jade', color: '#4ade80', title: 'Jade Motion' },
+        { id: 'sky', color: '#60a5fa', title: 'Sky Static' }
+    ]
+
+    let selected = $state<Album | null>(null)
+
+    const open = (album: Album) => {
+        animateView(() => {
+            selected = album
+        }).add(`[data-thumb="${album.id}"]`, '[data-hero]')
+    }
+
+    const close = () => {
+        const album = selected
+        if (!album) return
+        animateView(() => {
+            selected = null
+        }).add('[data-hero]', `[data-thumb="${album.id}"]`)
+    }
+</script>
+
+<!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
+<div class="dk-demo-shell">
+    {#if selected}
+        <div class="detail">
+            <div data-hero class="hero" style={`background:${selected.color}`}></div>
+            <p>{selected.title}</p>
+            <button onclick={close}>Back</button>
+        </div>
+    {:else}
+        <div class="grid">
+            {#each albums as album (album.id)}
+                <button
+                    data-thumb={album.id}
+                    class="thumb"
+                    style={`background:${album.color}`}
+                    aria-label={`Open ${album.title}`}
+                    onclick={() => open(album)}
+                ></button>
+            {/each}
+        </div>
+    {/if}
+</div>
+
+<style>
+    /* Fixed height (not min-height): the grid and detail states differ
+       in natural height, and a content-driven shell makes the whole
+       example card jump when the view swaps. */
+    .dk-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1.5rem;
+        height: 360px;
+    }
+
+    /* Matching PERCENTAGE radii on both morph endpoints — snapshots bake
+       rounding in as transparency, so proportional radii keep the two
+       silhouettes coincident at every scale (no corner ghosting). */
+    .thumb,
+    .hero {
+        border-radius: 12%;
+    }
+
+    .grid {
+        display: grid;
+        grid-template-columns: repeat(4, 72px);
+        gap: 12px;
+    }
+
+    .thumb {
+        width: 72px;
+        height: 72px;
+        border: none;
+        cursor: pointer;
+    }
+
+    .detail {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 12px;
+    }
+
+    .hero {
+        width: 200px;
+        height: 200px;
+    }
+
+    .detail p {
+        margin: 0;
+        font-weight: 600;
+    }
+
+    .detail button {
+        padding: 6px 14px;
+        border: none;
+        border-radius: 8px;
+        background: rgba(120, 120, 140, 0.25);
+        cursor: pointer;
+    }
+</style>

--- a/docs/src/routes/docs/view/+page.svx
+++ b/docs/src/routes/docs/view/+page.svx
@@ -1,0 +1,149 @@
+---
+title: View Transitions
+description: Animate between two DOM states with the browser View Transitions API — crossfades, shared-element morphs, and enter/exit animations via animateView
+---
+
+<script>
+  import Example from '$lib/components/general/Example.svelte'
+  import ViewExample from '$lib/examples/ViewExample.svelte'
+  import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+  const seo = getSeoContext()
+  if (seo) {
+      seo.title = 'View Transitions | Docs | Svelte Motion'
+      seo.description = 'Animate between two DOM states with animateView and the browser View Transitions API — crossfades, shared-element morphs, and enter/exit animations with spring timing.'
+      seo.ogTitle = 'View Transitions'
+      seo.ogTagline = 'Shared-element morphs and page transitions with animateView'
+      seo.ogFeatures = ['Shared Element Morphs', 'Spring Timing', 'Enter/Exit Layers', 'Native Browser API']
+      seo.ogSlug = 'docs-view'
+  }
+</script>
+
+# View Transitions
+
+`animateView` animates between two DOM states using the browser's native [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API) — whole-page crossfades, shared-element morphs (a thumbnail flying into a hero), and enter/exit animations for appearing and disappearing elements, all driven by Motion's spring-capable timing.
+
+```svelte
+<script lang="ts">
+    import { animateView } from '@humanspeak/svelte-motion'
+
+    let selected = $state<Item | null>(null)
+
+    const open = (item: Item) => {
+        animateView(() => {
+            selected = item
+        }).add(`[data-thumb="${item.id}"]`, '[data-hero]')
+    }
+</script>
+```
+
+<Example isSmall>
+  <ViewExample />
+</Example>
+
+## How it works
+
+`animateView(update, options?)` takes an **update callback** that performs the state change producing the new view. The browser snapshots the page before and after the update, then animates between the snapshots.
+
+Svelte `$state` mutations made inside `update` are flushed to the DOM synchronously before the new snapshot is captured — plain assignment just works, no `tick()` ceremony:
+
+```ts
+animateView(() => (showDetail = true))
+```
+
+The returned builder is **thenable** — `await` it for completion:
+
+```ts
+await animateView(() => (items = shuffle(items))).add('[data-card]')
+console.log('transition finished')
+```
+
+## Opting the page in
+
+A bare call with no chained subject swaps **instantly by design** — nothing is captured unless something opts in. Chain `.layout()` on the implicit root subject for a whole-page crossfade:
+
+```ts
+animateView(() => (theme = 'dark'), { duration: 0.5 }).layout()
+```
+
+## Shared-element morphs
+
+`.add(oldTarget, newTarget)` pairs two different elements as one layer: the first resolves in the **old** snapshot, the second in the **new** one, and the browser morphs between them — the "now playing" pattern:
+
+```ts
+// Thumbnail grows into the detail hero…
+animateView(() => (selected = album)).add(`[data-thumb="${album.id}"]`, '[data-hero]')
+
+// …and morphs back on close.
+animateView(() => (selected = null)).add('[data-hero]', `[data-thumb="${album.id}"]`)
+```
+
+Targets can be CSS selectors or `Element`s. `view-transition-name`s are generated, applied, and cleaned up automatically.
+
+With a single argument, `.add(target)` registers every matched element — survivors morph to their new positions, and pure newcomers/leavers can animate via `.enter()` / `.exit()`:
+
+```ts
+animateView(() => (filter = 'circles'))
+    .add('[data-item]')
+    .enter({ opacity: [0, 1], scale: [0.6, 1] })
+    .exit({ opacity: [1, 0], scale: [1, 0.6] })
+```
+
+`.new()` and `.old()` are the ungated variants — they animate the new/old view of a layer whenever it exists, including survivors, for crossfades and slide-throughs.
+
+## Matching corner radii across morph endpoints
+
+View-transition snapshots are paints of the live DOM, so an element's corner rounding is **baked into its snapshot as transparency**. If the two ends of a shared-element morph have different *proportional* rounding, the outgoing snapshot's corners ghost through during the crossfade.
+
+Give both endpoints the **same percentage radius** so the silhouettes coincide at every scale:
+
+```css
+.thumb,
+.hero {
+    border-radius: 12%; /* not 14px on one and 20px on the other */
+}
+```
+
+For morphs whose **aspect ratio changes**, this is handled automatically — the layer is cropped with `object-fit: cover` and its clip radius animates from the old radius to the new. `.crop(true)` / `.crop(false)` overrides the automatic behavior.
+
+## Options
+
+The second argument sets default transition options for every layer (a subject's own `.layout()` / `.enter()` / … options win), plus `interrupt`:
+
+```ts
+animateView(update, {
+    type: 'spring',
+    visualDuration: 0.4,
+    bounce: 0.2,
+    interrupt: 'immediate' // skip an in-flight transition; 'wait' (default) queues
+})
+```
+
+## Browser support
+
+Browsers without `document.startViewTransition` still run the update — the view swaps instantly and the returned promise resolves, so no feature-gating is needed at call sites. As of 2026 the API is supported in Chromium and Safari 18+; Firefox support is in development.
+
+## Builder API
+
+| Method | Description |
+|--------|-------------|
+| `.add(target, newTarget?)` | Register elements by selector/Element; a second target pairs two elements into one shared-element morph |
+| `.layout(options?)` | Customize the morph timing; on the root subject, opts the page into the crossfade |
+| `.enter(keyframes, options?)` | Animate a pure newcomer's new view |
+| `.exit(keyframes, options?)` | Animate a pure leaver's old view |
+| `.new(keyframes, options?)` | Animate the new view of any layer, including survivors |
+| `.old(keyframes, options?)` | Animate the old view of any layer, including survivors |
+| `.crop(enabled?)` | Force the clip + animated corner radii on or off |
+| `.class(name)` | Tag the layer with a `view-transition-class` for CSS targeting |
+| `.group(enabled?)` | Opt out of DOM-hierarchy layer nesting so the layer escapes an ancestor's clip |
+| `await builder` | Resolves when the transition completes |
+
+## Related
+
+- [Layout Animations](/docs/layout-animations) — FLIP-based morphs for elements that persist in the DOM
+- [AnimatePresence](/docs/animate-presence) — component-level exit animations
+- [Motion values](/docs/motion-values) — drive styles imperatively
+
+---
+
+Based on [Motion's animateView](https://motion.dev/docs/view) API.

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -109,6 +109,11 @@ const EXAMPLES: Record<string, ExampleEntry> = {
         description:
             'Drag-to-reorder lists with Reorder.Group and Reorder.Item — FLIP siblings and edge auto-scroll.'
     },
+    view: {
+        title: 'View Transitions',
+        description:
+            'Shared-element morphs and enter/exit view layers with animateView and the native View Transitions API.'
+    },
     reordering: {
         title: 'Reordering',
         description: 'Interactive Reordering animation example using Svelte Motion.'

--- a/docs/src/routes/examples/view/+page.svelte
+++ b/docs/src/routes/examples/view/+page.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        type ExampleSection,
+        formatSheetLabel
+    } from '@humanspeak/docs-kit'
+    import {
+        Layers,
+        MousePointerClick,
+        Radius,
+        Sparkles,
+        SlidersHorizontal,
+        Zap
+    } from '@lucide/svelte'
+    import { demoCodeSample } from '$lib/demo-loaders'
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import ViewFilterGallery from '$lib/examples/view/demos/FilterGallery.svelte'
+    import ViewSharedElement from '$lib/examples/view/demos/SharedElement.svelte'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'View Transitions' }
+        ]
+    }
+    if (seo) {
+        seo.title = 'View Transitions | Examples | Svelte Motion'
+        seo.description =
+            'Shared-element morphs and filtered galleries with animateView — the browser View Transitions API driven by Motion timing.'
+        seo.ogTitle = 'View Transitions'
+        seo.h1 = { title: 'View Transitions', mode: 'sr-only' }
+        seo.ogTagline = 'Shared-element morphs with the native View Transitions API'
+        seo.ogFeatures = [
+            'Shared Element Morphs',
+            'Enter/Exit Layers',
+            'Spring Timing',
+            'Native Browser API'
+        ]
+        seo.ogSlug = 'examples-view'
+    }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    const sections: ExampleSection[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'MORPH',
+            title: { prefix: 'shared-element ', accent: 'morphs', end: '.' },
+            description:
+                'The "now playing" pattern: click a tile and it morphs into the detail hero — two different elements paired into one view-transition layer with .add(thumb, hero). Closing morphs it back.',
+            snippet: sharedSection,
+            codeSnippet: sharedCode,
+            notes: sharedNotes,
+            barCells: [{ k: 'pattern', v: 'add-pair' }],
+            sourceUrl: `${SOURCE_URL}view/demos/SharedElement.svelte`
+        },
+        {
+            figId: 'FIG-002',
+            tag: 'ENTER/EXIT',
+            title: { prefix: 'filtering with ', accent: 'view layers', end: '.' },
+            description:
+                'Filtering the grid inside animateView: surviving shapes glide to their new slots while entering and leaving shapes scale-fade through .enter() and .exit().',
+            snippet: filterSection,
+            codeSnippet: filterCode,
+            notes: filterNotes,
+            barCells: [{ k: 'pattern', v: 'enter-exit' }],
+            sourceUrl: `${SOURCE_URL}view/demos/FilterGallery.svelte`
+        }
+    ]
+</script>
+
+{#snippet sharedSection()}
+    <ViewSharedElement />
+{/snippet}
+{#snippet sharedNotes()}
+    <ul>
+        <li>
+            <MousePointerClick />
+            <span>
+                <code>animateView(update)</code> snapshots the page, runs the update — Svelte
+                <code>$state</code> mutations are flushed synchronously, so plain assignment works — then
+                animates between snapshots.
+            </span>
+        </li>
+        <li>
+            <Sparkles />
+            <span>
+                <code>.add(oldTarget, newTarget)</code> pairs two different elements into one layer: the
+                first resolves in the old snapshot, the second in the new one, and the browser morphs
+                between them. Names are generated and cleaned up automatically.
+            </span>
+        </li>
+        <li>
+            <Radius />
+            <span>
+                Both endpoints share a <em>percentage</em> <code>border-radius</code>: snapshots
+                bake rounding in as transparency, so proportional radii keep the silhouettes
+                coincident at every scale — no corner ghosting mid-morph.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet sharedCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'view/demos/SharedElement.svelte',
+                'view-shared-element',
+                'SharedElement.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#snippet filterSection()}
+    <ViewFilterGallery />
+{/snippet}
+{#snippet filterNotes()}
+    <ul>
+        <li>
+            <Layers />
+            <span>
+                <code>.add('[data-view-item]')</code> registers every matched element — items present
+                in both snapshots morph to their new grid slots automatically.
+            </span>
+        </li>
+        <li>
+            <Zap />
+            <span>
+                <code>.enter()</code> animates pure newcomers and <code>.exit()</code> pure leavers;
+                survivors get neither, they just morph. <code>.new()</code>/<code>.old()</code> are the
+                ungated variants for crossfades on surviving layers.
+            </span>
+        </li>
+        <li>
+            <SlidersHorizontal />
+            <span>
+                Rapid filter clicks queue behind the in-flight transition (<code
+                    >interrupt: 'wait'</code
+                >, the default) — pass
+                <code>interrupt: 'immediate'</code> to skip ahead instead.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet filterCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'view/demos/FilterGallery.svelte',
+                'view-filter-gallery',
+                'FilterGallery.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel={formatSheetLabel(i, sections.length)}
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/view/+page.ts
+++ b/docs/src/routes/examples/view/+page.ts
@@ -1,0 +1,9 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async () => {
+    return {
+        title: 'View Transitions',
+        description:
+            'Shared-element morphs and enter/exit view layers with animateView and the native View Transitions API.'
+    }
+}

--- a/e2e/_helpers/view.ts
+++ b/e2e/_helpers/view.ts
@@ -1,0 +1,40 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Whether any view-transition pseudo-element animation is live.
+ * Evaluated in the page.
+ */
+const hasViewAnimation = () =>
+    document
+        .getAnimations()
+        .some((animation) =>
+            /view-transition/.test((animation.effect as KeyframeEffect | null)?.pseudoElement ?? '')
+        )
+
+/**
+ * Wait until a view-transition pseudo-element animation is live. A
+ * single sample races the transition's async setup (snapshot capture
+ * happens a frame or two after the trigger), so this polls on rAF via
+ * `waitForFunction`. Throws with timeout diagnostics if none appears.
+ */
+export const waitForViewAnimation = (page: Page, timeout = 2000) =>
+    page.waitForFunction(hasViewAnimation, undefined, { timeout, polling: 'raf' })
+
+/**
+ * Wait until every view-transition pseudo-element animation has
+ * finished — the condition-based replacement for sleeping past a
+ * transition's duration.
+ */
+export const waitForViewAnimationsToFinish = (page: Page, timeout = 5000) =>
+    page.waitForFunction(
+        () =>
+            !document
+                .getAnimations()
+                .some((animation) =>
+                    /view-transition/.test(
+                        (animation.effect as KeyframeEffect | null)?.pseudoElement ?? ''
+                    )
+                ),
+        undefined,
+        { timeout, polling: 'raf' }
+    )

--- a/e2e/view/basic.spec.ts
+++ b/e2e/view/basic.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test'
+import { waitForViewAnimation } from '../_helpers/view'
+
+declare global {
+    interface Window {
+        __vtCalls?: number
+    }
+}
+
+test.describe('view/basic', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/view/basic?@isPlaywright=true')
+        await page.getByTestId('toggle').waitFor({ state: 'visible' })
+    })
+
+    test('runs the update through a real View Transition', async ({ page }) => {
+        // Chromium supports the View Transitions API — assert we actually
+        // use it rather than falling back to an instant swap.
+        await page.evaluate(() => {
+            window.__vtCalls = 0
+            const original = document.startViewTransition.bind(document)
+            document.startViewTransition = ((callback: () => Promise<void>) => {
+                window.__vtCalls = (window.__vtCalls ?? 0) + 1
+                return original(callback)
+            }) as typeof document.startViewTransition
+        })
+
+        await page.getByTestId('toggle').click()
+
+        // Mid-transition, view-transition pseudo-element animations exist
+        // (throws with timeout diagnostics if none appears).
+        await waitForViewAnimation(page)
+
+        await expect(page.getByTestId('stats')).toHaveText('transitions:1 settled:1')
+        await expect(page.getByTestId('mode')).toHaveText('dark')
+        expect(await page.evaluate(() => window.__vtCalls)).toBe(1)
+    })
+
+    test('queues rapid toggles and settles on the final state', async ({ page }) => {
+        const toggle = page.getByTestId('toggle')
+        await toggle.click()
+        await toggle.click()
+        await toggle.click()
+
+        // interrupt: 'wait' queues the transitions; all three must settle.
+        await expect(page.getByTestId('stats')).toHaveText('transitions:3 settled:3', {
+            timeout: 10000
+        })
+        await expect(page.getByTestId('mode')).toHaveText('dark')
+    })
+})

--- a/e2e/view/filter-gallery.spec.ts
+++ b/e2e/view/filter-gallery.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test'
+import { waitForViewAnimation } from '../_helpers/view'
+
+test.describe('view/filter-gallery', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/view/filter-gallery?@isPlaywright=true')
+        await page.getByTestId('grid').waitFor({ state: 'visible' })
+    })
+
+    test('filters with enter/exit view animations and settles on the right set', async ({
+        page
+    }) => {
+        await expect(page.getByTestId('count')).toHaveText('12')
+
+        await page.getByTestId('filter-circle').click()
+        await waitForViewAnimation(page)
+        await expect(page.getByTestId('count')).toHaveText('6')
+
+        await page.getByTestId('filter-square').click()
+        await expect(page.getByTestId('count')).toHaveText('6')
+
+        await page.getByTestId('filter-all').click()
+        await expect(page.getByTestId('count')).toHaveText('12')
+        // All 12 items back in the DOM after the final transition.
+        await expect(page.locator('[data-item]')).toHaveCount(12)
+    })
+})

--- a/e2e/view/shared-element.spec.ts
+++ b/e2e/view/shared-element.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test'
+import { waitForViewAnimation, waitForViewAnimationsToFinish } from '../_helpers/view'
+
+test.describe('view/shared-element', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/view/shared-element?@isPlaywright=true')
+        await page.getByTestId('grid').waitFor({ state: 'visible' })
+    })
+
+    test('morphs a thumbnail into the detail hero and back', async ({ page }) => {
+        await page.getByTestId('thumb-jade').click()
+
+        // During the morph the paired layer animates as a view-transition
+        // group (the .add(thumb, hero) shared-element pair).
+        await waitForViewAnimation(page)
+
+        await expect(page.getByTestId('detail-title')).toHaveText('Jade Motion')
+        await expect(page.getByTestId('grid')).toHaveCount(0)
+
+        await page.getByTestId('close').click()
+        await expect(page.getByTestId('grid')).toBeVisible()
+        await expect(page.getByTestId('thumb-jade')).toBeVisible()
+    })
+
+    test('temporary view-transition-names are cleaned up after the morph', async ({ page }) => {
+        await page.getByTestId('thumb-coral').click()
+        await expect(page.getByTestId('detail-title')).toHaveText('Coral Dreams')
+
+        // Wait for the transition to fully finish, then confirm no inline
+        // view-transition-name lingers on the hero.
+        await waitForViewAnimation(page)
+        await waitForViewAnimationsToFinish(page)
+        await expect
+            .poll(() =>
+                page.evaluate(() => {
+                    const hero = document.querySelector('[data-hero]') as HTMLElement | null
+                    return hero?.style.viewTransitionName || ''
+                })
+            )
+            .toBe('')
+    })
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,15 +11,19 @@ export default defineConfig({
     retries: process.env.CI ? 1 : 0,
     reporter: [['junit', { outputFile: 'junit-playwright.xml' }]],
     webServer: {
-        command: 'npm run build && npm run preview',
-        port: 4173,
+        // Project-specific port: vite's default preview port (4173) is
+        // shared by every repo on the machine, so concurrent e2e sessions
+        // in sibling projects reuse-then-kill each other's servers
+        // mid-run (reuseExistingServer can't tell whose server it is).
+        command: 'npm run build && npm run preview -- --port 4198',
+        port: 4198,
         timeout: 120000,
         reuseExistingServer: !process.env.CI,
         stdout: 'pipe',
         stderr: 'pipe'
     },
     use: {
-        baseURL: 'http://localhost:4173',
+        baseURL: 'http://localhost:4198',
         trace: 'on-first-retry',
         screenshot: 'on',
         // Force fresh context per test to prevent state leakage

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -67,6 +67,13 @@ export type {
 } from '$lib/types'
 export { useAnimate } from '$lib/utils/animate.svelte'
 export type { AnimationScope } from '$lib/utils/animate.svelte'
+export { animateView } from '$lib/utils/animateView'
+export type {
+    AnimateViewBuilder,
+    ViewTransitionOptions,
+    ViewTransitionTarget,
+    ViewTransitionTargetDefinition
+} from '$lib/utils/animateView'
 export {
     animationControls,
     isAnimationControls,

--- a/src/lib/utils/__tests__/AnimateViewProbe.svelte
+++ b/src/lib/utils/__tests__/AnimateViewProbe.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+    let value = $state('a')
+
+    export function swap(): void {
+        value = 'b'
+    }
+</script>
+
+<span data-testid="view-probe">{value}</span>

--- a/src/lib/utils/animateView.spec.ts
+++ b/src/lib/utils/animateView.spec.ts
@@ -1,0 +1,77 @@
+import { mount, unmount } from 'svelte'
+import { describe, expect, it, vi } from 'vitest'
+import AnimateViewProbe from './__tests__/AnimateViewProbe.svelte'
+import { animateView } from './animateView'
+
+// jsdom has no document.startViewTransition, so these tests exercise
+// motion-dom's documented fallback: `update` still runs and the builder
+// resolves. That fallback is exactly what non-supporting browsers get,
+// so it's a real contract, not a mock.
+describe('animateView', () => {
+    it('runs the update and resolves without View Transition support', async () => {
+        const update = vi.fn()
+        await animateView(update)
+        expect(update).toHaveBeenCalledTimes(1)
+    })
+
+    it('awaits an async update before resolving', async () => {
+        const order: string[] = []
+        // Microtask-based delay — the suite's global fake timers would
+        // never fire a real setTimeout, and a hung update blocks
+        // motion-dom's global view-transition queue for the whole file.
+        await animateView(async () => {
+            order.push('update-start')
+            await Promise.resolve()
+            order.push('update-end')
+        })
+        order.push('resolved')
+        expect(order).toEqual(['update-start', 'update-end', 'resolved'])
+    })
+
+    it('propagates a throwing update as a rejection', async () => {
+        await expect(
+            animateView(() => {
+                throw new Error('boom')
+            })
+        ).rejects.toThrow('boom')
+    })
+
+    it('returns the chainable builder', async () => {
+        const el = document.createElement('div')
+        document.body.appendChild(el)
+        const builder = animateView(() => {})
+            .add(el)
+            .layout({ duration: 0.2 })
+            .enter({ opacity: [0, 1] })
+            .exit({ opacity: 0 })
+            .new({ x: 0 })
+            .old({ x: 10 })
+            .crop(false)
+            .group(false)
+            .class('hero')
+        expect(typeof builder.then).toBe('function')
+        await builder
+        el.remove()
+    })
+
+    it('flushes Svelte state to the DOM inside the update', async () => {
+        const host = document.createElement('div')
+        document.body.appendChild(host)
+        const component = mount(AnimateViewProbe, { target: host })
+
+        expect(host.querySelector('[data-testid="view-probe"]')?.textContent).toBe('a')
+        let textDuringUpdate: string | undefined
+        await animateView(() => {
+            component.swap()
+            // flushSync runs after this callback returns, inside the
+            // wrapper — capture on the microtask right after.
+        }).then(() => {
+            textDuringUpdate = host.querySelector('[data-testid="view-probe"]')
+                ?.textContent as string
+        })
+        expect(textDuringUpdate).toBe('b')
+
+        unmount(component)
+        host.remove()
+    })
+})

--- a/src/lib/utils/animateView.ts
+++ b/src/lib/utils/animateView.ts
@@ -1,0 +1,78 @@
+import { isPromiseLike } from '$lib/utils/promise'
+import {
+    animateView as animateViewCore,
+    type ViewTransitionBuilder,
+    type ViewTransitionOptions
+} from 'motion-dom'
+import { flushSync } from 'svelte'
+
+export type { ViewTransitionTarget, ViewTransitionTargetDefinition } from 'motion-dom'
+export type { ViewTransitionOptions }
+export type AnimateViewBuilder = ViewTransitionBuilder
+
+/**
+ * Animate a view change with the browser's View Transitions API —
+ * crossfades, shared-element morphs, and enter/exit animations between
+ * two DOM states, driven by Motion's spring-capable timing.
+ *
+ * The `update` callback performs the state change that produces the new
+ * view. Unlike calling motion-dom's `animateView` directly, Svelte
+ * `$state` mutations made inside `update` are flushed to the DOM
+ * synchronously (via `flushSync`) before the new snapshot is captured —
+ * so plain state assignment "just works":
+ *
+ * ```svelte
+ * <script lang="ts">
+ *     import { animateView } from '@humanspeak/svelte-motion'
+ *
+ *     let showDetail = $state(false)
+ *     const open = () => {
+ *         animateView(() => (showDetail = true))
+ *             .add('.thumbnail', '.detail-hero')
+ *     }
+ * </script>
+ * ```
+ *
+ * Returns motion-dom's thenable {@link ViewTransitionBuilder}: chain
+ * `.add()` (shared-element pairs), `.enter()` / `.exit()` (pure
+ * newcomers/leavers), `.new()` / `.old()` (either view of any layer),
+ * `.layout()` (morph timing), `.crop()`, `.class()` and `.group()`, and
+ * `await` it for completion.
+ *
+ * A bare call with no chained subject swaps INSTANTLY by design —
+ * motion-dom suppresses the root capture unless something opts in.
+ * Chain `.layout()` to opt the page into the root crossfade:
+ *
+ * ```ts
+ * animateView(() => (theme = 'dark')).layout()
+ * ```
+ *
+ * Browsers without `document.startViewTransition` (or with reduced
+ * motion forcing it off) still run `update` — the view swaps instantly
+ * and the returned promise resolves, so no feature-gating is needed at
+ * call sites.
+ *
+ * @param update Applies the state/DOM change producing the new view. May
+ *     be async; the new snapshot is captured after it settles.
+ * @param options Default transition options for every layer (a subject's
+ *     own `.layout()`/`.enter()`/… options win), plus `interrupt`:
+ *     `'wait'` (default) queues behind an in-flight transition,
+ *     `'immediate'` skips it to its end state and starts this one.
+ * @returns The chainable, awaitable view-transition builder.
+ */
+export const animateView = (
+    update: () => void | Promise<void>,
+    options?: ViewTransitionOptions
+): AnimateViewBuilder =>
+    animateViewCore(() => {
+        const result = update()
+        // isPromiseLike (not instanceof) so thenables and cross-realm
+        // promises take the async branch — the sync path would flush
+        // before the state change lands and drop the pending work.
+        if (isPromiseLike(result)) {
+            return result.then(() => {
+                flushSync()
+            })
+        }
+        flushSync()
+    }, options)

--- a/src/lib/utils/animateView.ts
+++ b/src/lib/utils/animateView.ts
@@ -8,6 +8,13 @@ import { flushSync } from 'svelte'
 
 export type { ViewTransitionTarget, ViewTransitionTargetDefinition } from 'motion-dom'
 export type { ViewTransitionOptions }
+
+/**
+ * The chainable, awaitable builder returned by {@link animateView} —
+ * motion-dom's `ViewTransitionBuilder` under a stable local name.
+ * Chain `.add()`, `.enter()`/`.exit()`, `.new()`/`.old()`, `.layout()`,
+ * `.crop()`, `.class()` and `.group()`; `await` it for completion.
+ */
 export type AnimateViewBuilder = ViewTransitionBuilder
 
 /**
@@ -19,19 +26,7 @@ export type AnimateViewBuilder = ViewTransitionBuilder
  * view. Unlike calling motion-dom's `animateView` directly, Svelte
  * `$state` mutations made inside `update` are flushed to the DOM
  * synchronously (via `flushSync`) before the new snapshot is captured —
- * so plain state assignment "just works":
- *
- * ```svelte
- * <script lang="ts">
- *     import { animateView } from '@humanspeak/svelte-motion'
- *
- *     let showDetail = $state(false)
- *     const open = () => {
- *         animateView(() => (showDetail = true))
- *             .add('.thumbnail', '.detail-hero')
- *     }
- * </script>
- * ```
+ * so plain state assignment "just works".
  *
  * Returns motion-dom's thenable {@link ViewTransitionBuilder}: chain
  * `.add()` (shared-element pairs), `.enter()` / `.exit()` (pure
@@ -40,12 +35,8 @@ export type AnimateViewBuilder = ViewTransitionBuilder
  * `await` it for completion.
  *
  * A bare call with no chained subject swaps INSTANTLY by design —
- * motion-dom suppresses the root capture unless something opts in.
- * Chain `.layout()` to opt the page into the root crossfade:
- *
- * ```ts
- * animateView(() => (theme = 'dark')).layout()
- * ```
+ * motion-dom suppresses the root capture unless something opts in;
+ * chain `.layout()` to opt the page into the root crossfade.
  *
  * Browsers without `document.startViewTransition` (or with reduced
  * motion forcing it off) still run `update` — the view swaps instantly
@@ -59,6 +50,23 @@ export type AnimateViewBuilder = ViewTransitionBuilder
  *     `'wait'` (default) queues behind an in-flight transition,
  *     `'immediate'` skips it to its end state and starts this one.
  * @returns The chainable, awaitable view-transition builder.
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *     import { animateView } from '@humanspeak/svelte-motion'
+ *
+ *     let showDetail = $state(false)
+ *     const open = () => {
+ *         animateView(() => (showDetail = true))
+ *             .add('.thumbnail', '.detail-hero')
+ *     }
+ * </script>
+ * ```
+ * @example
+ * ```ts
+ * // Whole-page crossfade: opt the root in with .layout()
+ * await animateView(() => (theme = 'dark'), { duration: 0.5 }).layout()
+ * ```
  */
 export const animateView = (
     update: () => void | Promise<void>,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -224,6 +224,35 @@
             </ul>
         </div>
         <div>
+            <h2 class="mb-3 text-xl font-medium">View Transitions</h2>
+            <ul class="list-disc space-y-2 pl-5">
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/view/basic') + searchParams}
+                    >
+                        animateView Basic (root crossfade)
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/view/shared-element') + searchParams}
+                    >
+                        animateView Shared Element (thumb → hero morph)
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/view/filter-gallery') + searchParams}
+                    >
+                        animateView Filter Gallery (enter/exit)
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <div>
             <h2 class="mb-3 text-xl font-medium">Reorder</h2>
             <ul class="list-disc space-y-2 pl-5">
                 <li>

--- a/src/routes/tests/view/basic/+page.svelte
+++ b/src/routes/tests/view/basic/+page.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+    import { animateView } from '$lib'
+
+    let dark = $state(false)
+    let transitions = $state(0)
+    let settled = $state(0)
+
+    const toggle = async () => {
+        transitions += 1
+        // `.layout()` on the implicit root subject opts the page into the
+        // root crossfade — without any registered target, animateView
+        // swaps instantly by design (motion-dom suppresses root capture).
+        await animateView(
+            () => {
+                dark = !dark
+            },
+            { duration: 0.5 }
+        ).layout()
+        settled += 1
+    }
+</script>
+
+<div class="page" class:dark data-testid="page">
+    <h1>animateView — basic root crossfade</h1>
+    <p>
+        Clicking the button swaps the theme inside <code>animateView</code>. Browsers with the View
+        Transitions API crossfade between the two states; others swap instantly.
+    </p>
+
+    <button data-testid="toggle" onclick={toggle}>
+        Switch to {dark ? 'light' : 'dark'}
+    </button>
+
+    <div class="card" data-testid="card">
+        {dark ? '🌙 Night mode' : '☀️ Day mode'}
+    </div>
+
+    <div data-testid="stats">transitions:{transitions} settled:{settled}</div>
+    <div data-testid="mode">{dark ? 'dark' : 'light'}</div>
+</div>
+
+<style>
+    .page {
+        min-height: 100vh;
+        padding: 48px;
+        background: #f8fafc;
+        color: #0f1115;
+        font-family: system-ui, sans-serif;
+    }
+
+    .page.dark {
+        background: #0f1115;
+        color: #e5e7eb;
+    }
+
+    h1 {
+        font-size: 20px;
+        margin-bottom: 8px;
+    }
+
+    p {
+        max-width: 480px;
+        margin-bottom: 24px;
+        opacity: 0.7;
+    }
+
+    button {
+        padding: 10px 18px;
+        border: none;
+        border-radius: 10px;
+        background: #6366f1;
+        color: white;
+        font-weight: 600;
+        cursor: pointer;
+    }
+
+    .card {
+        margin-top: 24px;
+        width: 260px;
+        padding: 32px;
+        border-radius: 16px;
+        background: white;
+        color: #0f1115;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+        font-size: 20px;
+        font-weight: 600;
+    }
+
+    .page.dark .card {
+        background: #1f2937;
+        color: #e5e7eb;
+    }
+
+    [data-testid='stats'],
+    [data-testid='mode'] {
+        margin-top: 16px;
+        font-family: monospace;
+        opacity: 0.6;
+    }
+</style>

--- a/src/routes/tests/view/filter-gallery/+page.svelte
+++ b/src/routes/tests/view/filter-gallery/+page.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+    import { animateView } from '$lib'
+
+    type Item = { id: number; kind: 'circle' | 'square' }
+
+    const all: Item[] = Array.from({ length: 12 }, (_, index) => ({
+        id: index,
+        kind: index % 2 === 0 ? 'circle' : 'square'
+    }))
+
+    let filter = $state<'all' | 'circle' | 'square'>('all')
+    const visible = $derived(filter === 'all' ? all : all.filter((item) => item.kind === filter))
+
+    const setFilter = (next: typeof filter) => {
+        if (next === filter) return
+        // Survivors morph to their new grid slots; pure newcomers fade+
+        // scale in via .enter(), pure leavers out via .exit().
+        animateView(() => {
+            filter = next
+        })
+            .add('[data-item]')
+            .enter({ opacity: [0, 1], scale: [0.6, 1] })
+            .exit({ opacity: [1, 0], scale: [1, 0.6] })
+    }
+</script>
+
+<div class="page">
+    <h1>animateView — filter gallery</h1>
+    <p>
+        Filtering the grid inside <code>animateView</code>: surviving items morph to their new slots
+        while entering/leaving items scale-fade via <code>.enter()</code> /
+        <code>.exit()</code>.
+    </p>
+
+    <div class="filters">
+        {#each ['all', 'circle', 'square'] as const as kind (kind)}
+            <button
+                data-testid={`filter-${kind}`}
+                class:active={filter === kind}
+                onclick={() => setFilter(kind)}
+            >
+                {kind}
+            </button>
+        {/each}
+    </div>
+
+    <div class="grid" data-testid="grid">
+        {#each visible as item (item.id)}
+            <div
+                class={`item ${item.kind}`}
+                data-item
+                data-testid={`item-${item.id}`}
+                aria-hidden="true"
+            ></div>
+        {/each}
+    </div>
+
+    <div data-testid="count">{visible.length}</div>
+</div>
+
+<style>
+    .page {
+        min-height: 100vh;
+        padding: 48px;
+        background: #0f1115;
+        color: #e5e7eb;
+        font-family: system-ui, sans-serif;
+    }
+
+    h1 {
+        font-size: 20px;
+        margin-bottom: 8px;
+    }
+
+    p {
+        max-width: 480px;
+        margin-bottom: 24px;
+        color: #9ca3af;
+    }
+
+    .filters {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 24px;
+    }
+
+    .filters button {
+        padding: 8px 16px;
+        border: none;
+        border-radius: 8px;
+        background: #1f2937;
+        color: #e5e7eb;
+        cursor: pointer;
+        text-transform: capitalize;
+    }
+
+    .filters button.active {
+        background: #6366f1;
+    }
+
+    .grid {
+        display: grid;
+        grid-template-columns: repeat(6, 64px);
+        gap: 12px;
+        width: max-content;
+    }
+
+    .item {
+        width: 64px;
+        height: 64px;
+    }
+
+    .item.circle {
+        border-radius: 50%;
+        background: #f472b6;
+    }
+
+    .item.square {
+        border-radius: 12px;
+        background: #38bdf8;
+    }
+
+    [data-testid='count'] {
+        margin-top: 20px;
+        font-family: monospace;
+        color: #6b7280;
+    }
+</style>

--- a/src/routes/tests/view/filter-gallery/+page.svelte
+++ b/src/routes/tests/view/filter-gallery/+page.svelte
@@ -37,6 +37,7 @@
             <button
                 data-testid={`filter-${kind}`}
                 class:active={filter === kind}
+                aria-pressed={filter === kind}
                 onclick={() => setFilter(kind)}
             >
                 {kind}

--- a/src/routes/tests/view/shared-element/+page.svelte
+++ b/src/routes/tests/view/shared-element/+page.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+    import { animateView } from '$lib'
+
+    type Album = { id: string; color: string; title: string }
+
+    const albums: Album[] = [
+        { id: 'coral', color: '#f87171', title: 'Coral Dreams' },
+        { id: 'amber', color: '#fbbf24', title: 'Amber Waves' },
+        { id: 'jade', color: '#4ade80', title: 'Jade Motion' },
+        { id: 'sky', color: '#60a5fa', title: 'Sky Static' }
+    ]
+
+    let selected = $state<Album | null>(null)
+
+    const open = (album: Album) => {
+        // Morph the clicked thumbnail into the detail hero: the first
+        // .add() argument resolves in the OLD snapshot, the second in
+        // the NEW one — two different elements sharing one layer.
+        animateView(() => {
+            selected = album
+        }).add(`[data-thumb="${album.id}"]`, '[data-hero]')
+    }
+
+    const close = () => {
+        const album = selected
+        if (!album) return
+        animateView(() => {
+            selected = null
+        }).add('[data-hero]', `[data-thumb="${album.id}"]`)
+    }
+</script>
+
+<div class="page">
+    <h1>animateView — shared-element morph</h1>
+    <p>
+        Click a tile: it morphs into the detail hero (<code>.add(thumb, hero)</code>). Close and it
+        morphs back. The "now playing" pattern from motion.dev/docs/view.
+    </p>
+
+    {#if selected}
+        <section class="detail" data-testid="detail">
+            <div class="hero" data-hero style={`background:${selected.color}`}></div>
+            <h2 data-testid="detail-title">{selected.title}</h2>
+            <button data-testid="close" onclick={close}>Back</button>
+        </section>
+    {:else}
+        <div class="grid" data-testid="grid">
+            {#each albums as album (album.id)}
+                <button
+                    class="thumb"
+                    data-thumb={album.id}
+                    data-testid={`thumb-${album.id}`}
+                    style={`background:${album.color}`}
+                    onclick={() => open(album)}
+                    aria-label={`Open ${album.title}`}
+                ></button>
+            {/each}
+        </div>
+    {/if}
+</div>
+
+<style>
+    .page {
+        min-height: 100vh;
+        padding: 48px;
+        background: #0f1115;
+        color: #e5e7eb;
+        font-family: system-ui, sans-serif;
+    }
+
+    h1 {
+        font-size: 20px;
+        margin-bottom: 8px;
+    }
+
+    p {
+        max-width: 480px;
+        margin-bottom: 24px;
+        color: #9ca3af;
+    }
+
+    .grid {
+        display: grid;
+        grid-template-columns: repeat(4, 96px);
+        gap: 14px;
+    }
+
+    /*
+     * Both morph endpoints use the SAME percentage radius: view-transition
+     * snapshots bake corner rounding in as transparency, and a same-aspect
+     * morph can't crop the outgoing silhouette away (upstream limitation) —
+     * proportional radii make the two silhouettes coincide at every scale,
+     * so the crossfade has no corner ghosting.
+     */
+    .thumb {
+        width: 96px;
+        height: 96px;
+        border: none;
+        border-radius: 12%;
+        cursor: pointer;
+    }
+
+    .detail .hero {
+        width: 280px;
+        height: 280px;
+        border-radius: 12%;
+    }
+
+    .detail h2 {
+        margin: 16px 0;
+        font-size: 24px;
+    }
+
+    .detail button {
+        padding: 8px 16px;
+        border: none;
+        border-radius: 8px;
+        background: #374151;
+        color: #e5e7eb;
+        cursor: pointer;
+    }
+</style>


### PR DESCRIPTION
## Summary

Brings the **View Transitions API** to Svelte — `animateView()` for whole-page crossfades, shared-element morphs, and enter/exit layer animations with Motion's spring-capable timing. This is Motion 12.41's flagship feature (graduated from Motion+ in June), and no other Svelte library ships it. One Svelte-specific improvement over the upstream React story: `$state` mutations inside the update callback are `flushSync`-flushed before the new snapshot is captured, so `animateView(() => (selected = album))` just works — no `tick()` ceremony (React users must call `flushSync` themselves).

```svelte
<script lang="ts">
    import { animateView } from '@humanspeak/svelte-motion'

    let selected = $state<Album | null>(null)
    const open = (album: Album) => {
        animateView(() => (selected = album)).add(`[data-thumb="${album.id}"]`, '[data-hero]')
    }
</script>
```

Browsers without `document.startViewTransition` still run the update and resolve the returned promise — no feature-gating at call sites (and that fallback contract is what the jsdom unit tests exercise).

## Changes

- ✨ `animateView(update, options)` exported from the package root, returning motion-dom's chainable/awaitable `ViewTransitionBuilder` (`.add()` pairs, `.enter()`/`.exit()`, `.new()`/`.old()`, `.layout()`, `.crop()`, `.class()`, `.group()`); `AnimateViewBuilder` + option/target types re-exported
- ✨ The wrapper is `isPromiseLike`-aware (reuses `src/lib/utils/promise.ts`), so async updates and cross-realm thenables are awaited before the new snapshot
- 🧪 Test pages `/tests/view/{basic, shared-element, filter-gallery}` linked from the test index; 5 unit specs + 5 e2e specs, with shared helpers in `e2e/_helpers/view.ts` (rAF-polled real-transition detection via `::view-transition` pseudo-element animations, interrupt queueing across rapid toggles, generated-name cleanup)
- 🔧 `playwright.config.ts` pins the e2e preview server to project-specific port **4198**: vite's default 4173 is shared machine-wide, and a concurrent e2e session in a sibling repo reuses-then-kills the server mid-run (`reuseExistingServer` can't tell whose server it found) — this truncated local full-suite runs at 147/131/102 of 292 before diagnosis
- 📚 Docs page `/docs/view` (Animation nav): usage, the **`.layout()` root opt-in gotcha** (a bare call swaps instantly by design — verified in upstream `start.ts`, which suppresses root capture without a registered target), shared-element morphs, a dedicated **"Matching corner radii across morph endpoints"** section (snapshots bake rounding in as transparency; same-aspect morphs need matching percentage radii — upstream's own comment concedes forced crop "can't hide the outgoing snapshot's silhouette"), options/`interrupt`, browser support, and a builder API table
- 📚 Examples page `/examples/view` with two live figures (shared-element "now playing" morph + enter/exit filter gallery); fixed-height demo stages so view swaps don't reflow the cards on mobile
- 📚 README: parity table gains **Reorder** and **View Transitions** rows and corrects the stale "Pan — Not yet supported" row; adds the tokenmaxing badge

## Upstream fidelity

The heavy lifting is motion-dom's own `animateView` (already our dependency at 12.42.x) — the Svelte layer is a thin adapter, matching the pattern of `useAnimate`. Behaviors verified against `~/Github/motion/packages/motion-dom/src/view/` (`index.ts` builder, `start.ts` snapshot/crop/root-suppression logic, fallback path at `start.ts:78`).

## Verification

- Full local suite on the isolated port: **290 passed, 2 skipped, 0 failed** (292 collected, 9.8m) — plus 676 vitest units, `svelte-check` 0 errors, trunk clean, docs production build passing
- All three demo pages driven live in Chromium (spied `startViewTransition`, polled pseudo-element animations); docs + examples pages verified at desktop and 390px mobile viewports (no layout jumps on view swaps)
- `/simplify` pass applied (4-agent review): `isPromiseLike` reuse, shared e2e helpers on `waitForFunction`, no fixed sleeps

## Commits

- [`2cf9f9e`](https://github.com/humanspeak/svelte-motion/commit/2cf9f9e) test(e2e): pin the preview webServer to a project-specific port
- [`e2adc9e`](https://github.com/humanspeak/svelte-motion/commit/e2adc9e) feat(view): add animateView — View Transitions API with Svelte flushSync
- [`6c2df57`](https://github.com/humanspeak/svelte-motion/commit/6c2df57) chore: ignore docs/test-results artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
