### PR TITLE
feat(values): vanilla motion-value layer with unified rune sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Goal: Framer Motion API parity for Svelte where common React examples can be tra
 | Shared layout (`layoutId`, `LayoutGroup`, `layoutScroll`)              | Supported                                  |
 | Reorder (`Reorder.Group`, `Reorder.Item`, edge auto-scroll)            | Supported                                  |
 | View Transitions (`animateView`, shared-element morphs)                | Supported                                  |
+| Vanilla values (`motionValue`, `styleEffect`, `toMotionValue` bridge)  | Supported                                  |
 | Pan gesture API (`onPan*`, `onPanSessionStart`)                        | Supported                                  |
 | `MotionConfig` parity beyond `transition`                              | Partial                                    |
 | `reducedMotion`, `features`, `transformPagePoint`                      | Not yet supported                          |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Svelte Motion — Framer Motion API for Svelte 5
 
 [![NPM version](https://img.shields.io/npm/v/@humanspeak/svelte-motion.svg)](https://www.npmjs.com/package/@humanspeak/svelte-motion)
-[![tokenmaxing](https://tokenmaxing.app/badge/humanspeak/svelte-motion)](https://tokenmaxing.app/card/humanspeak/svelte-motion)
+[![AI tokens used building this repo — TokenMaxing](https://tokenmaxing.app/badge/humanspeak/svelte-motion)](https://tokenmaxing.app/card/humanspeak/svelte-motion)
 [![Build Status](https://github.com/humanspeak/svelte-motion/actions/workflows/npm-publish.yml/badge.svg)](https://github.com/humanspeak/svelte-motion/actions/workflows/npm-publish.yml)
 [![Coverage Status](https://coveralls.io/repos/github/humanspeak/svelte-motion/badge.svg?branch=main)](https://coveralls.io/github/humanspeak/svelte-motion?branch=main)
 [![License](https://img.shields.io/npm/l/@humanspeak/svelte-motion.svg)](https://github.com/humanspeak/svelte-motion/blob/main/LICENSE)
@@ -298,18 +298,18 @@ Validated against current source and test suite (local run):
 
 Part of the [Humanspeak](https://humanspeak.com) family of runes-native Svelte 5 packages:
 
-| Package | Description |
-| --- | --- |
-| [@humanspeak/svelte-markdown](https://markdown.svelte.page) | Runtime markdown renderer for Svelte |
-| [@humanspeak/svelte-virtual-list](https://virtuallist.svelte.page) | Virtual scrolling for Svelte |
-| **[@humanspeak/svelte-motion](https://motion.svelte.page)** — _this package_ | Framer Motion for Svelte 5 |
-| [@humanspeak/svelte-headless-table](https://table.svelte.page) | Headless data tables for Svelte |
-| [@humanspeak/svelte-diff-match-patch](https://diff.svelte.page) | Diff comparison for Svelte |
-| [@humanspeak/svelte-purify](https://purify.svelte.page) | HTML sanitisation for Svelte |
-| [@humanspeak/svelte-virtual-chat](https://virtualchat.svelte.page) | Virtual chat viewport for Svelte 5 |
-| [@humanspeak/memory-cache](https://memory.svelte.page) | In-memory cache for TypeScript |
-| [@humanspeak/svelte-json-view-lite](https://jsonview.svelte.page) | JSON tree viewer for Svelte 5 |
-| [@humanspeak/svelte-scoped-props](https://scoped.svelte.page) | Scoped class props for Svelte |
+| Package                                                                      | Description                          |
+| ---------------------------------------------------------------------------- | ------------------------------------ |
+| [@humanspeak/svelte-markdown](https://markdown.svelte.page)                  | Runtime markdown renderer for Svelte |
+| [@humanspeak/svelte-virtual-list](https://virtuallist.svelte.page)           | Virtual scrolling for Svelte         |
+| **[@humanspeak/svelte-motion](https://motion.svelte.page)** — _this package_ | Framer Motion for Svelte 5           |
+| [@humanspeak/svelte-headless-table](https://table.svelte.page)               | Headless data tables for Svelte      |
+| [@humanspeak/svelte-diff-match-patch](https://diff.svelte.page)              | Diff comparison for Svelte           |
+| [@humanspeak/svelte-purify](https://purify.svelte.page)                      | HTML sanitisation for Svelte         |
+| [@humanspeak/svelte-virtual-chat](https://virtualchat.svelte.page)           | Virtual chat viewport for Svelte 5   |
+| [@humanspeak/memory-cache](https://memory.svelte.page)                       | In-memory cache for TypeScript       |
+| [@humanspeak/svelte-json-view-lite](https://jsonview.svelte.page)            | JSON tree viewer for Svelte 5        |
+| [@humanspeak/svelte-scoped-props](https://scoped.svelte.page)                | Scoped class props for Svelte        |
 
 ## License
 

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -77,6 +77,7 @@ export const docsSections: NavSection[] = [
         icon: Signal,
         items: [
             { title: 'Overview', href: '/docs/motion-values', icon: Signal },
+            { title: 'Vanilla values', href: '/docs/vanilla-values', icon: Zap },
             { title: 'MotionValue children', href: '/docs/motion-value-children', icon: Code },
             {
                 title: 'Object style MotionValues',

--- a/docs/src/lib/examples/VanillaValuesExample.svelte
+++ b/docs/src/lib/examples/VanillaValuesExample.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+    import { mapValue, springValue, styleEffect, toMotionValue } from '@humanspeak/svelte-motion'
+
+    // No motion components: a $state slider feeds the rune bridge, the
+    // vanilla factories derive position, and styleEffect drives a plain div.
+    let slider = $state(20)
+
+    const progress = toMotionValue(() => slider / 100)
+    const x = mapValue(progress, [0, 1], [0, 180])
+    const smoothX = springValue(x, { stiffness: 300, damping: 22 })
+
+    let box = $state<HTMLElement | null>(null)
+
+    $effect(() => {
+        if (!box) return
+        const stop = styleEffect(box, { x: smoothX })
+        return () => stop()
+    })
+
+    $effect(() => () => {
+        progress.destroy()
+        x.destroy()
+        smoothX.destroy()
+    })
+</script>
+
+<div class="flex flex-col items-center gap-4">
+    <p class="text-text-muted text-sm">
+        <code>$state</code> → <code>toMotionValue</code> → <code>mapValue</code> →
+        <code>springValue</code> → <code>styleEffect</code>
+    </p>
+    <input type="range" min="0" max="100" bind:value={slider} class="w-56" aria-label="Drive x" />
+    <div class="w-64 rounded-xl bg-neutral-800 p-1.5">
+        <div bind:this={box} class="h-10 w-16 rounded-lg bg-violet-400"></div>
+    </div>
+</div>

--- a/docs/src/lib/examples/VanillaValuesExample.svelte
+++ b/docs/src/lib/examples/VanillaValuesExample.svelte
@@ -2,18 +2,30 @@
     import { mapValue, springValue, styleEffect, toMotionValue } from '@humanspeak/svelte-motion'
 
     // No motion components: a $state slider feeds the rune bridge, the
-    // vanilla factories derive position, and styleEffect drives a plain div.
+    // vanilla factories derive position AND color (mapValue mixes color
+    // stops), and styleEffect drives a plain div.
     let slider = $state(20)
 
     const progress = toMotionValue(() => slider / 100)
     const x = mapValue(progress, [0, 1], [0, 180])
     const smoothX = springValue(x, { stiffness: 300, damping: 22 })
+    const smoothProgress = springValue(progress, { stiffness: 300, damping: 22 })
+    const backgroundColor = mapValue(smoothProgress, [0, 0.5, 1], ['#ff0088', '#9911ff', '#00ccff'])
+    const boxShadow = mapValue(
+        smoothProgress,
+        [0, 0.5, 1],
+        [
+            '0 6px 18px rgba(255, 0, 136, 0.45)',
+            '0 6px 18px rgba(153, 17, 255, 0.45)',
+            '0 6px 18px rgba(0, 204, 255, 0.45)'
+        ]
+    )
 
     let box = $state<HTMLElement | null>(null)
 
     $effect(() => {
         if (!box) return
-        const stop = styleEffect(box, { x: smoothX })
+        const stop = styleEffect(box, { x: smoothX, backgroundColor, boxShadow })
         return () => stop()
     })
 
@@ -21,16 +33,28 @@
         progress.destroy()
         x.destroy()
         smoothX.destroy()
+        smoothProgress.destroy()
+        backgroundColor.destroy()
+        boxShadow.destroy()
     })
 </script>
 
-<div class="flex flex-col items-center gap-4">
+<div class="flex flex-col items-center gap-4 pt-1 pb-5">
     <p class="text-text-muted text-sm">
         <code>$state</code> → <code>toMotionValue</code> → <code>mapValue</code> →
         <code>springValue</code> → <code>styleEffect</code>
     </p>
-    <input type="range" min="0" max="100" bind:value={slider} class="w-56" aria-label="Drive x" />
-    <div class="w-64 rounded-xl bg-neutral-800 p-1.5">
-        <div bind:this={box} class="h-10 w-16 rounded-lg bg-violet-400"></div>
+    <input
+        type="range"
+        min="0"
+        max="100"
+        bind:value={slider}
+        class="w-56 accent-[#9911ff]"
+        aria-label="Drive x"
+    />
+    <div
+        class="w-64 rounded-2xl bg-black/5 p-2 ring-1 ring-black/10 dark:bg-white/5 dark:ring-white/10"
+    >
+        <div bind:this={box} class="h-10 w-16 rounded-xl"></div>
     </div>
 </div>

--- a/docs/src/lib/examples/vanilla-values/demos/Default.svelte
+++ b/docs/src/lib/examples/vanilla-values/demos/Default.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+    import { mapValue, springValue, styleEffect, toMotionValue } from '@humanspeak/svelte-motion'
+
+    // No motion components anywhere: a $state slider feeds the rune
+    // bridge (toMotionValue), the vanilla factories derive position and
+    // color, and styleEffect binds them to a plain div.
+    let slider = $state(20)
+
+    const progress = toMotionValue(() => slider / 100)
+    const x = mapValue(progress, [0, 1], [0, 180])
+    const smoothX = springValue(x, { stiffness: 300, damping: 22 })
+    const smoothProgress = springValue(progress, { stiffness: 300, damping: 22 })
+    const backgroundColor = mapValue(smoothProgress, [0, 0.5, 1], ['#ff0088', '#9911ff', '#00ccff'])
+    const boxShadow = mapValue(
+        smoothProgress,
+        [0, 0.5, 1],
+        [
+            '0 6px 18px rgba(255, 0, 136, 0.45)',
+            '0 6px 18px rgba(153, 17, 255, 0.45)',
+            '0 6px 18px rgba(0, 204, 255, 0.45)'
+        ]
+    )
+
+    let box = $state<HTMLElement | null>(null)
+
+    $effect(() => {
+        if (!box) return
+        const stop = styleEffect(box, { x: smoothX, backgroundColor, boxShadow })
+        return () => stop()
+    })
+
+    $effect(() => () => {
+        progress.destroy()
+        x.destroy()
+        smoothX.destroy()
+        smoothProgress.destroy()
+        backgroundColor.destroy()
+        boxShadow.destroy()
+    })
+</script>
+
+<!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
+<div class="dk-demo-shell">
+    <div class="stack">
+        <input type="range" min="0" max="100" bind:value={slider} aria-label="Drive the values" />
+        <div class="track">
+            <div bind:this={box} class="box"></div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .dk-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        min-height: 280px;
+    }
+
+    .stack {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 20px;
+    }
+
+    input[type='range'] {
+        width: 224px;
+        accent-color: #9911ff;
+    }
+
+    .track {
+        width: 260px;
+        padding: 8px;
+        border-radius: 16px;
+        background: rgba(120, 120, 140, 0.12);
+    }
+
+    .box {
+        width: 64px;
+        height: 40px;
+        border-radius: 12px;
+    }
+</style>

--- a/docs/src/routes/docs/motion-values/+page.svx
+++ b/docs/src/routes/docs/motion-values/+page.svx
@@ -47,6 +47,10 @@ Motion values:
 - Are **SSR-safe** — on the server they return static values with no timers
 - Implement Svelte's `Readable` store contract via a `.subscribe` shim, so `$x` template syntax, `svelte/store`'s `get()`, and `derived()` keep working
 
+## Outside components: the vanilla layer
+
+Every hook has a component-free counterpart — `motionValue`, `springValue`, `transformValue`, `mapValue` — plus `styleEffect` for binding values straight to plain elements and `toMotionValue` for turning `$state`/`$derived` (or any readable) into a motion value. Same augmented shape, manual lifecycle. See [Vanilla motion values](/docs/vanilla-values).
+
 ## Hooks at a glance
 
 | Hook | Returns | Read pattern |

--- a/docs/src/routes/docs/vanilla-values/+page.svx
+++ b/docs/src/routes/docs/vanilla-values/+page.svx
@@ -129,6 +129,7 @@ Plus the `steps`, `mirrorEasing`, and `reverseEasing` easing helpers alongside t
 
 ## Related
 
+- [Vanilla Values example](/examples/vanilla-values) — this page's demo with full source
 - [Motion values overview](/docs/motion-values) — the hook layer and the augmented value shape
 - [useTransform](/docs/use-transform) / [useSpring](/docs/use-spring) — component-scoped counterparts
 - [Motion component](/docs) — object-form `style` accepts these values directly

--- a/docs/src/routes/docs/vanilla-values/+page.svx
+++ b/docs/src/routes/docs/vanilla-values/+page.svx
@@ -1,0 +1,138 @@
+---
+title: Vanilla motion values
+description: Component-free motion values — motionValue, springValue, transformValue, mapValue, styleEffect and the toMotionValue rune bridge
+---
+
+<script>
+  import Example from '$lib/components/general/Example.svelte'
+  import VanillaValuesExample from '$lib/examples/VanillaValuesExample.svelte'
+  import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+  const seo = getSeoContext()
+  if (seo) {
+      seo.title = 'Vanilla motion values | Docs | Svelte Motion'
+      seo.description = 'Component-free motion values for Svelte — motionValue, springValue, transformValue, mapValue, element effects, and the toMotionValue bridge that turns runes into motion values.'
+      seo.ogTitle = 'Vanilla Motion Values'
+      seo.ogTagline = 'Motion values anywhere — module scope, stores, event handlers'
+      seo.ogFeatures = ['No Components Needed', 'Rune Bridge', 'Element Effects', 'Manual Lifecycle']
+      seo.ogSlug = 'docs-vanilla-values'
+  }
+</script>
+
+# Vanilla motion values
+
+Everything the `use*` motion-value hooks do, **without a component**: create values in module scope, `.svelte.ts` stores, or event handlers, and bind them straight to plain DOM elements with `styleEffect` — mirroring Motion's "vanilla JavaScript" API.
+
+```ts
+// stores/scroll.svelte.ts — impossible with useMotionValue
+import { motionValue } from '@humanspeak/svelte-motion'
+
+export const scrollProgress = motionValue(0)
+```
+
+<Example isSmall>
+  <VanillaValuesExample />
+</Example>
+
+## Hooks vs vanilla
+
+Both layers return the **same augmented value**: a real motion-dom `MotionValue` (passes `isMotionValue`, works with `animate()`) with a rune-reactive `.current` and a store `.subscribe`. The only difference is lifecycle:
+
+| | `use*` hooks | Vanilla factories |
+|---|---|---|
+| Where they work | Component init only | Anywhere |
+| Cleanup | Automatic on unmount | Manual `.destroy()` |
+| Examples | `useMotionValue`, `useSpring`, `useTransform` | `motionValue`, `springValue`, `transformValue`, `mapValue` |
+
+Values that live for the app's lifetime (module-scope stores) never need destroying. Values created per-interaction should be destroyed when done — a getter-bridged value holds a live Svelte effect until then.
+
+## The factories
+
+```ts
+import { mapValue, motionValue, springValue, transformValue } from '@humanspeak/svelte-motion'
+
+const x = motionValue(0)
+
+// Range mapping — numbers, colors, unit strings
+const opacity = mapValue(x, [0, 200], [1, 0])
+const color = mapValue(x, [0, 200], ['#ff0088', '#00ccff'])
+
+// Springs toward a source (values or unit strings)
+const smooth = springValue(x, { stiffness: 300, damping: 30 })
+
+// Computed from .get() reads — dependencies auto-tracked
+const label = transformValue(() => `${Math.round(x.get())}px`)
+```
+
+`springValue` and `mapValue` accept any source kind: a `MotionValue`, a Svelte readable store, or a reactive getter.
+
+## `toMotionValue` — the rune bridge
+
+Turn **any** Svelte state into a motion value. The getter form tracks `$state` / `$derived` reads (and other augmented values' `.current`):
+
+```svelte
+<script lang="ts">
+    import { styleEffect, toMotionValue } from '@humanspeak/svelte-motion'
+
+    let progress = $state(0)
+    const opacity = toMotionValue(() => progress / 100)
+
+    let el = $state<HTMLElement | null>(null)
+    $effect(() => {
+        if (!el) return
+        const stop = styleEffect(el, { opacity })
+        return () => stop()
+    })
+</script>
+
+<input type="range" bind:value={progress} />
+<div bind:this={el}>Fades with the slider</div>
+```
+
+Passing an existing `MotionValue` returns the same value; passing a readable store returns a mirroring value. Getter-driven updates flush on Svelte's effect schedule (a microtask), matching template timing.
+
+The hooks understand getters too — `useSpring(() => target)` and `useTransform(() => count, [0, 10], [0, 100])` track rune state the same way.
+
+## Element effects
+
+Bind values directly to elements — no motion component in sight:
+
+```ts
+import { attrEffect, styleEffect, svgEffect } from '@humanspeak/svelte-motion'
+
+const stop = styleEffect('.box', { x, opacity })      // inline styles
+attrEffect(input, { value: count })                    // attributes
+svgEffect(path, { pathLength: progress })              // SVG attributes
+```
+
+Each returns an unbind function. Import them from this package (not `motion`) so both raw and augmented values type-check.
+
+## Scheduler, generators, config
+
+The rest of Motion's vanilla toolkit re-exports directly:
+
+```ts
+import {
+    cancelFrame,
+    frame,            // frameloop scheduler: frame.read / frame.update / frame.render
+    MotionGlobalConfig, // e.g. skipAnimations for tests
+    scrollInfo,
+    spring            // spring generator for WAAPI / custom drivers
+} from '@humanspeak/svelte-motion'
+
+frame.render(() => {
+    // runs on Motion's render step this frame
+})
+```
+
+Plus the `steps`, `mirrorEasing`, and `reverseEasing` easing helpers alongside the existing easing exports.
+
+## Related
+
+- [Motion values overview](/docs/motion-values) — the hook layer and the augmented value shape
+- [useTransform](/docs/use-transform) / [useSpring](/docs/use-spring) — component-scoped counterparts
+- [Motion component](/docs) — object-form `style` accepts these values directly
+
+---
+
+Based on [Motion's vanilla motion value](https://motion.dev/docs/motion-value) API.

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -109,6 +109,11 @@ const EXAMPLES: Record<string, ExampleEntry> = {
         description:
             'Drag-to-reorder lists with Reorder.Group and Reorder.Item — FLIP siblings and edge auto-scroll.'
     },
+    'vanilla-values': {
+        title: 'Vanilla Values',
+        description:
+            'Motion values without motion components — runes driving plain elements through styleEffect.'
+    },
     view: {
         title: 'View Transitions',
         description:

--- a/docs/src/routes/examples/vanilla-values/+page.svelte
+++ b/docs/src/routes/examples/vanilla-values/+page.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        type ExampleSection,
+        formatSheetLabel
+    } from '@humanspeak/docs-kit'
+    import { Blend, Signal, Unplug } from '@lucide/svelte'
+    import { demoCodeSample } from '$lib/demo-loaders'
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import VanillaDefault from '$lib/examples/vanilla-values/demos/Default.svelte'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'Vanilla Values' }
+        ]
+    }
+    if (seo) {
+        seo.title = 'Vanilla Values | Examples | Svelte Motion'
+        seo.description =
+            'Motion values without motion components — a $state slider driving a plain div through toMotionValue, mapValue, springValue, and styleEffect.'
+        seo.ogTitle = 'Vanilla Values'
+        seo.h1 = { title: 'Vanilla Values', mode: 'sr-only' }
+        seo.ogTagline = 'Motion values on plain elements — no components needed'
+        seo.ogFeatures = ['Rune Bridge', 'Color Mapping', 'Spring Physics', 'styleEffect']
+        seo.ogSlug = 'examples-vanilla-values'
+    }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    const sections: ExampleSection[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'VANILLA',
+            title: { prefix: 'motion values on ', accent: 'plain elements', end: '.' },
+            description:
+                'No motion components anywhere: a $state slider feeds toMotionValue, mapValue derives position and color, springValue smooths them, and styleEffect binds the result to a plain div.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'rune-bridge' }],
+            sourceUrl: `${SOURCE_URL}vanilla-values/demos/Default.svelte`
+        }
+    ]
+</script>
+
+{#snippet defaultSection()}
+    <VanillaDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Unplug />
+            <span>
+                <code>toMotionValue(() => slider / 100)</code> is the rune bridge — reads of
+                <code>$state</code> inside the getter are tracked, so plain Svelte state drives the
+                whole motion-value chain. Everything here works in module scope or a
+                <code>.svelte.ts</code> store too.
+            </span>
+        </li>
+        <li>
+            <Blend />
+            <span>
+                <code>mapValue</code> mixes COLOR stops as happily as numbers — one spring-smoothed
+                progress value drives position, <code>backgroundColor</code>, and a tinted
+                <code>boxShadow</code> through three-stop ranges.
+            </span>
+        </li>
+        <li>
+            <Signal />
+            <span>
+                <code>styleEffect</code> binds the values straight to a plain
+                <code>&lt;div&gt;</code> — updates run on Motion's frame loop, outside Svelte's
+                render cycle. The unbind function and <code>.destroy()</code> calls in the
+                <code>$effect</code> cleanups are the manual lifecycle vanilla values ask for.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'vanilla-values/demos/Default.svelte',
+                'vanilla-values-default',
+                'Default.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel={formatSheetLabel(i, sections.length)}
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/vanilla-values/+page.ts
+++ b/docs/src/routes/examples/vanilla-values/+page.ts
@@ -1,0 +1,9 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async () => {
+    return {
+        title: 'Vanilla Values',
+        description:
+            'Motion values without motion components — runes driving plain elements through styleEffect.'
+    }
+}

--- a/e2e/vanilla-values/basic.spec.ts
+++ b/e2e/vanilla-values/basic.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('vanilla-values/basic', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/vanilla-values?@isPlaywright=true')
+        await page.getByTestId('slider').waitFor({ state: 'visible' })
+        await page.waitForTimeout(300)
+    })
+
+    test('a $state slider drives plain elements through the vanilla layer', async ({ page }) => {
+        const direct = page.getByTestId('direct-box')
+        const before = await direct.boundingBox()
+        if (!before) throw new Error('no box')
+        const bgBefore = await direct.evaluate((el) => getComputedStyle(el).backgroundColor)
+
+        await page.getByTestId('slider').fill('100')
+
+        // toMotionValue(getter) → mapValue → styleEffect: the plain div
+        // translates the full 240px mapped range.
+        await expect
+            .poll(async () => {
+                const box = await direct.boundingBox()
+                return (box?.x ?? 0) - before.x
+            })
+            .toBeCloseTo(240, 0)
+
+        // transformValue-derived color applied by the same styleEffect.
+        const bgAfter = await direct.evaluate((el) => getComputedStyle(el).backgroundColor)
+        expect(bgAfter).not.toBe(bgBefore)
+    })
+
+    test('springValue follows the mapped value and settles at its target', async ({ page }) => {
+        const spring = page.getByTestId('spring-box')
+        const before = await spring.boundingBox()
+        if (!before) throw new Error('no box')
+
+        await page.getByTestId('slider').fill('100')
+
+        // Mid-flight the spring lags the direct value…
+        await page.waitForTimeout(60)
+        const mid = await spring.boundingBox()
+        if (!mid) throw new Error('no mid box')
+        expect(mid.x - before.x).toBeLessThan(240)
+
+        // …and settles at the target.
+        await expect
+            .poll(
+                async () => {
+                    const box = await spring.boundingBox()
+                    return (box?.x ?? 0) - before.x
+                },
+                { timeout: 5000 }
+            )
+            .toBeCloseTo(240, 0)
+    })
+
+    test('reactive .current readouts track the values in the template', async ({ page }) => {
+        await expect(page.getByTestId('readout')).toHaveText('progress:0.00 x:0 spring:0')
+        await page.getByTestId('slider').fill('50')
+        await expect(page.getByTestId('readout')).toContainText('progress:0.50 x:120')
+    })
+
+    test('vanilla motionValue works from an event handler', async ({ page }) => {
+        const counter = page.getByTestId('click-counter')
+        await expect(counter).toHaveText('clicked 0 times')
+        await counter.click()
+        await counter.click()
+        await counter.click()
+        await expect(counter).toHaveText('clicked 3 times')
+    })
+})

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -17,8 +17,40 @@ export { m } from '$lib/m'
 export { motion } from '$lib/motion'
 export { Reorder } from '$lib/reorder'
 
-// Re-export core animation functions from motion
-export { animate, delay, hover, inView, press, resize, scroll, stagger, transform } from 'motion'
+// Re-export core animation functions plus the vanilla (component-free)
+// layer — element effects, the frameloop scheduler, generators, global
+// config — straight from motion.
+export {
+    MotionGlobalConfig,
+    animate,
+    cancelFrame,
+    delay,
+    frame,
+    frameData,
+    hover,
+    inView,
+    isMotionValue,
+    press,
+    resize,
+    scroll,
+    scrollInfo,
+    spring,
+    stagger,
+    transform
+} from 'motion'
+
+// Element effects re-typed to accept both raw and Svelte-augmented
+// motion values (runtime passthrough to motion's implementations).
+export { attrEffect, propEffect, styleEffect, svgEffect } from '$lib/utils/effects'
+export type { EffectValues } from '$lib/utils/effects'
+
+// Svelte-augmented vanilla value factories (reactive .current, store
+// .subscribe, manual lifecycle) and the rune/readable → MotionValue
+// bridge. Their `use*` hook counterparts add component auto-cleanup.
+export { toMotionValue } from '$lib/utils/toMotionValue.svelte'
+export type { MotionValueSource } from '$lib/utils/toMotionValue.svelte'
+export { mapValue, motionValue, springValue, transformValue } from '$lib/utils/vanillaValues.svelte'
+export type { SpringValueOptions } from '$lib/utils/vanillaValues.svelte'
 
 // Re-export easing functions
 export {
@@ -32,7 +64,10 @@ export {
     cubicBezier,
     easeIn,
     easeInOut,
-    easeOut
+    easeOut,
+    mirrorEasing,
+    reverseEasing,
+    steps
 } from 'motion'
 
 // Re-export utility functions

--- a/src/lib/utils/__tests__/GetterSourceProbe.svelte
+++ b/src/lib/utils/__tests__/GetterSourceProbe.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+    import { useSpring } from '../spring.svelte.js'
+    import { useTransform } from '../transform.svelte.js'
+
+    // Rune GETTER sources — $state reads inside the getters are tracked
+    // through resolveMotionValueSource for both hooks.
+    let source = $state(0)
+
+    export const mapped = useTransform(() => source, [0, 10], [0, 100])
+    export const smooth = useSpring(() => source, { stiffness: 1000, damping: 100 })
+
+    export function setSource(next: number): void {
+        source = next
+    }
+</script>
+
+<span data-testid="getter-probe">{mapped.current}</span>

--- a/src/lib/utils/__tests__/HookLifecycleHarness.svelte
+++ b/src/lib/utils/__tests__/HookLifecycleHarness.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+    import type { Readable } from 'svelte/store'
+    import { useMotionValue } from '../motionValue.svelte.js'
+    import { useTransform } from '../transform.svelte.js'
+    import type { AugmentedMotionValue } from '../augmentMotionValue.svelte.js'
+
+    // Exposes hook-created values to the spec so it can assert on their
+    // behavior before AND after the component unmounts.
+    let {
+        source,
+        onvalues
+    }: {
+        source?: Readable<number>
+        onvalues: (values: {
+            x: AugmentedMotionValue<number>
+            doubled: AugmentedMotionValue<number>
+            mapped?: AugmentedMotionValue<number>
+            outputMap?: { a: AugmentedMotionValue<number>; b: AugmentedMotionValue<number> }
+        }) => void
+    } = $props()
+
+    const x = useMotionValue(1)
+    const doubled = useTransform(() => x.get() * 2)
+    // The harness deliberately captures the initial `source` prop; hooks
+    // are init-time constructs.
+    // svelte-ignore state_referenced_locally
+    const mapped = source ? useTransform(source, [0, 10], [0, 100]) : undefined
+    // svelte-ignore state_referenced_locally
+    const outputMap = source
+        ? useTransform(source, [0, 10], { a: [0, 100], b: [100, 0] })
+        : undefined
+
+    // svelte-ignore state_referenced_locally
+    onvalues({ x, doubled, mapped, outputMap })
+</script>
+
+<span data-testid="hook-harness">{x.current}</span>

--- a/src/lib/utils/augmentMotionValue.svelte.ts
+++ b/src/lib/utils/augmentMotionValue.svelte.ts
@@ -77,6 +77,22 @@ export const sampleSource = <T>(source: T | MotionValue<T> | Readable<T>): T => 
 }
 
 /**
+ * Whether a `MotionValue` has already been through
+ * {@link augmentMotionValue} — its `current` is an accessor rather
+ * than a plain data field. Lives HERE, next to the representation it
+ * sniffs, so a change to how augmentation marks values updates the
+ * detector in the same edit. Augmenting mutates in place and must only
+ * happen once; pass-through code paths check this first.
+ *
+ * @param value The motion value to test.
+ * @returns Whether the value is already augmented.
+ */
+export const isAugmentedMotionValue = <T>(
+    value: MotionValue<T>
+): value is MotionValue<T> & AugmentedMotionValue<T> =>
+    typeof Object.getOwnPropertyDescriptor(value, 'current')?.get === 'function'
+
+/**
  * Layer Svelte 5 affordances onto a motion-dom `MotionValue`:
  *
  * 1. A `$state`-tracked `.current` accessor. motion-dom writes to its own

--- a/src/lib/utils/effects.ts
+++ b/src/lib/utils/effects.ts
@@ -1,0 +1,81 @@
+import {
+    attrEffect as attrEffectCore,
+    propEffect as propEffectCore,
+    styleEffect as styleEffectCore,
+    svgEffect as svgEffectCore,
+    type ElementOrSelector
+} from 'motion-dom'
+import type { AnyMotionValue } from './transform.svelte.js'
+
+/**
+ * Values accepted by the element effects: any motion value this library
+ * produces — raw motion-dom values AND the Svelte-augmented values the
+ * hooks/factories return. Runtime-identical; the alias exists because
+ * upstream's `Record<string, MotionValue>` signature rejects the
+ * augmented TYPE (TypeScript's private-field nominal typing), even
+ * though the values are the same instances.
+ */
+export type EffectValues = Record<string, AnyMotionValue<string> | AnyMotionValue<number>>
+
+type Effect = (subject: ElementOrSelector, values: EffectValues) => VoidFunction
+
+/**
+ * Bind motion values directly to elements' inline styles — no motion
+ * component required. Identical to motion's `styleEffect` at runtime,
+ * re-typed to accept this library's augmented values.
+ *
+ * @param subject Element(s) or a CSS selector.
+ * @param values Map of style names to motion values.
+ * @returns Unbind function.
+ * @example
+ * ```ts
+ * import { motionValue, styleEffect } from '@humanspeak/svelte-motion'
+ *
+ * const opacity = motionValue(1)
+ * const stop = styleEffect(element, { opacity })
+ * ```
+ */
+export const styleEffect: Effect = styleEffectCore as Effect
+
+/**
+ * Bind motion values to element attributes. Identical to motion's
+ * `attrEffect` at runtime, re-typed to accept augmented values.
+ *
+ * @param subject Element(s) or a CSS selector.
+ * @param values Map of attribute names to motion values.
+ * @returns Unbind function.
+ * @example
+ * ```ts
+ * attrEffect(circle, { r: radius })
+ * ```
+ */
+export const attrEffect: Effect = attrEffectCore as Effect
+
+/**
+ * Bind motion values to object properties. Identical to motion's
+ * `propEffect` at runtime, re-typed to accept augmented values.
+ *
+ * @param subject The target object.
+ * @param values Map of property names to motion values.
+ * @returns Unbind function.
+ * @example
+ * ```ts
+ * propEffect(audioNode, { volume })
+ * ```
+ */
+export const propEffect = propEffectCore as (subject: object, values: EffectValues) => VoidFunction
+
+/**
+ * Bind motion values to SVG attributes (with SVG-specific handling).
+ * Identical to motion's `svgEffect` at runtime, re-typed to accept
+ * augmented values.
+ *
+ * @param subject SVG element(s) or a CSS selector.
+ * @param values Map of attribute names to motion values.
+ * @returns Unbind function.
+ * @example
+ * ```ts
+ * svgEffect(path, { pathLength: progress })
+ * ```
+ */
+export const svgEffect: Effect = svgEffectCore as Effect

--- a/src/lib/utils/followValue.svelte.ts
+++ b/src/lib/utils/followValue.svelte.ts
@@ -1,17 +1,11 @@
-import {
-    attachFollow,
-    isMotionValue,
-    motionValue,
-    type FollowValueOptions,
-    type MotionValue
-} from 'motion-dom'
+import { attachFollow, motionValue, type FollowValueOptions, type MotionValue } from 'motion-dom'
 import { type Readable } from 'svelte/store'
 import {
     augmentMotionValue,
-    isSvelteReadable,
     sampleSource,
     type AugmentedMotionValue
 } from './augmentMotionValue.svelte.js'
+import { resolveMotionValueSource, type MotionValueSource } from './toMotionValue.svelte.js'
 
 /**
  * Options accepted by {@link useFollowValue}. Mirrors framer-motion's
@@ -58,7 +52,8 @@ export type FollowMotionValue<T extends number | string> = AugmentedMotionValue<
  * the server-rendered snapshot.
  *
  * @template T The value type — `number` or `string` (unit strings preserved).
- * @param source Initial value, a `MotionValue` to follow, or a Svelte readable.
+ * @param source Initial value, a `MotionValue` to follow, a Svelte readable,
+ *     or a reactive getter (`$state` / `$derived` reads inside it are tracked).
  * @param options Transition + follow configuration (`type: 'spring' | 'tween' | 'inertia' | 'keyframes'`, plus the corresponding per-type options).
  * @returns A `MotionValue<T>` with `.current` and `.subscribe`.
  *
@@ -107,14 +102,14 @@ export function useFollowValue(
     source: MotionValue<string>,
     options?: UseFollowValueOptions
 ): FollowMotionValue<string>
-// Generic readable overload preserves the concrete T from the source so
-// callers passing `Readable<number>` get `FollowMotionValue<number>` back.
+// Generic source overload preserves the concrete T from the source so
+// callers passing `Readable<T>` or `() => T` get `FollowMotionValue<T>` back.
 export function useFollowValue<T extends number | string>(
-    source: Readable<T>,
+    source: Readable<T> | (() => T),
     options?: UseFollowValueOptions
 ): FollowMotionValue<T>
 export function useFollowValue(
-    source: number | string | MotionValue<number> | MotionValue<string> | Readable<number | string>,
+    source: number | string | MotionValueSource<number> | MotionValueSource<string>,
     options: UseFollowValueOptions = {}
 ): FollowMotionValue<number> | FollowMotionValue<string> {
     type T = number | string
@@ -123,7 +118,10 @@ export function useFollowValue(
     // best-effort initial value; .set / .jump become no-ops to avoid drifting
     // away from the server-rendered snapshot.
     if (typeof window === 'undefined') {
-        const initial = sampleSource(source as T | MotionValue<T> | Readable<T>)
+        const initial =
+            typeof source === 'function'
+                ? (source as () => T)()
+                : sampleSource(source as T | MotionValue<T> | Readable<T>)
         const ssrValue = motionValue<T>(initial)
         ssrValue.set = () => undefined
         ssrValue.jump = () => undefined
@@ -132,30 +130,25 @@ export function useFollowValue(
             | FollowMotionValue<string>
     }
 
-    // Resolve initial + follow source. Svelte readables get bridged into a
-    // motion-dom MotionValue so `attachFollow` can subscribe to their emits.
+    // Resolve the follow source through the shared machinery: MotionValues
+    // pass through, readables and reactive getters are bridged (a readable's
+    // synchronous initial emit is inert — the bridge skips it, and motion-dom
+    // ignores same-value writes — so no explicit guard is needed here).
     let followSource: T | MotionValue<T>
-    let cleanupReadableBridge: VoidFunction | undefined
-    let svelteBridge: MotionValue<T> | undefined
+    let disposeBridge: VoidFunction = () => undefined
 
-    if (isMotionValue(source)) {
-        followSource = source as MotionValue<T>
-    } else if (isSvelteReadable<T>(source)) {
-        const initialFromReadable = sampleSource(source as Readable<T>)
-        svelteBridge = motionValue<T>(initialFromReadable)
-        cleanupReadableBridge = source.subscribe((v) => {
-            // Svelte readable contract emits synchronously on subscribe. Skip
-            // the initial emit (already seeded above) so attachFollow doesn't
-            // fire an animation on attach.
-            if (svelteBridge!.get() === v) return
-            svelteBridge!.set(v as T)
-        })
-        followSource = svelteBridge
+    if (typeof source === 'number' || typeof source === 'string') {
+        followSource = source
     } else {
-        followSource = source as T
+        const resolved = resolveMotionValueSource(source as MotionValueSource<T>)
+        followSource = resolved.value
+        disposeBridge = resolved.dispose
     }
 
-    const initial: T = isMotionValue(followSource) ? (followSource.get() as T) : (followSource as T)
+    const initial: T =
+        typeof followSource === 'number' || typeof followSource === 'string'
+            ? followSource
+            : (followSource.get() as T)
 
     const value = motionValue<T>(initial)
     // Default transition is `spring` — matches React framer-motion's
@@ -164,8 +157,7 @@ export function useFollowValue(
 
     const dispose = () => {
         stopFollow?.()
-        cleanupReadableBridge?.()
-        svelteBridge?.destroy()
+        disposeBridge()
     }
 
     $effect(() => () => value.destroy())

--- a/src/lib/utils/hookVanillaParity.svelte.spec.ts
+++ b/src/lib/utils/hookVanillaParity.svelte.spec.ts
@@ -1,0 +1,169 @@
+import { render } from '@testing-library/svelte'
+import { isMotionValue } from 'motion-dom'
+import { flushSync, mount, unmount } from 'svelte'
+import { describe, expect, it, vi } from 'vitest'
+import GetterSourceProbe from './__tests__/GetterSourceProbe.svelte'
+import HookLifecycleHarness from './__tests__/HookLifecycleHarness.svelte'
+import type { AugmentedMotionValue } from './augmentMotionValue.svelte.js'
+import { motionValue } from './vanillaValues.svelte.js'
+
+// Characterization tests pinning the hook behaviors that the
+// hooks-delegate-to-vanilla-factories refactor must preserve.
+
+type Captured = {
+    x: AugmentedMotionValue<number>
+    doubled: AugmentedMotionValue<number>
+    mapped?: AugmentedMotionValue<number>
+    outputMap?: { a: AugmentedMotionValue<number>; b: AugmentedMotionValue<number> }
+}
+
+/** A readable store that counts its active subscriptions. */
+const countingReadable = (initial: number) => {
+    let value = initial
+    const runs = new Set<(v: number) => void>()
+    let active = 0
+    return {
+        get activeSubscriptions() {
+            return active
+        },
+        set(next: number) {
+            value = next
+            runs.forEach((run) => run(value))
+        },
+        subscribe(run: (v: number) => void) {
+            active++
+            runs.add(run)
+            run(value)
+            return () => {
+                active--
+                runs.delete(run)
+            }
+        }
+    }
+}
+
+const mountHarness = (source?: ReturnType<typeof countingReadable>) => {
+    let captured: Captured | undefined
+    const utils = render(HookLifecycleHarness, {
+        props: {
+            source,
+            onvalues: (values: Captured) => (captured = values)
+        }
+    })
+    if (!captured) throw new Error('harness did not expose values')
+    return { ...utils, values: captured }
+}
+
+describe('hook/vanilla parity — shared value shape', () => {
+    it('hook and vanilla values expose an identical surface', () => {
+        const { values, unmount } = mountHarness()
+        const vanilla = motionValue(1)
+
+        for (const value of [values.x, vanilla]) {
+            expect(isMotionValue(value)).toBe(true)
+            expect(value.current).toBe(1)
+            expect(typeof value.subscribe).toBe('function')
+            expect(typeof value.destroy).toBe('function')
+            value.set(3)
+            expect(value.get()).toBe(3)
+            expect(value.current).toBe(3)
+        }
+
+        vanilla.destroy()
+        unmount()
+    })
+})
+
+describe('hook lifecycle — auto-destroy on unmount', () => {
+    it('useMotionValue stops notifying subscribers after unmount', () => {
+        const { values, unmount } = mountHarness()
+        const seen: number[] = []
+        values.x.subscribe((v) => seen.push(v))
+        values.x.set(5)
+        expect(seen).toEqual([1, 5])
+
+        unmount()
+        values.x.set(9)
+        expect(seen).toEqual([1, 5]) // destroyed: listeners cleared
+    })
+
+    it('useTransform compute values stop updating after unmount', async () => {
+        const { values, unmount } = mountHarness()
+        values.x.set(4)
+        await vi.advanceTimersByTimeAsync(100)
+        expect(values.doubled.get()).toBe(8)
+
+        unmount()
+        values.x.set(10)
+        await vi.advanceTimersByTimeAsync(100)
+        expect(values.doubled.get()).toBe(8) // destroyed: no recompute
+    })
+})
+
+describe('hook lifecycle — readable-source bridges', () => {
+    it('mapping form bridges a readable and updates through it', async () => {
+        const source = countingReadable(0)
+        const { values, unmount } = mountHarness(source)
+        expect(values.mapped?.get()).toBe(0)
+
+        source.set(5)
+        await vi.advanceTimersByTimeAsync(100)
+        expect(values.mapped?.get()).toBe(50)
+        unmount()
+    })
+
+    it('unsubscribes every source bridge on unmount', () => {
+        const source = countingReadable(0)
+        const { unmount } = mountHarness(source)
+        expect(source.activeSubscriptions).toBeGreaterThan(0)
+
+        unmount()
+        expect(source.activeSubscriptions).toBe(0)
+    })
+
+    it('the multi-output map form shares ONE bridge across its keys', async () => {
+        const source = countingReadable(0)
+        const { values, unmount } = mountHarness(source)
+        // mapped uses one subscription; the outputMap (2 keys) must add
+        // only one more — per-key bridging would make this 3.
+        expect(source.activeSubscriptions).toBe(2)
+
+        source.set(10)
+        await vi.advanceTimersByTimeAsync(100)
+        expect(values.outputMap?.a.get()).toBe(100)
+        expect(values.outputMap?.b.get()).toBe(0)
+        unmount()
+    })
+})
+
+describe('useTransform — rune getter sources (unlocked by the unification)', () => {
+    it('maps a $state-driven getter source through ranges', async () => {
+        const host = document.createElement('div')
+        document.body.appendChild(host)
+        const probe = mount(GetterSourceProbe, { target: host })
+
+        expect(probe.mapped.get()).toBe(0)
+        probe.setSource(5)
+        flushSync()
+        await vi.advanceTimersByTimeAsync(100)
+        expect(probe.mapped.get()).toBe(50)
+
+        unmount(probe)
+        host.remove()
+    })
+
+    it('useSpring follows a $state-driven getter source', async () => {
+        const host = document.createElement('div')
+        document.body.appendChild(host)
+        const probe = mount(GetterSourceProbe, { target: host })
+
+        expect(probe.smooth.get()).toBe(0)
+        probe.setSource(100)
+        flushSync()
+        await vi.advanceTimersByTimeAsync(2000)
+        expect(probe.smooth.get()).toBeGreaterThan(0)
+
+        unmount(probe)
+        host.remove()
+    })
+})

--- a/src/lib/utils/motionValue.svelte.ts
+++ b/src/lib/utils/motionValue.svelte.ts
@@ -1,5 +1,6 @@
-import { motionValue, type MotionValue as MotionDomMotionValue } from 'motion-dom'
-import { augmentMotionValue, type AugmentedMotionValue } from './augmentMotionValue.svelte.js'
+import { type MotionValue as MotionDomMotionValue } from 'motion-dom'
+import { type AugmentedMotionValue } from './augmentMotionValue.svelte.js'
+import { motionValue } from './vanillaValues.svelte.js'
 
 /**
  * The shape returned by {@link useMotionValue}: a real motion-dom
@@ -62,7 +63,9 @@ export type RawMotionValue<T = number> = MotionDomMotionValue<T>
  * @see https://motion.dev/docs/react-motion-value
  */
 export const useMotionValue = <T = number>(initial: T): MotionValue<T> => {
+    // Lifecycle variant of the vanilla factory: same construction path,
+    // plus auto-destroy bound to the surrounding component.
     const value = motionValue<T>(initial)
     $effect(() => () => value.destroy())
-    return augmentMotionValue(value)
+    return value
 }

--- a/src/lib/utils/spring.svelte.ts
+++ b/src/lib/utils/spring.svelte.ts
@@ -85,14 +85,21 @@ export function useSpring(
     source: MotionValue<string>,
     options?: UseSpringOptions
 ): SpringMotionValue<string>
-// Generic readable overload preserves the concrete T from the source so callers
-// passing `Readable<number>` get `SpringMotionValue<number>` back.
+// Generic source overload preserves the concrete T from the source so callers
+// passing `Readable<T>` or a reactive getter `() => T` get
+// `SpringMotionValue<T>` back.
 export function useSpring<T extends number | string>(
-    source: Readable<T>,
+    source: Readable<T> | (() => T),
     options?: UseSpringOptions
 ): SpringMotionValue<T>
 export function useSpring(
-    source: number | string | MotionValue<number> | MotionValue<string> | Readable<number | string>,
+    source:
+        | number
+        | string
+        | MotionValue<number>
+        | MotionValue<string>
+        | Readable<number | string>
+        | (() => number | string),
     options: UseSpringOptions = {}
 ): SpringMotionValue<number> | SpringMotionValue<string> {
     // Cast through `unknown` because TypeScript can't narrow the multi-form

--- a/src/lib/utils/toMotionValue.svelte.spec.ts
+++ b/src/lib/utils/toMotionValue.svelte.spec.ts
@@ -1,0 +1,73 @@
+import { isMotionValue, motionValue as rawMotionValue } from 'motion-dom'
+import { flushSync } from 'svelte'
+import { writable } from 'svelte/store'
+import { describe, expect, it } from 'vitest'
+import { toMotionValue } from './toMotionValue.svelte.js'
+
+describe('toMotionValue', () => {
+    it('passes an existing MotionValue through with the same identity', () => {
+        const source = rawMotionValue(5)
+        const value = toMotionValue(source)
+        expect(value).toBe(source)
+        expect(value.current).toBe(5)
+        source.set(9)
+        expect(value.get()).toBe(9)
+    })
+
+    it('does not re-augment an already-augmented value', () => {
+        const source = rawMotionValue(1)
+        const once = toMotionValue(source)
+        const twice = toMotionValue(once)
+        expect(twice).toBe(once)
+    })
+
+    it('mirrors a Svelte readable store', () => {
+        const store = writable(10)
+        const value = toMotionValue(store)
+        expect(value.get()).toBe(10)
+        store.set(25)
+        expect(value.get()).toBe(25)
+        expect(isMotionValue(value)).toBe(true)
+        value.destroy()
+        store.set(99)
+        expect(value.get()).toBe(25)
+    })
+
+    it('tracks rune state through a getter', () => {
+        let progress = $state(0)
+        const value = toMotionValue(() => progress / 100)
+        expect(value.get()).toBe(0)
+
+        progress = 50
+        flushSync()
+        expect(value.get()).toBe(0.5)
+
+        progress = 100
+        flushSync()
+        expect(value.get()).toBe(1)
+
+        value.destroy()
+        progress = 10
+        flushSync()
+        expect(value.get()).toBe(1)
+    })
+
+    it('tracks another augmented value read via .current inside a getter', () => {
+        const source = toMotionValue(rawMotionValue(2))
+        const doubled = toMotionValue(() => source.current * 2)
+        expect(doubled.get()).toBe(4)
+
+        source.set(10)
+        flushSync()
+        expect(doubled.get()).toBe(20)
+
+        doubled.destroy()
+    })
+
+    it('getter values compose with motion-dom consumers (isMotionValue)', () => {
+        const n = $state(1)
+        const value = toMotionValue(() => n)
+        expect(isMotionValue(value)).toBe(true)
+        value.destroy()
+    })
+})

--- a/src/lib/utils/toMotionValue.svelte.ts
+++ b/src/lib/utils/toMotionValue.svelte.ts
@@ -1,0 +1,123 @@
+import { isMotionValue, motionValue as motionValueCore, type MotionValue } from 'motion-dom'
+import type { Readable } from 'svelte/store'
+import {
+    augmentMotionValue,
+    bridgeReadableToMotionValue,
+    isAugmentedMotionValue,
+    isSvelteReadable,
+    type AugmentedMotionValue
+} from './augmentMotionValue.svelte.js'
+
+/**
+ * Anything {@link toMotionValue} can turn into a `MotionValue`:
+ * an existing `MotionValue`, a Svelte readable store, or a reactive
+ * getter (the rune-native form — reads of `$state` / `$derived` inside
+ * the getter are tracked).
+ *
+ * @template T The value type — typically `number` or `string`.
+ */
+export type MotionValueSource<T> = MotionValue<T> | Readable<T> | (() => T)
+
+/**
+ * Normalize any {@link MotionValueSource} into a motion-dom
+ * `MotionValue`, reporting whether the caller owns its lifecycle.
+ *
+ * - A `MotionValue` passes through untouched (`dispose` is a no-op —
+ *   the caller didn't create it, so it must not destroy it).
+ * - A Svelte readable is bridged; `dispose` tears the bridge down.
+ * - A getter is bridged through a Svelte effect root (see
+ *   {@link toMotionValue}); `dispose` tears the root down.
+ *
+ * Used by the vanilla factories (`springValue`, `mapValue`) so their
+ * sources can be any of the three kinds, with bridge lifecycles chained
+ * onto the returned value's `.destroy()`.
+ */
+export const resolveMotionValueSource = <T>(
+    source: MotionValueSource<T>
+): { value: MotionValue<T>; dispose: VoidFunction } => {
+    if (isMotionValue(source)) {
+        return { value: source as MotionValue<T>, dispose: () => undefined }
+    }
+
+    if (isSvelteReadable<T>(source)) {
+        return bridgeReadableToMotionValue<T>(source)
+    }
+
+    const getter = source as () => T
+    const bridge = motionValueCore<T>(getter())
+    // $effect.root gives the getter a reactive context outside any
+    // component, so `$state` / `$derived` (and augmented `.current`)
+    // reads inside it re-run the sync. Updates flush on Svelte's effect
+    // schedule (microtask), matching template timing.
+    const stopRoot = $effect.root(() => {
+        $effect(() => {
+            bridge.set(getter())
+        })
+    })
+    return {
+        value: bridge,
+        dispose: () => {
+            stopRoot()
+            bridge.destroy()
+        }
+    }
+}
+
+/**
+ * Convert any source into an augmented `MotionValue` — the bridge
+ * between Svelte reactivity and motion-dom's vanilla APIs.
+ *
+ * The getter form is the rune-native entry point: reads of `$state`,
+ * `$derived`, or another augmented value's `.current` inside the getter
+ * are tracked, and the returned `MotionValue` follows them. That lets
+ * plain Svelte state drive anything that takes a `MotionValue` —
+ * `styleEffect`, `springValue`, `mapValue`, `animate()`, motion
+ * component `style` props — without the component wrapper hooks.
+ *
+ * Passing an existing `MotionValue` returns the SAME value (augmented
+ * in place if it wasn't already), so the function is safe to call on
+ * "whatever the consumer handed you". Passing a Svelte readable store
+ * returns a mirroring value.
+ *
+ * Lifecycle: for getter and readable sources the returned value owns a
+ * bridge — call `.destroy()` when done, e.g. in your `$effect` cleanup
+ * as in the example below. The getter form's effect root is UNOWNED by
+ * any component, so a forgotten `.destroy()` leaves a permanently live
+ * effect. For pass-through `MotionValue` sources, `.destroy()` behaves
+ * as it did before.
+ *
+ * @template T The value type — typically `number` or `string`.
+ * @param source A `MotionValue`, Svelte readable, or reactive getter.
+ * @returns An {@link AugmentedMotionValue} tracking the source.
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *     import { styleEffect, toMotionValue } from '@humanspeak/svelte-motion'
+ *
+ *     let progress = $state(0)
+ *     const opacity = toMotionValue(() => progress / 100)
+ *
+ *     $effect(() => {
+ *         const stop = styleEffect(element, { opacity })
+ *         return () => {
+ *             stop()
+ *             opacity.destroy()
+ *         }
+ *     })
+ * </script>
+ * ```
+ * @example
+ * ```ts
+ * // Readable store → MotionValue
+ * import { writable } from 'svelte/store'
+ * const store = writable(0)
+ * const value = toMotionValue(store)
+ * ```
+ */
+export const toMotionValue = <T>(source: MotionValueSource<T>): AugmentedMotionValue<T> => {
+    // Fresh bridges are never pre-augmented, so their dispose is never
+    // dropped by the pass-through branch; a pass-through's dispose is a
+    // no-op by construction.
+    const { value, dispose } = resolveMotionValueSource(source)
+    return isAugmentedMotionValue(value) ? value : augmentMotionValue(value, dispose)
+}

--- a/src/lib/utils/transform.svelte.ts
+++ b/src/lib/utils/transform.svelte.ts
@@ -1,18 +1,12 @@
 // Utilities for building and validating transform strings
 
+import { type MotionValue, type TransformOptions } from 'motion-dom'
+import { type AugmentedMotionValue } from './augmentMotionValue.svelte.js'
+import { resolveMotionValueSource, type MotionValueSource } from './toMotionValue.svelte.js'
 import {
-    isMotionValue,
-    mapValue,
-    transformValue,
-    type MotionValue,
-    type TransformOptions
-} from 'motion-dom'
-import { type Readable } from 'svelte/store'
-import {
-    augmentMotionValue,
-    bridgeReadableToMotionValue,
-    type AugmentedMotionValue
-} from './augmentMotionValue.svelte.js'
+    mapValue as createMapValue,
+    transformValue as createTransformValue
+} from './vanillaValues.svelte.js'
 
 export type TransformValues = Partial<{
     x: number
@@ -138,27 +132,14 @@ export type { TransformOptions }
 export type AnyMotionValue<T> = MotionValue<T> | AugmentedMotionValue<T>
 
 /**
- * A source for {@link useTransform}'s mapping form: any motion value or a
- * Svelte readable store. Svelte readables are bridged into a `MotionValue`
- * internally so motion-dom's `mapValue` / `transformValue` can track them.
+ * A source for {@link useTransform}'s mapping form: any motion value, a
+ * Svelte readable store, or a reactive getter (`$state` / `$derived`
+ * reads inside it are tracked). Extends {@link MotionValueSource} with
+ * the augmented value shape so both flavors type-check at call sites;
+ * non-motion-value sources are bridged internally (via
+ * `resolveMotionValueSource`) so motion-dom can track them.
  */
-export type TransformSource<T> = AnyMotionValue<T> | Readable<T>
-
-/**
- * Normalizes a `TransformSource<T>` into a `MotionValue<T>`. Returns the
- * source as-is for any motion-value input (no bridge), or a bridge
- * `MotionValue` + cleanup for `Readable` inputs. The cast at the
- * motion-value branch is safe — both `MotionValue` and `AugmentedMotionValue`
- * are the same instance at runtime.
- */
-const toMotionValue = <T>(
-    source: TransformSource<T>
-): { value: MotionValue<T>; dispose: VoidFunction } => {
-    if (isMotionValue(source)) {
-        return { value: source as unknown as MotionValue<T>, dispose: () => undefined }
-    }
-    return bridgeReadableToMotionValue<T>(source as Readable<T>)
-}
+export type TransformSource<T> = AugmentedMotionValue<T> | MotionValueSource<T>
 
 /**
  * Single-input transformer signature: `(latest) => output`.
@@ -177,38 +158,46 @@ export type TransformOutputMap<O> = { [key: string]: O[] }
 
 /**
  * Creates an augmented `MotionValue<O>` derived from one or more `MotionValue`s
- * (or Svelte readables), composed via a range mapping or a compute function.
+ * (or Svelte readables / reactive getters), composed via a range mapping or a
+ * compute function.
  *
  * Mirrors framer-motion's `useTransform` 1:1 with five forms:
  *
  * - **Mapping form** — `useTransform(source, input, output, options?)` maps a
  *   numeric source's value across `input → output` stops with clamp, easing,
- *   and a pluggable mixer for non-numeric outputs. Delegates to motion-dom's
- *   `mapValue` (which is itself `transformValue` over the curried mapper).
+ *   and a pluggable mixer for non-numeric outputs. The source may be a motion
+ *   value, a Svelte readable, or a reactive getter (`$state` / `$derived`
+ *   reads inside it are tracked). Delegates to motion-dom's `mapValue`.
  * - **Multi-output mapping form** — `useTransform(source, input, outputMap, options?)`
  *   produces an object of motion values, one per key in `outputMap`. Each
- *   value is the same mapping form applied to that key's output stops.
- * - **Single-transformer form** — `useTransform(mv, (latest) => O)` recomputes
- *   on every change of `mv`. Auto-tracks via `transformValue`.
+ *   value is the same mapping form applied to that key's output stops; all
+ *   keys share one source bridge.
+ * - **Single-transformer form** — `useTransform(source, (latest) => O)`
+ *   recomputes on every change of the source (motion value, readable, or
+ *   getter). Auto-tracks via `transformValue`.
  * - **Multi-transformer form** — `useTransform([mv1, mv2, …], ([latest, …]) => O)`
  *   recomputes on every change of any input. Auto-tracks via `transformValue`.
  * - **Compute form** — `useTransform(() => compute)` recomputes whenever any
- *   `MotionValue` referenced inside `compute` (via `.get()` or `.current`)
- *   changes. Auto-tracks via `transformValue` — no explicit deps array; the
+ *   `MotionValue` referenced inside `compute` via `.get()` changes.
+ *   Auto-tracks via `transformValue` — no explicit deps array; the
  *   `collectMotionValues` session inside `transformValue` discovers them.
+ *
+ * Dispatch rule for functions: a BARE function argument is the compute form;
+ * a function accompanied by range/transformer arguments is a reactive getter
+ * SOURCE for the other forms.
  *
  * Returns an {@link AugmentedMotionValue<O>} — a real motion-dom `MotionValue`
  * (composes with `useSpring`, `useVelocity`, `animate()`, etc.) plus a
  * `$state`-backed `.current` getter and a Svelte readable `.subscribe` shim.
  *
  * Lifecycle: must be called during component initialization. Source
- * subscriptions, the underlying motion value, and any Svelte-readable bridges
+ * subscriptions, the underlying motion value, and any readable/getter bridges
  * are torn down when the surrounding `$effect` scope unmounts.
  *
  * @template O Output value type.
- * @param sourceOrCompute A motion value / readable (mapping forms), a single
- *   `MotionValue` (single-transformer form), an array of `MotionValue`s
- *   (multi-transformer form), or a compute function (compute form).
+ * @param sourceOrCompute A motion value / readable / reactive getter (mapping
+ *   and single-transformer forms), an array of `MotionValue`s
+ *   (multi-transformer form), or a bare compute function (compute form).
  * @param inputOrTransformer Input stops `number[]` (mapping forms) or a
  *   transformer function (`(latest) => O` / `(latest[]) => O`).
  * @param outputOrOutputMap Output stops `O[]` (single-output mapping) or an
@@ -265,7 +254,7 @@ export function useTransform<T extends TransformOutputMap<unknown>>(
     options?: TransformOptions<T[keyof T][number]>
 ): { [K in keyof T]: AugmentedMotionValue<T[K][number]> }
 export function useTransform<I, O>(
-    source: AnyMotionValue<I>,
+    source: TransformSource<I>,
     transformer: SingleTransformer<I, O>
 ): AugmentedMotionValue<O>
 export function useTransform<I, O>(
@@ -283,42 +272,49 @@ export function useTransform<O>(
     outputOrOutputMap?: O[] | TransformOutputMap<unknown>,
     options?: TransformOptions<unknown>
 ): AugmentedMotionValue<O> | { [key: string]: AugmentedMotionValue<O> } {
-    // Compute form: useTransform(() => compute).
-    if (typeof sourceOrCompute === 'function') {
-        const compute = sourceOrCompute as () => O
-        const value = transformValue<O>(compute)
+    // Compute form: useTransform(() => compute). A bare function with NO
+    // range arguments — a function WITH ranges is a getter SOURCE for the
+    // mapping forms below.
+    if (typeof sourceOrCompute === 'function' && inputOrTransformer === undefined) {
+        const value = createTransformValue<O>(sourceOrCompute as () => O)
         $effect(() => () => value.destroy())
-        return augmentMotionValue(value)
+        return value
     }
 
     // Multi-input list form: useTransform([mv, mv, …], ([a, b, …]) => O).
     if (Array.isArray(sourceOrCompute) && typeof inputOrTransformer === 'function') {
         const sources = sourceOrCompute as ReadonlyArray<AnyMotionValue<unknown>>
         const transformer = inputOrTransformer as MultiTransformer<unknown, O>
-        const value = transformValue<O>(() => {
+        const value = createTransformValue<O>(() => {
             const latest: unknown[] = []
             for (let i = 0; i < sources.length; i++) {
-                latest.push((sources[i] as unknown as MotionValue<unknown>).get())
+                latest.push(sources[i].get())
             }
             return transformer(latest)
         })
         $effect(() => () => value.destroy())
-        return augmentMotionValue(value)
+        return value
     }
 
-    // Single-MV transformer form: useTransform(mv, (latest) => O).
+    // Single-source transformer form: useTransform(source, (latest) => O).
+    // Resolved through the shared source machinery so readable/getter
+    // sources work here just like in the mapping forms — without this,
+    // an untyped getter call would crash on `source.get`.
     if (typeof inputOrTransformer === 'function') {
-        const source = sourceOrCompute as unknown as MotionValue<unknown>
+        const { value: source, dispose } = resolveMotionValueSource(
+            sourceOrCompute as MotionValueSource<unknown>
+        )
         const transformer = inputOrTransformer as SingleTransformer<unknown, O>
-        const value = transformValue<O>(() => transformer(source.get()))
-        $effect(() => () => value.destroy())
-        return augmentMotionValue(value)
+        const value = createTransformValue<O>(() => transformer(source.get()))
+        $effect(() => () => {
+            value.destroy()
+            dispose()
+        })
+        return value
     }
 
-    // Mapping forms (single output array or output map).
     const source = sourceOrCompute as TransformSource<number>
     const input = (inputOrTransformer as number[]) ?? []
-    const { value: numericSource, dispose: disposeBridge } = toMotionValue(source)
 
     // Multi-output mapping form: useTransform(source, [range], { key: [out], … }, options).
     // The `outputOrOutputMap !== null` check is load-bearing — `typeof null`
@@ -330,40 +326,41 @@ export function useTransform<O>(
         !Array.isArray(outputOrOutputMap) &&
         typeof outputOrOutputMap === 'object'
     ) {
-        const outputMap = outputOrOutputMap as TransformOutputMap<unknown>
+        // Resolve the source ONCE so all keys share a single bridge (a
+        // readable/getter source must not be subscribed per key).
+        const { value: numericSource, dispose: disposeBridge } = resolveMotionValueSource(
+            source as MotionValueSource<number>
+        )
+        const outputMap = outputOrOutputMap as TransformOutputMap<O>
         const keys = Object.keys(outputMap)
         const result: { [key: string]: AugmentedMotionValue<O> } = {}
-        const inners: MotionValue<unknown>[] = []
         for (const key of keys) {
-            const inner = mapValue<unknown>(
+            result[key] = createMapValue(
                 numericSource,
                 input,
                 outputMap[key],
-                options as TransformOptions<unknown> | undefined
+                options as TransformOptions<O> | undefined
             )
-            inners.push(inner)
-            result[key] = augmentMotionValue(inner) as unknown as AugmentedMotionValue<O>
         }
         // One cleanup effect for all per-key MVs plus the shared bridge —
         // saves N effect nodes vs. registering one per key.
         $effect(() => () => {
-            for (const inner of inners) inner.destroy()
+            for (const key of keys) result[key].destroy()
             disposeBridge()
         })
         return result
     }
 
     // Single-output mapping form: useTransform(source, [range], [out], options).
+    // The vanilla factory resolves the source (bridging readables/getters)
+    // and chains that bridge's teardown onto the value's own destroy.
     const output = (outputOrOutputMap as O[]) ?? []
-    const value = mapValue<O>(
-        numericSource,
+    const value = createMapValue(
+        source as MotionValueSource<number>,
         input,
         output,
         options as TransformOptions<O> | undefined
     )
-    $effect(() => () => {
-        value.destroy()
-        disposeBridge()
-    })
-    return augmentMotionValue(value)
+    $effect(() => () => value.destroy())
+    return value
 }

--- a/src/lib/utils/vanillaValues.svelte.spec.ts
+++ b/src/lib/utils/vanillaValues.svelte.spec.ts
@@ -1,0 +1,88 @@
+import { isMotionValue } from 'motion-dom'
+import { flushSync } from 'svelte'
+import { describe, expect, it, vi } from 'vitest'
+import { mapValue, motionValue, springValue, transformValue } from './vanillaValues.svelte.js'
+
+describe('vanilla motionValue', () => {
+    it('creates an augmented value outside component context', () => {
+        const x = motionValue(3)
+        expect(isMotionValue(x)).toBe(true)
+        expect(x.current).toBe(3)
+        x.set(7)
+        expect(x.get()).toBe(7)
+        expect(x.current).toBe(7)
+        x.destroy()
+    })
+
+    it('implements the readable store contract', () => {
+        const x = motionValue(1)
+        const seen: number[] = []
+        const unsubscribe = x.subscribe((value) => seen.push(value))
+        x.set(2)
+        expect(seen).toEqual([1, 2])
+        unsubscribe()
+        x.destroy()
+    })
+})
+
+describe('vanilla transformValue', () => {
+    it('recomputes when tracked MotionValues change', async () => {
+        const x = motionValue(2)
+        const doubled = transformValue(() => x.get() * 2)
+        expect(doubled.get()).toBe(4)
+        x.set(5)
+        await vi.advanceTimersByTimeAsync(50)
+        expect(doubled.get()).toBe(10)
+        doubled.destroy()
+        x.destroy()
+    })
+})
+
+describe('vanilla mapValue', () => {
+    it('maps a MotionValue source across ranges', async () => {
+        const x = motionValue(0)
+        const opacity = mapValue(x, [0, 100], [1, 0])
+        expect(opacity.get()).toBe(1)
+        x.set(50)
+        await vi.advanceTimersByTimeAsync(50)
+        expect(opacity.get()).toBe(0.5)
+        opacity.destroy()
+        x.destroy()
+    })
+
+    it('accepts a rune getter as a source and tears the bridge down on destroy', async () => {
+        let n = $state(0)
+        const mapped = mapValue(() => n, [0, 10], [0, 100])
+        expect(mapped.get()).toBe(0)
+
+        n = 5
+        flushSync()
+        await vi.advanceTimersByTimeAsync(50)
+        expect(mapped.get()).toBe(50)
+
+        mapped.destroy()
+        n = 10
+        flushSync()
+        await vi.advanceTimersByTimeAsync(50)
+        expect(mapped.get()).toBe(50)
+    })
+})
+
+describe('vanilla springValue', () => {
+    it('accepts a static initial number', () => {
+        const spring = springValue(0, { stiffness: 300, damping: 30 })
+        expect(isMotionValue(spring)).toBe(true)
+        expect(spring.get()).toBe(0)
+        spring.destroy()
+    })
+
+    it('follows a MotionValue source toward its target', async () => {
+        const x = motionValue(0)
+        const smooth = springValue(x, { stiffness: 1000, damping: 100 })
+        x.set(100)
+        await vi.advanceTimersByTimeAsync(2000)
+        expect(smooth.get()).toBeGreaterThan(0)
+        smooth.destroy()
+        x.destroy()
+    })
+})

--- a/src/lib/utils/vanillaValues.svelte.ts
+++ b/src/lib/utils/vanillaValues.svelte.ts
@@ -1,0 +1,146 @@
+import {
+    mapValue as mapValueCore,
+    motionValue as motionValueCore,
+    springValue as springValueCore,
+    transformValue as transformValueCore,
+    type FollowValueOptions,
+    type SpringOptions,
+    type TransformOptions
+} from 'motion-dom'
+import { augmentMotionValue, type AugmentedMotionValue } from './augmentMotionValue.svelte.js'
+import { resolveMotionValueSource, type MotionValueSource } from './toMotionValue.svelte.js'
+
+/**
+ * Vanilla (component-free) counterparts of the `use*` motion-value
+ * hooks. Same augmented value shape — rune-reactive `.current`, store
+ * `.subscribe`, real motion-dom identity — but with MANUAL lifecycle:
+ * nothing auto-destroys when a component unmounts, so call `.destroy()`
+ * when done (module-scope values that live for the app's lifetime don't
+ * need to).
+ *
+ * Inside components, prefer the `use*` hooks — they register cleanup
+ * automatically. Reach for these in `.svelte.ts` modules, shared
+ * stores, event handlers, or anywhere outside component init.
+ */
+
+/**
+ * Create a mutable `MotionValue` outside component context — the
+ * vanilla counterpart of `useMotionValue`.
+ *
+ * @template T The value type — typically `number` or `string`.
+ * @param initial The starting value.
+ * @returns An {@link AugmentedMotionValue} with manual lifecycle.
+ * @example
+ * ```ts
+ * // module-scope shared value, readable reactively anywhere
+ * import { motionValue } from '@humanspeak/svelte-motion'
+ *
+ * export const scrollProgress = motionValue(0)
+ * ```
+ */
+export const motionValue = <T = number>(initial: T): AugmentedMotionValue<T> =>
+    augmentMotionValue(motionValueCore<T>(initial))
+
+/**
+ * Spring + follow options for {@link springValue} — every
+ * `SpringOptions` key plus `skipInitialAnimation` (forwarded to the
+ * underlying follow attachment), matching `useSpring`'s option surface.
+ */
+export type SpringValueOptions = SpringOptions & Pick<FollowValueOptions, 'skipInitialAnimation'>
+
+/**
+ * Create a `MotionValue` that springs toward its source — the vanilla
+ * counterpart of `useSpring`. The source can be a static initial value
+ * (number or unit string like `'100vh'`), another `MotionValue`, a
+ * Svelte readable, or a reactive getter (runes tracked).
+ *
+ * @param source Initial value or a source to follow.
+ * @param options Spring physics options (`stiffness`, `damping`, `visualDuration`, …) plus `skipInitialAnimation`.
+ * @returns An {@link AugmentedMotionValue} animating toward the source. `.destroy()` also tears down any internal source bridge.
+ * @example
+ * ```ts
+ * import { motionValue, springValue } from '@humanspeak/svelte-motion'
+ *
+ * const x = motionValue(0)
+ * const smoothX = springValue(x, { stiffness: 300, damping: 30 })
+ * x.set(200) // smoothX animates there
+ * ```
+ * @example
+ * ```ts
+ * // Rune-driven source via a getter
+ * let target = $state(0)
+ * const smooth = springValue(() => target, { visualDuration: 0.3 })
+ * ```
+ */
+export function springValue(
+    source: number | MotionValueSource<number>,
+    options?: SpringValueOptions
+): AugmentedMotionValue<number>
+export function springValue(
+    source: string | MotionValueSource<string>,
+    options?: SpringValueOptions
+): AugmentedMotionValue<string>
+export function springValue<T extends number | string>(
+    source: T | MotionValueSource<T>,
+    options?: SpringValueOptions
+): AugmentedMotionValue<T> {
+    if (typeof source === 'number' || typeof source === 'string') {
+        return augmentMotionValue(springValueCore<T>(source as T, options))
+    }
+    const { value, dispose } = resolveMotionValueSource(source)
+    return augmentMotionValue(springValueCore<T>(value, options), dispose)
+}
+
+/**
+ * Create a computed `MotionValue` from a function — the vanilla
+ * counterpart of `useTransform`'s compute form. Dependencies are
+ * collected exactly like upstream motion-dom: `.get()` reads on
+ * `MotionValue`s inside the compute are tracked.
+ *
+ * Svelte runes are NOT tracked here (upstream semantics, kept
+ * deliberately) — bring rune state in through `toMotionValue`:
+ *
+ * @param compute Function deriving the value from `MotionValue.get()` reads.
+ * @returns An {@link AugmentedMotionValue} recomputing when tracked values change.
+ * @example
+ * ```ts
+ * import { motionValue, toMotionValue, transformValue } from '@humanspeak/svelte-motion'
+ *
+ * const x = motionValue(0)
+ * // Rune state enters via toMotionValue, then tracks like any value:
+ * const scale = toMotionValue(() => ui.scale)
+ * const shifted = transformValue(() => x.get() * scale.get())
+ * ```
+ */
+export const transformValue = <O>(compute: () => O): AugmentedMotionValue<O> =>
+    augmentMotionValue(transformValueCore(compute))
+
+/**
+ * Create a `MotionValue` mapping a source range onto an output range —
+ * the vanilla counterpart of `useTransform`'s range form. The source
+ * can be a `MotionValue`, a Svelte readable, or a reactive getter.
+ *
+ * @template O The output value type (number, color string, unit string, …).
+ * @param source The driving value.
+ * @param inputRange Ascending breakpoints sampled from the source.
+ * @param outputRange Values (same length) the input maps onto — mixable numbers, colors, or unit strings.
+ * @param options Mapping options (`clamp`, `ease`, `mixer`).
+ * @returns An {@link AugmentedMotionValue} of the mapped value. `.destroy()` also tears down any internal source bridge.
+ * @example
+ * ```ts
+ * import { mapValue, motionValue } from '@humanspeak/svelte-motion'
+ *
+ * const x = motionValue(0)
+ * const opacity = mapValue(x, [0, 200], [1, 0])
+ * const color = mapValue(x, [0, 200], ['#ff0088', '#00ccff'])
+ * ```
+ */
+export const mapValue = <O>(
+    source: MotionValueSource<number>,
+    inputRange: number[],
+    outputRange: O[],
+    options?: TransformOptions<O>
+): AugmentedMotionValue<O> => {
+    const { value, dispose } = resolveMotionValueSource(source)
+    return augmentMotionValue(mapValueCore(value, inputRange, outputRange, options), dispose)
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -224,6 +224,19 @@
             </ul>
         </div>
         <div>
+            <h2 class="mb-3 text-xl font-medium">Vanilla Values</h2>
+            <ul class="list-disc space-y-2 pl-5">
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/vanilla-values') + searchParams}
+                    >
+                        Vanilla motion values (styleEffect, toMotionValue, no components)
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <div>
             <h2 class="mb-3 text-xl font-medium">View Transitions</h2>
             <ul class="list-disc space-y-2 pl-5">
                 <li>

--- a/src/routes/tests/vanilla-values/+page.svelte
+++ b/src/routes/tests/vanilla-values/+page.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+    import {
+        mapValue,
+        motionValue,
+        springValue,
+        styleEffect,
+        toMotionValue,
+        transformValue
+    } from '$lib'
+
+    // The entire page runs on the VANILLA layer: no motion.* components —
+    // plain DOM elements driven by styleEffect + value factories, with a
+    // Svelte $state slider as the only input.
+
+    let slider = $state(0)
+
+    // Rune → MotionValue bridge (the getter is $state-tracked).
+    const progress = toMotionValue(() => slider / 100)
+
+    // Vanilla factories composing off the bridge.
+    const x = mapValue(progress, [0, 1], [0, 240])
+    const smoothX = springValue(x, { stiffness: 300, damping: 25 })
+    const hue = mapValue(progress, [0, 1], [340, 200])
+    const background = transformValue(() => `hsl(${Math.round(hue.get())}, 80%, 62%)`)
+
+    // A raw counter value set imperatively from an event handler —
+    // impossible with useMotionValue (component-init only).
+    const clicks = motionValue(0)
+
+    let directBox = $state<HTMLElement | null>(null)
+    let springBox = $state<HTMLElement | null>(null)
+
+    // styleEffect binds values straight to plain elements. Registered in
+    // $effect so unbinding + value teardown follow the page lifecycle.
+    $effect(() => {
+        if (!(directBox && springBox)) return
+        const stopDirect = styleEffect(directBox, { x, backgroundColor: background })
+        const stopSpring = styleEffect(springBox, { x: smoothX, backgroundColor: background })
+        return () => {
+            stopDirect()
+            stopSpring()
+        }
+    })
+
+    $effect(() => () => {
+        progress.destroy()
+        x.destroy()
+        smoothX.destroy()
+        hue.destroy()
+        background.destroy()
+        clicks.destroy()
+    })
+</script>
+
+<div class="page">
+    <h1>Vanilla motion values — no motion components</h1>
+    <p>
+        A <code>$state</code> slider feeds <code>toMotionValue</code>; <code>mapValue</code>,
+        <code>springValue</code> and <code>transformValue</code> derive position and color;
+        <code>styleEffect</code> drives plain <code>&lt;div&gt;</code>s.
+    </p>
+
+    <label>
+        Slider
+        <input
+            type="range"
+            min="0"
+            max="100"
+            bind:value={slider}
+            data-testid="slider"
+            aria-label="Drive the motion values"
+        />
+    </label>
+
+    <div class="track">
+        <div class="box" bind:this={directBox} data-testid="direct-box">direct</div>
+    </div>
+    <div class="track">
+        <div class="box" bind:this={springBox} data-testid="spring-box">spring</div>
+    </div>
+
+    <button data-testid="click-counter" onclick={() => clicks.set(clicks.get() + 1)}>
+        clicked {clicks.current} times
+    </button>
+
+    <div class="readout" data-testid="readout">
+        progress:{progress.current.toFixed(2)} x:{Math.round(x.current)} spring:{Math.round(
+            smoothX.current
+        )}
+    </div>
+</div>
+
+<style>
+    .page {
+        min-height: 100vh;
+        padding: 48px;
+        background: #0f1115;
+        color: #e5e7eb;
+        font-family: system-ui, sans-serif;
+    }
+
+    h1 {
+        font-size: 20px;
+        margin-bottom: 8px;
+    }
+
+    p {
+        max-width: 520px;
+        margin-bottom: 24px;
+        color: #9ca3af;
+    }
+
+    label {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 24px;
+    }
+
+    input[type='range'] {
+        width: 260px;
+    }
+
+    .track {
+        width: 320px;
+        margin-bottom: 12px;
+        padding: 6px;
+        border-radius: 12px;
+        background: #1f2937;
+    }
+
+    .box {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 72px;
+        height: 44px;
+        border-radius: 8px;
+        color: #0f1115;
+        font-size: 12px;
+        font-weight: 600;
+    }
+
+    button {
+        margin-top: 8px;
+        padding: 8px 16px;
+        border: none;
+        border-radius: 8px;
+        background: #374151;
+        color: #e5e7eb;
+        cursor: pointer;
+    }
+
+    .readout {
+        margin-top: 16px;
+        font-family: monospace;
+        color: #6b7280;
+    }
+</style>

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,13 +1,26 @@
 import '@testing-library/jest-dom/vitest'
 import { afterEach, beforeEach, vi } from 'vitest'
 
-// Mock requestAnimationFrame and related timing functions
+// Mock requestAnimationFrame and related timing functions. The mock keeps
+// its own PENDING registry (added on schedule, removed on invoke/cancel):
+// sinon fake timers swap the GLOBAL per test, but motion-dom's frameloop
+// captures this mock at module load, so the frame-loop heal in beforeEach
+// below must reach state the swapped-out global can't provide. A registry
+// of genuinely pending callbacks (rather than vi.fn call records) keeps
+// the heal exact — never re-invoking already-run or cancelled callbacks —
+// and O(1) in memory across long worker runs.
+const pendingRafCallbacks = new Map<number, FrameRequestCallback>()
 global.requestAnimationFrame = vi.fn().mockImplementation((cb: FrameRequestCallback): number => {
-    const handle = setTimeout(() => cb(0 as unknown as DOMHighResTimeStamp), 0)
+    const handle = setTimeout(() => {
+        pendingRafCallbacks.delete(handle as unknown as number)
+        cb(0 as unknown as DOMHighResTimeStamp)
+    }, 0)
     // Return the actual handle, but type it as a number for the DOM signature
+    pendingRafCallbacks.set(handle as unknown as number, cb)
     return handle as unknown as number
 })
 global.cancelAnimationFrame = vi.fn((id: number) => {
+    pendingRafCallbacks.delete(id)
     const handle = id as unknown as NodeJS.Timeout
     clearTimeout(handle)
 })
@@ -15,6 +28,20 @@ global.cancelAnimationFrame = vi.fn((id: number) => {
 // Reset mocks between tests
 beforeEach(() => {
     vi.useFakeTimers()
+    // Heal motion-dom's frame loop. Each test gets a fresh fake clock, so
+    // an rAF scheduled near the end of the PREVIOUS test (e.g. by the
+    // frame.read that MotionValue change-unsubscribers enqueue) is
+    // silently dropped with that test's clock — but the batcher's
+    // `runNextFrame` flag stays true, and `frame.*()` only wakes the
+    // scheduler when the flag is false. Every frame-driven update
+    // (computed values, springs, velocity) in the worker is then frozen.
+    // Invoking the still-pending callbacks processes stale queues and
+    // resets the flag. NOTE: an afterEach flush can't replace this —
+    // processing a keepAlive batch RESCHEDULES it, re-stranding the flag
+    // one layer later.
+    const stale = [...pendingRafCallbacks.values()]
+    pendingRafCallbacks.clear()
+    for (const cb of stale) cb(performance.now())
 })
 
 afterEach(() => {


### PR DESCRIPTION
## Summary

Closes the "vanilla layer" gap from the parity analysis: Motion's component-free value API — `motionValue`, `springValue`, `transformValue`, `mapValue`, the element effects, the frameloop scheduler — now ships from the package root, and **every source-taking API in the library (hooks and vanilla alike) accepts the same three source kinds through one resolver: a `MotionValue`, a Svelte readable, or a reactive rune getter**. That last one is the Svelte-native piece React doesn't have:

```ts
let progress = $state(0)
const opacity = toMotionValue(() => progress / 100)  // $state tracked
styleEffect(el, { opacity })                          // plain div, no components
```

The hooks were deduped onto the same machinery rather than left as parallel implementations — which handed `useSpring`, `useFollowValue`, and `useTransform`'s mapping/transformer forms rune-getter sources for free.

## Changes

- ✨ **`toMotionValue(source)`** — the rune bridge: getters run in an `$effect.root` so `$state`/`$derived` reads are tracked; readables mirror; existing values pass through (idempotent — never double-augments). Manual `.destroy()` tears down the bridge.
- ✨ **Vanilla factories** `motionValue` / `springValue` / `transformValue` / `mapValue`: the same augmented shape the hooks return (rune-reactive `.current`, store `.subscribe`, real motion-dom identity) with manual lifecycle — usable in module scope, `.svelte.ts` stores, and event handlers where `use*` hooks throw `effect_orphan`. `springValue` matches `useSpring`'s full surface (unit strings, `skipInitialAnimation`).
- ✨ **Element effects** `styleEffect` / `attrEffect` / `propEffect` / `svgEffect` re-exported with widened typing: upstream's nominal `MotionValue` signature rejects the augmented TYPE (TypeScript private-field nominal typing) even though the instances are identical — these are runtime passthroughs that accept both flavors.
- ✨ Straight re-exports: `frame`, `cancelFrame`, `frameData`, `spring` generator, `scrollInfo`, `MotionGlobalConfig`, `isMotionValue`, plus `steps`/`mirrorEasing`/`reverseEasing` easings.
- 🔧 **Hooks dedup ("dedup to the strongest variant")**: `useMotionValue` delegates to the vanilla factory; `useTransform`'s five forms build on the factories with its private bridge deleted; `useFollowValue`'s hand-rolled readable bridge (with divergent skip-initial semantics) deleted for the shared resolver. Net: one construction path, one source-resolution path, getter sources everywhere.
- 🐛 **Test-infra fix with repo-wide impact**: motion-dom's frame loop was freezing mid-worker under fake timers — a change-unsubscribe enqueues a `frame.read`, the test's clock drops the scheduled batch, and the batcher's `runNextFrame` flag strands `true` so nothing ever wakes it again (this is what previously forced frame-dependent specs into isolated files). The rAF mock now keeps an exact pending-callback registry and `beforeEach` drains genuinely pending batches. An `afterEach` flush can't replace this — keepAlive batches reschedule themselves.
- 🧪 20 unit specs for the bridge/factories, **8 hook/vanilla parity characterization specs written green against the old implementation and held through the refactor** (auto-destroy on unmount, per-bridge disposal, one-shared-bridge-per-output-map via subscription counting, getter sources on both hooks), and a components-free test page `/tests/vanilla-values` with 4 Playwright specs (mapped translation, spring lag-then-settle, reactive `.current` readouts, event-handler `motionValue`).
- 📚 Docs page `/docs/vanilla-values` (hooks-vs-vanilla lifecycle table, the factories, the rune bridge with its microtask-timing note, element effects, scheduler re-exports) + `/examples/vanilla-values` with show-code source; Motion values overview cross-links; README parity table gains the Vanilla values row.
- 📚 README badge alt text per request.

## Notes for review

- `useSpring` deliberately does NOT delegate to vanilla `springValue` — it wraps the richer `useFollowValue` (SSR guard, other transition types). The dedup went the other direction: `useFollowValue` now uses the shared source resolver.
- A `/simplify` pass (4-agent review) ran mid-branch: it caught the `isPromiseLike`-class issues, an artificial generic constraint that forced six casts, the rAF-mock memory growth, and a misleading lifecycle doc sentence — all fixed here.

## Verification

- 697/697 unit tests (65 files), 4/4 new e2e, `svelte-check` 0 errors, trunk clean, docs production build passing (docs errors hold at the pre-existing 15)
- Docs + example pages driven live: the slider demo runs the full `$state → toMotionValue → mapValue (position + color + shadow) → springValue → styleEffect` chain on a plain div, code viewer loads the source, index card links through

## Commits

- [`ce2913b`](https://github.com/humanspeak/svelte-motion/commit/ce2913b) test(setup): heal motion-dom's frame loop between fake-timer tests
- [`3e5e248`](https://github.com/humanspeak/svelte-motion/commit/3e5e248) feat(values): vanilla motion-value layer with unified rune/readable sources
- [`58e1d1f`](https://github.com/humanspeak/svelte-motion/commit/58e1d1f) chore(readme): describe the tokenmaxing badge as AI tokens used
- [`832affa`](https://github.com/humanspeak/svelte-motion/commit/832affa) docs(values): vanilla motion-values docs page + parity row
- [`486a454`](https://github.com/humanspeak/svelte-motion/commit/486a454) docs(values): color-map the vanilla demo box and add breathing room
- [`056c0a1`](https://github.com/humanspeak/svelte-motion/commit/056c0a1) docs(values): add the Vanilla Values examples page with viewable source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
