### PR TITLE
fix(interaction): honor resolved transition for whileTap gestures

### DIFF
--- a/docs/src/routes/docs/gestures/+page.svx
+++ b/docs/src/routes/docs/gestures/+page.svx
@@ -75,6 +75,21 @@ Animate while the element is being pressed.
 
 `onTap` fires only when the press completes on the element. If the pointer drags off before release, `onTapCancel` fires instead.
 
+### Tuning the tap transition
+
+Without a transition, taps use Motion's per-value defaults — a spring for transforms, which intentionally overshoots rest by a hair on release (the "springy" Framer feel). The resolution order matches Framer: an inline `whileTap.transition` shapes the press, the base variant's `transition` shapes the release, the component `transition` prop (or `<MotionConfig>`) covers both, and per-value defaults fill the rest.
+
+If a transform must **never pass its resting value** — e.g. a `scale` press on an element where any growth is visible — pin the release with a critically damped spring (`bounce: 0`) or an ease-out tween:
+
+```svelte
+<motion.button
+    whileTap={{ scale: 0.95 }}
+    animate={{ scale: 1, transition: { type: 'spring', visualDuration: 0.2, bounce: 0 } }}
+>
+    No overshoot on release
+</motion.button>
+```
+
 ## `whileFocus`
 
 Animate while the element has keyboard focus.

--- a/e2e/motion/rapid-tap.test.ts
+++ b/e2e/motion/rapid-tap.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Regression guard for the tap-transition parity change: the default tap
+ * press/release now delegates to motion-dom's per-value spring defaults instead
+ * of a hardcoded tween. Springs were historically avoided here because rapid
+ * press/release could pump velocity into the spring and cause the scale to run
+ * away (see the old "Hold on run away code" guard in git history). Because every
+ * animate() call reuses the same motion values, velocity is now continuous and
+ * interrupts cleanly — this test hammers the element and asserts the scale stays
+ * bounded and settles back to rest.
+ */
+test.describe('Rapid tap (spring runaway guard)', () => {
+    const readScale = async (box: import('@playwright/test').Locator) => {
+        const t = await box.evaluate((el) => getComputedStyle(el).transform)
+        if (!t || t === 'none') return 1
+        try {
+            if (t.startsWith('matrix(')) {
+                const nums = t
+                    .slice('matrix('.length, -1)
+                    .split(',')
+                    .map((v) => parseFloat(v.trim()))
+                if (nums.length < 4 || nums.slice(0, 4).some((n) => Number.isNaN(n))) return 1
+                return (Math.hypot(nums[0]!, nums[1]!) + Math.hypot(nums[2]!, nums[3]!)) / 2
+            }
+            if (t.startsWith('matrix3d(')) {
+                const nums = t
+                    .slice('matrix3d('.length, -1)
+                    .split(',')
+                    .map((v) => parseFloat(v.trim()))
+                if (nums.length !== 16 || nums.some((n) => Number.isNaN(n))) return 1
+                return (
+                    (Math.hypot(nums[0]!, nums[1]!, nums[2]!) +
+                        Math.hypot(nums[4]!, nums[5]!, nums[6]!)) /
+                    2
+                )
+            }
+            return 1
+        } catch {
+            return 1
+        }
+    }
+
+    test('rapid press/release stays bounded and settles back to rest', async ({ page }) => {
+        await page.goto('/tests/motion/rapid-tap?@isPlaywright=true')
+
+        const box = page.getByTestId('motion-rapid-tap')
+        await expect(box).toBeVisible()
+
+        const bounds = await box.boundingBox()
+        if (!bounds) throw new Error('no bounding box')
+        const cx = bounds.x + bounds.width / 2
+        const cy = bounds.y + bounds.height / 2
+        await page.mouse.move(cx, cy)
+
+        // Hammer press/release at roughly the spring's resonant cadence — the
+        // exact condition that pumped the historical runaway.
+        let maxScale = 1
+        for (let i = 0; i < 25; i++) {
+            await page.mouse.down()
+            await page.waitForTimeout(60)
+            maxScale = Math.max(maxScale, await readScale(box))
+            await page.mouse.up()
+            await page.waitForTimeout(60)
+            maxScale = Math.max(maxScale, await readScale(box))
+        }
+
+        // whileTap is scale: 0.9 (shrinks). No sane spring should ever push the
+        // element meaningfully ABOVE its resting size, and it must never run away.
+        // A generous 1.25 ceiling catches a runaway while tolerating the intended
+        // mild spring overshoot on release.
+        expect(maxScale).toBeLessThan(1.25)
+
+        // After the final release, the spring must settle back to rest (~1).
+        await expect.poll(() => readScale(box), { timeout: 2000 }).toBeGreaterThan(0.97)
+        await expect.poll(() => readScale(box), { timeout: 2000 }).toBeLessThan(1.03)
+    })
+})

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -2468,7 +2468,8 @@
                 hoverDef: isNotEmpty(resolvedWhileHover ?? {})
                     ? ((resolvedWhileHover ?? {}) as Record<string, unknown>)
                     : undefined,
-                hoverFallbackTransition: (mergedTransition ?? {}) as AnimationOptions
+                hoverFallbackTransition: (mergedTransition ?? {}) as AnimationOptions,
+                tapTransition: (mergedTransition ?? {}) as AnimationOptions
             }
         )
     })

--- a/src/lib/utils/interaction.spec.ts
+++ b/src/lib/utils/interaction.spec.ts
@@ -112,6 +112,102 @@ describe('utils/interaction', () => {
         expect(animateMock.mock.calls.length).toBe(callsAfterCleanup)
     })
 
+    it('attachWhileTap: delegates to motion per-value defaults when no transition is set', async () => {
+        const el = document.createElement('div')
+        animateMock.mockClear()
+        const cleanup = attachWhileTap(el, { scale: 0.95 }, { scale: 1 }, {})
+
+        const onPressEnd = pressCallback!(el, new PointerEvent('pointerdown'))
+        onPressEnd!(new PointerEvent('pointerup'), { success: true })
+        await Promise.resolve()
+
+        // With no inline / component / <MotionConfig> transition, we must pass
+        // NONE through so motion-dom applies its own per-value defaults (spring
+        // for scale + other transforms, ease for the rest) — exact framer parity.
+        // Injecting a hand-rolled ease here would diverge from upstream tuning.
+        expect(animateMock.mock.calls.length).toBeGreaterThanOrEqual(2)
+        for (const call of animateMock.mock.calls) {
+            const t = call[2] as Record<string, unknown> | undefined
+            expect(t == null || Object.keys(t).length === 0).toBe(true)
+        }
+        cleanup()
+    })
+
+    it('attachWhileTap: honors the component transition prop for press and release', async () => {
+        const el = document.createElement('div')
+        animateMock.mockClear()
+        // Represents a component `transition` prop or a page-wide <MotionConfig>
+        // transition (mergedTransition) — framer retimes taps with it.
+        const tapTransition = { type: 'tween' as const, duration: 0.12 }
+        const cleanup = attachWhileTap(el, { scale: 0.95 }, { scale: 1 }, {}, { tapTransition })
+
+        const onPressEnd = pressCallback!(el, new PointerEvent('pointerdown'))
+        expect(animateMock.mock.calls.at(-1)?.[2]).toMatchObject(tapTransition)
+        onPressEnd!(new PointerEvent('pointerup'), { success: true })
+        await Promise.resolve()
+        expect(animateMock.mock.calls.at(-1)?.[2]).toMatchObject(tapTransition)
+        cleanup()
+    })
+
+    it('attachWhileTap: inline whileTap.transition drives the press and beats the component prop', async () => {
+        const el = document.createElement('div')
+        animateMock.mockClear()
+        const inline = { type: 'spring' as const, stiffness: 700 }
+        const tapTransition = { type: 'tween' as const, duration: 0.5 }
+        const cleanup = attachWhileTap(
+            el,
+            { scale: 0.95, transition: inline } as unknown as Record<string, unknown>,
+            { scale: 1 },
+            {},
+            { tapTransition }
+        )
+
+        const onPressEnd = pressCallback!(el, new PointerEvent('pointerdown'))
+        await Promise.resolve()
+        const press = animateMock.mock.calls.at(-1)
+        // Inline transition wins for the press (entering the tap state)...
+        expect(press?.[2]).toMatchObject(inline)
+        // ...and the inline `transition` key must not leak into the keyframes.
+        expect((press?.[1] as Record<string, unknown>).transition).toBeUndefined()
+        expect(press?.[1]).toMatchObject({ scale: 0.95 })
+
+        // Release animates back to the base variant → uses the component
+        // transition, not the inline (tap-entry) one.
+        onPressEnd!(new PointerEvent('pointerup'), { success: true })
+        await Promise.resolve()
+        expect(animateMock.mock.calls.at(-1)?.[2]).toMatchObject(tapTransition)
+        cleanup()
+    })
+
+    it("attachWhileTap: release honors the base variant's inline transition over the component prop", async () => {
+        const el = document.createElement('div')
+        animateMock.mockClear()
+        const animateInline = { type: 'spring' as const, bounce: 0, visualDuration: 0.2 }
+        const tapTransition = { type: 'tween' as const, duration: 0.5 }
+        const cleanup = attachWhileTap(
+            el,
+            { scale: 0.95 },
+            { scale: 1 },
+            { scale: 1, transition: animateInline } as unknown as Record<string, unknown>,
+            { tapTransition }
+        )
+
+        const onPressEnd = pressCallback!(el, new PointerEvent('pointerdown'))
+        // Press has no inline whileTap.transition → component prop applies.
+        expect(animateMock.mock.calls.at(-1)?.[2]).toMatchObject(tapTransition)
+
+        onPressEnd!(new PointerEvent('pointerup'), { success: true })
+        await Promise.resolve()
+        const release = animateMock.mock.calls.at(-1)
+        // Release returns to the base (animate) variant, so ITS inline
+        // transition wins — this is how a consumer pins a no-overshoot
+        // return (e.g. bounce: 0) without changing the press feel.
+        expect(release?.[2]).toMatchObject(animateInline)
+        // The base variant's `transition` key must not leak into the reset keyframes.
+        expect((release?.[1] as Record<string, unknown>).transition).toBeUndefined()
+        cleanup()
+    })
+
     it('attachWhileTap: negative - no-op when whileTap is undefined', () => {
         const el = document.createElement('div')
         const cleanup = attachWhileTap(el, undefined)
@@ -284,8 +380,8 @@ describe('utils/interaction', () => {
         await Promise.resolve()
         const last = animateMock.mock.calls.at(-1)
         expect(last?.[1]).toMatchObject({ scale: 1.2 })
-        // Uses releaseTransition (tween with overshoot) to prevent velocity accumulation
-        expect(last?.[2]).toMatchObject({ duration: 0.3 })
+        // Reapplying hover uses the hover definition's own transition.
+        expect(last?.[2]).toMatchObject({ duration: 0.12 })
         cleanup()
         vi.unstubAllGlobals()
     })
@@ -470,8 +566,8 @@ describe('utils/interaction', () => {
         await Promise.resolve()
         const last = animateMock.mock.calls.at(-1)
         expect(last?.[1]).toMatchObject({ scale: 1.2 })
-        // Uses releaseTransition (tween with overshoot) to prevent velocity accumulation
-        expect(last?.[2]).toMatchObject({ duration: 0.3 })
+        // Reapplying hover uses the hover definition's own transition.
+        expect(last?.[2]).toMatchObject({ duration: 0.12 })
         cleanup()
         vi.unstubAllGlobals()
     })

--- a/src/lib/utils/interaction.ts
+++ b/src/lib/utils/interaction.ts
@@ -95,17 +95,54 @@ export const attachWhileTap = (
         onTapCancel?: () => void
         hoverDef?: Record<string, unknown> | undefined
         hoverFallbackTransition?: AnimationOptions | undefined
+        /** The component's resolved `transition` (or `<MotionConfig>` transition) —
+         *  honored for the tap gesture (framer parity). When empty, the gesture
+         *  passes no transition so motion-dom applies its per-value defaults. */
+        tapTransition?: AnimationOptions | undefined
     }
 ): (() => void) => {
     if (!whileTap) return () => {}
 
     pwLog('[tap] attached', { whileTap, initial, animateDef, hasHoverDef: !!callbacks?.hoverDef })
 
-    // Tween transitions prevent spring velocity accumulation during rapid
-    // press/release cycles. Cubic-bezier with slight overshoot mimics the
-    // reference spring feel (~275ms settle, ~7% overshoot).
-    const pressTransition: AnimationOptions = { duration: 0.25, ease: [0.22, 1.1, 0.36, 1] }
-    const releaseTransition: AnimationOptions = { duration: 0.3, ease: [0.22, 1.1, 0.36, 1] }
+    // Split any inline `transition` out of the whileTap definition (mirrors
+    // splitHoverDefinition) so it never leaks into the animated keyframes and
+    // can be honored as the press transition.
+    const { transition: inlineTapTransition, ...tapKeyframes } = whileTap as {
+        transition?: AnimationOptions
+    } & Record<string, unknown>
+
+    // Resolve the gesture transition with framer-motion's precedence:
+    //   1. inline `whileTap.transition` — configures entering the tap state (press only)
+    //   2. the component's resolved `transition` / <MotionConfig> (via `tapTransition`)
+    //   3. undefined → motion-dom applies its own per-value defaults:
+    //        scale           → spring(stiffness 550, damping 30)  (mild ~7% overshoot)
+    //        x / y / rotate… → spring(stiffness 500, damping 25)
+    //        everything else → ease [0.25, 0.1, 0.35, 1] over 0.3s
+    //      Passing no transition is exact framer parity (including the intended
+    //      spring overshoot on transforms) and inherits future upstream tuning
+    //      for free. See upstream:
+    //        motion-dom/src/animation/utils/default-transitions.ts        (getDefaultTransition)
+    //        motion-dom/src/animation/interfaces/motion-value.ts          (per-value application)
+    //        motion-dom/src/animation/interfaces/visual-element-target.ts (component-transition precedence)
+    //      The historical spring "runaway" (see git history around the old
+    //      hardcoded tweens) does not recur: every animate() call reuses the
+    //      same motion values, so velocity is continuous and rapid press/release
+    //      interrupts cleanly instead of accumulating. Covered by a rapid-tap e2e.
+    const componentTapTransition =
+        callbacks?.tapTransition && Object.keys(callbacks.tapTransition).length > 0
+            ? callbacks.tapTransition
+            : undefined
+    // Press honors an inline whileTap.transition (framer applies it only when
+    // entering the tap state). Release animates back to the BASE variant, so
+    // upstream resolves ITS inline transition (`animate={{ ..., transition }}`)
+    // first, then the component transition, then the per-value defaults.
+    const animateInlineTransition = (animateDef as { transition?: AnimationOptions } | undefined)
+        ?.transition
+    const pressTransition: AnimationOptions | undefined =
+        (inlineTapTransition as AnimationOptions | undefined) ?? componentTapTransition
+    const releaseTransition: AnimationOptions | undefined =
+        animateInlineTransition ?? componentTapTransition
 
     // Motion's animate() returns AnimationPlaybackControls (not native Animation).
     type GestureCtl = {
@@ -149,7 +186,7 @@ export const attachWhileTap = (
         callbacks?.onTapStart?.()
         gestureCtl = animate(
             el,
-            whileTap as unknown as DOMKeyframesDefinition,
+            tapKeyframes as unknown as DOMKeyframesDefinition,
             pressTransition
         ) as unknown as GestureCtl
         Promise.resolve(gestureCtl?.finished)
@@ -181,16 +218,21 @@ export const attachWhileTap = (
             pwLog('[tap] hover-reapply-skip', { reason: 'matches threw' })
             return false
         }
-        const { keyframes } = splitHoverDefinition(callbacks.hoverDef as Record<string, unknown>)
+        const { keyframes, transition: hoverTransition } = splitHoverDefinition(
+            callbacks.hoverDef as Record<string, unknown>
+        )
         pwLog('[tap] hover-reapply', {
             keyframes,
             transform: getComputedStyle(el).transform,
             w: el.getBoundingClientRect().width
         })
+        // Reapplying hover after a tap animates to the hover state, so it should
+        // use the hover definition's own transition when provided, falling back
+        // to the release transition (component prop → per-value defaults).
         gestureCtl = animate(
             el,
             keyframes as unknown as DOMKeyframesDefinition,
-            releaseTransition
+            hoverTransition ?? releaseTransition
         ) as unknown as GestureCtl
         Promise.resolve(gestureCtl?.finished)
             .then(() =>
@@ -219,7 +261,7 @@ export const attachWhileTap = (
         // If still hovering after a successful tap, animate to hover state
         if (success && reapplyHoverIfActive()) return
 
-        const resetRecord = buildTapResetRecord(initial ?? {}, animateDef ?? {}, whileTap ?? {})
+        const resetRecord = buildTapResetRecord(initial ?? {}, animateDef ?? {}, tapKeyframes)
         pwLog('[tap] reset-record', resetRecord)
         if (Object.keys(resetRecord).length > 0) {
             gestureCtl = animate(

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -144,6 +144,14 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/motion/rapid-tap') + searchParams}
+                    >
+                        Rapid Tap (spring runaway guard)
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/motion/while-focus') + searchParams}
                     >
                         While Focus

--- a/src/routes/tests/motion/rapid-tap/+page.svelte
+++ b/src/routes/tests/motion/rapid-tap/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import { motion } from '$lib'
+</script>
+
+<!--
+    Tap-only target (no whileHover) used to validate that delegating the tap
+    press/release to motion-dom's per-value spring defaults does NOT reintroduce
+    the historical "velocity accumulation" runaway during rapid press/release.
+-->
+<motion.button
+    whileTap={{ scale: 0.9 }}
+    data-testid="motion-rapid-tap"
+    style="width: 120px; height: 120px; background-color: #22aa66; border: none; border-radius: 12px; cursor: pointer;"
+>
+    tap
+</motion.button>


### PR DESCRIPTION
## Summary

`whileTap` ignored every resolved transition — a component `transition` prop, a page-wide `<MotionConfig>`, an inline `whileTap.transition`, and the base variant's transition all had no effect. Both press and release ran a hardcoded cubic-bezier (`[0.22, 1.1, 0.36, 1]`), a tween pretending to be a spring that matched neither framer's spring feel nor a clean settle. This resolves the transition with framer-motion's real precedence and, when nothing is set, delegates to motion-dom's per-value spring defaults for exact upstream parity.

## Changes

🐛 **Resolve the tap transition with framer's precedence** (`src/lib/utils/interaction.ts`)
- **press:** inline `whileTap.transition` → component / `<MotionConfig>` → per-value defaults
- **release:** base variant `animate` transition → component / `<MotionConfig>` → per-value defaults
- when none is set, pass **no** transition so motion-dom applies its own per-value defaults (scale/other-transform springs, ease for the rest) — inheriting upstream tuning for free
- inline `whileTap.transition` is split out (mirrors `splitHoverDefinition`) so it drives the press and never leaks into the animated keyframes
- hover-reapply-after-tap now honors the hover definition's own `transition`

🔧 **Wire the resolved transition through** (`src/lib/html/_MotionContainer.svelte`)
- forward `mergedTransition` as `tapTransition` into `attachWhileTap`

🧪 **Prove the historical spring runaway does not recur**
- the hardcoded tweens originally existed to dodge a spring "velocity accumulation" runaway during rapid press/release; that was tied to now-removed manual transform rebasing (motion values are reused across taps, so velocity is continuous)
- new tap-only demo page + rapid-tap e2e hammers 25 press/release cycles at the spring's resonant cadence and asserts scale stays bounded and settles to rest
- unit tests: no-transition delegates to defaults; component transition honored for press + release; inline `whileTap.transition` drives press (beats component prop, no keyframe leak); base variant transition drives release

📚 **Docs**
- document tap-transition tuning under `docs/gestures`

### Upstream fidelity (verified against `~/Github/motion`)
- `motion-dom/.../utils/default-transitions.ts` — `getDefaultTransition` (per-value scale/transform/ease defaults)
- `motion-dom/.../interfaces/motion-value.ts` — applies defaults per value when none is defined
- `motion-dom/.../interfaces/visual-element-target.ts` — component `transition` precedence
- `motion-dom/.../generators/spring.ts:260` — confirms scale's `stiffness 550 / damping 30` is **underdamped** (dampingRatio ≈ 0.64, ~7% overshoot **by design**), not critically damped

> **Behavior change:** the default tap feel is now framer's spring (a slight, intended overshoot on transforms) instead of the old hand-rolled tween. Consumers who want a monotonic settle can pin the release via the base variant (`animate={{ scale: 1, transition: { type: 'spring', bounce: 0 } }}`) or pass any `transition`.

## Commits

- [`cc0a9cd`](https://github.com/humanspeak/svelte-motion/commit/cc0a9cd) fix(interaction): honor resolved transition for whileTap, delegate to motion springs
