### PR TITLE
feat(svg): bind MotionValues to SVG attributes, add attrX/attrY/attrScale

### DIFF
--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard-report.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard-report.md
@@ -80,16 +80,18 @@ primitives, no.
 
 The plan existed because a `MotionValue` passed as any non-path SVG attribute
 was spread raw and stringified as `[object Object]`, and because `attrX/attrY/attrScale`
-did not exist. Both are closed, and the e2e asserts the absence of `[object Object]`
-in the hydrated DOM _and_ in the raw SSR payload (`request.get`, not a hydrated
-snapshot). Scroll-linked rings, chart lines, and filter primitives now work.
+did not exist. The `attr*` family is closed, and the e2e asserts the absence of
+`[object Object]` in the hydrated DOM _and_ in the raw SSR payload (`request.get`, not a
+hydrated snapshot) — but only for the keys the demo exercises. Scroll-linked rings and
+chart lines work. Filter primitives work **only** through `attrScale`; a bare
+`stdDeviation={mv}` still stringifies (Blocker 1).
 
 The work also exceeded the plan in one way that matters: it fixed SVG **tag-name**
 casing (revision (b), operator-approved). `motion.fedisplacementmap` was rendering an
 inert generic `SVGElement` — the filter primitive was silently ignored. That was never
 in the original plan and would have blocked Plan 005.
 
-## Done criteria — every one re-run at `8f51399`, not trusted
+## Done criteria — every one re-run at `8f51399` (all green, and insufficient — see Blocker 1)
 
 | #   | Criterion                                           | Result                                                        |
 | --- | --------------------------------------------------- | ------------------------------------------------------------- |

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard-report.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard-report.md
@@ -1,220 +1,155 @@
 # Guard close-out report — 002 Bind MotionValues to SVG presentation attributes
 
-- **Verdict**: **NO-PASS** — retracted from PASS on 2026-07-09 after a CodeRabbit
-  review surfaced a functional bug that every done criterion missed. See
-  **Blocker 1**. PR #441 is open but **must not merge** until it is fixed.
-- **Date**: 2026-07-09 (revised same day)
+- **Verdict**: **PASS**
+- **Date**: 2026-07-09 (supersedes the same-day NO-PASS; both blockers closed)
 - **Plan**: `002-svg-motionvalue-attributes.md` (`Planned at` `9557778`, revision (b))
-- **Snapshot reviewed**: `54b7620` on `feat/svg-motion-value-attributes`
-  (source gates run at `8f51399`; `54b7620` is a docs-only follow-up — see Late edit)
+- **Snapshot reviewed**: `1f593e2` on `feat/svg-motion-value-attributes`
 - **Base**: `3b16d0a` (merge-base with `main`)
 - **PR**: <https://github.com/humanspeak/svelte-motion/pull/441> (open, unmerged)
 
-## Blocker 1 — filter-primitive attributes still render `[object Object]`
-
-**This is the exact failure `Why this matters` exists to eliminate, on the exact
-elements Plan 005 depends on.** Found by CodeRabbit, reproduced by guard.
-
-`SVG_ATTRIBUTE_PROPERTIES` (`svg.ts:34-69`) never claims the filter-primitive
-attributes, so a `MotionValue` on one falls through to `staticAttrs` and hits the raw
-spread. Reproduced against the real module:
-
-```text
-stdDeviation    claimed: false      numOctaves  claimed: false
-baseFrequency   claimed: false      dx / dy     claimed: false   (feOffset)
-radius          claimed: false      cx          claimed: true
-
-extractSVGMotionValueAttributes({ stdDeviation: motionValue(4) })
-  motionValueAttrs: []
-  staticAttrs     : ['stdDeviation']
-  rendered as     : stdDeviation="[object Object]"
-```
-
-Why every gate missed it: the demo drives `feDisplacementMap` through **`attrScale`**,
-which takes the `attr`-prefix branch and works. No demo, e2e, or unit case ever passes a
-MotionValue on a bare filter-primitive key through classification.
-
-The plan's own v2 ruling named these keys: _"the filter-primitive entries
-(`baseFrequency`, `numOctaves`, `stdDeviation`) are exactly what Plan 005's
-`feTurbulence` work will drive through this path."_ They reach the SSR casing gate
-correctly and were unit-tested there — but they never get **claimed**, so the gate is
-never called for them.
-
-**Fix**: extend the allowlist with the filter-primitive keys, or resolve against
-`camelCaseAttributes` before the final `isSVGMotionValueAttribute` check.
-
-## Blocker 2 — two tests create false confidence
-
-- `svg.spec.ts:547` ("should honor upstream camelCase entries beyond the ones we
-  hand-picked") passes `stdDeviation`/`baseFrequency`/`numOctaves` **directly** to
-  `computeSSRSVGAttrValues`, bypassing `extractSVGMotionValueAttributes`. It reads as
-  filter-primitive coverage and is why Blocker 1 hid in plain sight. Route the same keys
-  through classification.
-- `+page.svelte:297` binds the `highlight` class to the **`mv-circle`** `<svg>`, while
-  `attr-rect` lives in a separate `<svg>` at `:374-390`. The e2e
-  _"an unrelated re-render does not clobber attribute-routed values"_
-  (`spec.ts:~330-337`) toggles it and then asserts on `attr-rect` — so it can pass even
-  if the clobbering bug returns. Move the class onto the `attr-rect` subtree or a shared
-  ancestor.
-
-Non-blocking nits from the same review: `role="toolbar"` missing on the demo's
-`aria-label`led `div`; docs snippets aren't copy-paste self-contained; an SSR doc comment
-at `spec.ts:33-36` describes output that `computeSSRSVGAttrValues` doesn't produce;
-`attrY`/`attrScale` lack the JSDoc `@example` that `attrX` has (repo convention requires
-`@param`/`@returns`/`@example` on `src/lib/utils/*.ts`).
-
-## What guard got wrong
-
-Every done criterion passed and the work still fails `Why this matters` on filter
-primitives. That is "in-scope but beside the point," and the final gate did not catch
-it: guard verified the _channel split_ and the _casing gate_ exhaustively, and checked
-that `attrScale` reached `feDisplacementMap`, but never asked whether a bare
-filter-primitive key survives classification. The `attrScale` demo made the filter path
-look covered. A green suite is not coverage — this is the same lesson Findings 3 and 8
-taught, missed a third time.
-
 ## Does it deliver `Why this matters`?
 
-Partially — see Blocker 1. For shape geometry and the `attr*` family, yes. For filter
-primitives, no.
+Yes, now including the case that broke the previous gate. A `MotionValue` bound to any
+non-path SVG attribute reaches its element instead of stringifying as `[object Object]`
+— shape geometry (`cx`, `r`, `x2`), the `stroke-*` family, `attrX/attrY/attrScale`, and
+**filter primitives** (`stdDeviation`, `baseFrequency`, `numOctaves`, `dx`, `dy`,
+`radius`). Plan 005's `feTurbulence`/`feOffset` dependency is unblocked.
 
-The plan existed because a `MotionValue` passed as any non-path SVG attribute
-was spread raw and stringified as `[object Object]`, and because `attrX/attrY/attrScale`
-did not exist. The `attr*` family is closed, and the e2e asserts the absence of
-`[object Object]` in the hydrated DOM _and_ in the raw SSR payload (`request.get`, not a
-hydrated snapshot) — but only for the keys the demo exercises. Scroll-linked rings and
-chart lines work. Filter primitives work **only** through `attrScale`; a bare
-`stdDeviation={mv}` still stringifies (Blocker 1).
+Beyond the original plan, the work also fixed case-sensitive SVG **tag names**
+(revision (b)): `motion.fedisplacementmap` had been rendering an inert generic
+`SVGElement`, silently discarding every filter primitive created client-side.
 
-The work also exceeded the plan in one way that matters: it fixed SVG **tag-name**
-casing (revision (b), operator-approved). `motion.fedisplacementmap` was rendering an
-inert generic `SVGElement` — the filter primitive was silently ignored. That was never
-in the original plan and would have blocked Plan 005.
+## Done criteria — every one re-run at `1f593e2`, not trusted
 
-## Done criteria — every one re-run at `8f51399` (all green, and insufficient — see Blocker 1)
+| #   | Criterion                                       | Result                                                 |
+| --- | ----------------------------------------------- | ------------------------------------------------------ |
+| 1   | `pnpm check` exits 0                            | **PASS** — 0 errors, 32 pre-existing warnings          |
+| 2   | `pnpm test`; new `svg.spec.ts` cases pass       | **PASS** — 66 files, 752/752 (+7 since the NO-PASS)    |
+| 3   | `pnpm exec playwright test e2e/svg`             | **PASS** — full suite: 317 passed, 2 skipped, 0 failed |
+| 4   | Demo route exists and is linked                 | **PASS**                                               |
+| 5   | Docs page + nav entry; sitemap regenerated      | **PASS on intent** — see Plan defect 1                 |
+| 6   | No modified files outside the in-scope list     | **PASS** — scope audit `3b16d0a...1f593e2` exact       |
+| 7   | Batch README status row updated                 | **PASS** — 002 → DONE                                  |
+| 8   | Tag-casing asserted on a client-created element | **PASS** — verified non-vacuous at the prior gate      |
 
-| #   | Criterion                                           | Result                                                        |
-| --- | --------------------------------------------------- | ------------------------------------------------------------- |
-| 1   | `pnpm check` exits 0                                | **PASS** — 0 errors, 32 pre-existing warnings                 |
-| 2   | `pnpm test`; new `svg.spec.ts` cases pass           | **PASS** — 66 files, 745/745                                  |
-| 3   | `pnpm exec playwright test e2e/svg`                 | **PASS** — full suite re-run: 315 passed, 2 skipped, 0 failed |
-| 4   | Demo route exists and is linked                     | **PASS** — `src/routes/+page.svelte`                          |
-| 5   | Docs page exists w/ nav entry; sitemap regenerated  | **PASS on intent** — see Plan defect 1                        |
-| 6   | No modified files outside the in-scope list         | **PASS** — scope audit `3b16d0a...8f51399` exact              |
-| 7   | Batch README status row updated                     | **PASS** — 002 → DONE                                         |
-| 8   | Tag-casing asserted on a **client-created** element | **PASS** — independently verified non-vacuous (below)         |
+The 2 e2e skips are pre-existing (`e2e/drag/single-frame.spec.ts:20`,
+`e2e/motion/svg-path-length.test.ts:149`), in files this branch never touched.
+`pnpm --filter docs check` → 0 errors. `trunk check` → no issues, 17 files.
 
-The 2 e2e skips (`e2e/drag/single-frame.spec.ts:20` `test.fixme`,
-`e2e/motion/svg-path-length.test.ts:149` `test.skip`) are pre-existing — neither file
-is touched by this branch. `trunk check` → no issues across 16 modified files.
+## Blocker 1 — closed, and the fix was verified by reverting it
 
-## Finding 8 (prior checkpoint) — verified closed, by experiment
+`isSVGMotionValueAttribute` (`svg.ts:107-115`) now resolves in a deliberate order:
 
-The earlier checkpoint found the tag-casing tests vacuous: they asserted on the
-first-paint node, which the HTML parser creates and silently case-corrects, and which
-Svelte reuses when hydrating
-(`svelte/src/internal/client/dom/blocks/svelte-element.js:74`).
+1. path props rejected **first**;
+2. `attr`-prefixed props accepted;
+3. **motion-dom's exported `camelCaseAttributes`** consulted;
+4. local allowlist last, for the lowercase/kebab names upstream cannot express.
 
-The executor's fix adds `await remount(page)` before asserting. Guard did **not** take
-that on trust. In a throwaway `git worktree` (the real tree untouched), the fix was
-reverted (`this={renderTag}` → `this={tag}`, 4 sites) and the test re-run:
+Step 1 preceding step 3 is load-bearing — `pathLength` is a member of
+`camelCaseAttributes`, and claiming it would double-write `stroke-dasharray`. This is
+pinned by `svg.spec.ts:528` ("should still refuse pathLength even though
+camelCaseAttributes lists it"), which passes.
+
+No vendored copy: `grep baseFrequency src/lib/utils/svg.ts` → one hit, in a JSDoc line.
+The set itself is imported. `dx`/`dy`/`radius` are added explicitly because upstream's
+set holds camelCase names only — pinned by a unit case asserting they are **absent**
+from `camelCaseAttributes`, so nobody later assumes the import covers them.
+
+Guard did not take the fix on trust. In a throwaway worktree the `camelCaseAttributes`
+lookup and the three lowercase keys were removed, and both new e2e tests **failed**:
+
+```text
+2 failed
+  › binds a MotionValue to a filter primitive attribute
+  › server-renders a filter primitive attribute without stringifying it
+```
+
+## Blocker 2 — closed, both tests verified non-vacuous
+
+- The SSR unit case now routes filter keys through `extractSVGMotionValueAttributes`
+  rather than straight into `computeSSRSVGAttrValues`. It went red without the fix
+  (5 failures at `22ed10e`), green with it.
+- The clobber e2e now marks `attr-rect`'s subtree with `data-highlight` and changes the
+  motion element's own `class`, and **asserts its own premise**
+  (`rect.closest('[data-highlight="true"]')`) before checking `x`. Reverting only the
+  fixture makes it fail:
 
 ```text
 1 failed
-  › renders camelCase SVG tags with their case-sensitive spec spelling
-  expect(info.tagName).toBe('feDisplacementMap')   // spec.ts:186
+  › an unrelated re-render does not clobber attribute-routed values
 ```
 
-The test now genuinely detects the bug it was written for. Worktree removed; the real
-working tree was never modified.
+That self-assertion is the durable part: the old test lied because nothing forced the
+toggle to reach the element under test.
 
-## Findings 1-7 — all closed
+## A relaxed assertion, examined and accepted
 
-- **1, 2** (e2e polled `getAttribute('cx')` for style-routed keys; `Number("12.5px")`
-  → `NaN`): fixed. e2e reads `getComputedStyle(...).getPropertyValue(prop)` and
-  `parseFloat` throughout.
-- **3** (vacuous static-attribute assertion): fixed with the reasoning inlined —
-  `spec.ts:292-294` reads the style channel and comments _"Asserting the attribute is
-  unchanged would pass even if the subscription were broken."_
-- **4** (React camelCase allowlist would let `stroke-width={mv}` render
-  `[object Object]`): fixed; kebab spellings allowlisted and unit-tested.
-- **5** (SSR emitted inert `strokeDashoffset`): fixed via the upstream casing gate.
-- **6** (gate-vs-`attr`-prefix ordering — `attrX` must never emit `attr-x`): fixed at
-  `svg.ts:169-170`, `resolveSVGAttrKey` **then** the gate; unit-pinned at
-  `svg.spec.ts:542-544` (`not.toHaveProperty('attr-x')`).
-- **7** (v1 ruling mandated a read-back test with no caller): respected —
-  `grep -c getAttribute src/lib/utils/svg.ts` → **0**. No dead read-back path was built.
+The executor widened the SSR check from `/stdDeviation="[\d.]+"/` to a case-insensitive
+match, with a story attached. Weakening a test to fit observed output is the classic
+laundering move, so guard verified the story rather than the diff.
 
-## Upstream fidelity
+It holds. Svelte's SSR spread lowercases attribute names — the live payload really is
+`<feGaussianBlur ... stddeviation="2">` (tag name preserved, attribute lowercased). The
+HTML parser's SVG attribute-adjustment table maps it back, confirmed in Chromium:
 
-`camelCaseAttributes` and `camelToDash` are **imported from `motion-dom`**
-(`svg.ts:1-7`), not vendored, so upstream additions track on version bumps — exactly
-what the v2 ruling required. Installed `motion-dom` is `12.42.2`, the version the
-ruling was made against.
+```text
+setContent('<svg><filter><feGaussianBlur stddeviation="2">…')
+  getAttributeNames() -> ['data-testid','in','stdDeviation']
+  stdDeviationX.baseVal -> 2      (also baseFrequency, numOctaves)
+```
+
+So there is no inert attribute and no hydration flash. The test still forbids
+`std-deviation=`, the one casing no parser would rescue, and the client-DOM test asserts
+`stdDeviationX.baseVal` after a live update. The property under test survived; only the
+over-specific spelling was dropped. Accepted.
+
+## Findings 1-8 — all closed
+
+1, 2 (wrong DOM channel; `Number("12.5px")` → `NaN`), 3 (vacuous static assertion),
+4 (React camelCase allowlist), 5 (inert `strokeDashoffset` in SSR), 6 (`attrX` → `attr-x`
+ordering), 7 (read-back path with no caller — respected: `grep -c getAttribute
+src/lib/utils/svg.ts` → **0**), 8 (tag test asserted on a parser-created node).
 
 ## Plan defect 1 — criterion 5's sitemap command no longer exists (not executor drift)
 
-Step 4 says `Regenerate sitemap: pnpm --filter docs sitemap:manifest`. That script is
-gone: `docs/package.json` has no sitemap script, `docs/src/lib/sitemap-manifest.json`
-is gitignored (`docs/.gitignore:36`) and emitted by a docs vite plugin at build time.
+Step 4 says `pnpm --filter docs sitemap:manifest`; no such script exists.
+`docs/src/lib/sitemap-manifest.json` is gitignored (`docs/.gitignore:36`) and emitted by
+a docs vite plugin at build. Verified on intent: the manifest contains `svg-animation`
+(2 entries) and docs check is clean. Plan text is stale, the work is not. **Not amended**
+— nothing needed lowering to reach PASS.
 
-Guard verified the **intent** rather than the command: the on-disk manifest contains
-`svg-animation` (2 entries — docs + examples), and `pnpm --filter docs check` → 0
-errors. So the criterion's purpose is satisfied and no work is missing. The plan text
-is stale, not the work. Not amended — guard does not amend without operator agreement,
-and nothing here needed lowering to reach PASS.
+## Environment hazard worth fixing (outside this plan)
 
-**Recommended (optional) amendment**: reword criterion 5 to "docs page + nav entry
-exist; sitemap manifest regenerates on build and contains the new routes."
+`playwright.config.ts:21` sets `reuseExistingServer: !process.env.CI`. During this gate,
+a stale preview server left over on port 4198 caused a worktree run with the fix
+**reverted** to pass — it was silently served the old, fixed build. Guard caught it via
+`lsof` and re-ran with `CI=1`, which produced the correct failures. Any local e2e run can
+be validated against a stale build this way. The port pin (4198) prevents cross-repo
+collisions but not stale-server reuse.
 
-## Quality notes (unprompted improvements worth keeping)
+## Quality notes
 
-- The old `renders attrScale as the scale attribute` test asserted `scale` on a
-  `<rect>`, where the attribute is inert. Replaced with a `feDisplacementMap` case that
-  reads `scale.baseVal` through the SVG IDL, plus `expect(scale).not.toContain('px')`
-  pinning the unitless `numberValueTypes` entry.
-- The docs page teaches the two-channel split honestly, including the devtools trap:
-  _"the attribute you see in devtools is the initial server-rendered value"_
-  (`+page.svx:46-65`). A user debugging a "stuck" `cx` will find the answer.
-- `SVG_TAG_CASING` covers the full SVG 2 case-sensitive element set; the omitted names
-  (`altGlyph*`, `glyphRef`, `font-face-*`) are SVG 1.1 elements removed from SVG 2.
+- `attrScale`'s JSDoc example correctly uses `<feDisplacementMap>`, the only element
+  where the attribute means anything.
+- CodeRabbit's SSR doc-comment finding was a **false positive**, rejected with evidence:
+  SSR emits `x="10"` (raw stringify) while the client's `addAttrValue` applies the px
+  value type (`x="10px"`). The comment sits on the client reader and was already right.
+  The executor then improved it to document both.
 
 ## Process notes
 
-- The plan was twice amended by the **advisor** rather than guard (the "upstream
-  ruling"). Not tampering — the executor never touched the plan, and the operator
-  surfaced both. Recorded because v1 of that ruling shipped three defects that only
-  independent verification caught (a wrong entry count, an omitted public export, and
-  the `attr-x` ordering bug).
-- Two commits were made with `--no-verify` (`af90f5a`, `b932936`) under explicit
-  operator authorization, because the repo's pre-commit `svelte-check` cannot pass on a
-  knowingly-red test-first commit. Both messages record the reason.
-- `8f51399` was committed by the maintainer concurrently with guard's checkpoint rather
-  than by guard. No content impact — the snapshot is complete and the tree is clean.
-
-### Late edit — caught at the PR preflight
-
-After the gates passed at `8f51399`, the `pr` preflight found the tree dirty again: two
-docs files had been edited under guard. Publication was stopped rather than pushed over
-unreviewed work. The diff was read (`docs/.../demos/Default.svelte`,
-`docs/.../svg-animation/+page.svx`): cosmetic typography only — `<strong>`/`<code>` in
-the embedded demo were losing to `.prose-v2`'s rules on cascade order, plus dropping
-`isSmall`. `git diff --name-only -- src/ e2e/` → **0 files**, so no source gate was
-invalidated. Snapshotted as `54b7620`; the two gates it could affect were re-run:
-`pnpm --filter docs check` → 0 errors, `trunk check` → no issues (17 files).
+- Two commits used `--no-verify` (`af90f5a`, `b932936`, plus `22ed10e`) under explicit
+  operator authorization: the pre-commit `svelte-check` cannot pass on a knowingly-red
+  test-first commit. Each message records the reason.
+- The plan was twice amended by the advisor rather than guard. Not tampering — the
+  executor never edited the plan. Recorded because v1 of that "upstream ruling" shipped
+  three defects that only independent verification caught.
+- The CodeRabbit nits were fixed by a dispatched executor, not by guard, preserving the
+  separation that lets guard gate the result.
 
 ## Publication
 
-Work is committed at `54b7620` and published as
-[PR #441](https://github.com/humanspeak/svelte-motion/pull/441) (`Closes #435`).
-The PR was opened under the original PASS and is **now blocked** — do not merge until
-Blockers 1 and 2 are resolved.
-
-**What flips this back to PASS**: the allowlist claims filter-primitive attributes
-(`stdDeviation`, `baseFrequency`, `numOctaves`, `dx`, `dy`, `radius`, …) — ideally by
-resolving against `camelCaseAttributes` rather than another hand-maintained list — with
-a unit case driving them through `extractSVGMotionValueAttributes` (not just the SSR
-helper), an e2e asserting a MotionValue-driven `stdDeviation` never renders
-`[object Object]`, and the `highlight` toggle moved onto the `attr-rect` subtree.
-
-Guard stops here and does not fix the code. **Merging remains the operator's call.**
+Work is committed at `1f593e2` and published as
+[PR #441](https://github.com/humanspeak/svelte-motion/pull/441) (`Closes #435`), opened
+under the earlier PASS and now re-validated. Guard stops here.
+**Merging remains the operator's call.**

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard-report.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard-report.md
@@ -1,0 +1,140 @@
+# Guard close-out report — 002 Bind MotionValues to SVG presentation attributes
+
+- **Verdict**: **PASS**
+- **Date**: 2026-07-09
+- **Plan**: `002-svg-motionvalue-attributes.md` (`Planned at` `9557778`, revision (b))
+- **Snapshot reviewed**: `54b7620` on `feat/svg-motion-value-attributes`
+  (source gates run at `8f51399`; `54b7620` is a docs-only follow-up — see Late edit)
+- **Base**: `3b16d0a` (merge-base with `main`)
+- **PR**: <https://github.com/humanspeak/svelte-motion/pull/441> (open, unmerged)
+
+## Does it deliver `Why this matters`?
+
+Yes. The plan existed because a `MotionValue` passed as any non-path SVG attribute
+was spread raw and stringified as `[object Object]`, and because `attrX/attrY/attrScale`
+did not exist. Both are closed, and the e2e asserts the absence of `[object Object]`
+in the hydrated DOM _and_ in the raw SSR payload (`request.get`, not a hydrated
+snapshot). Scroll-linked rings, chart lines, and filter primitives now work.
+
+The work also exceeded the plan in one way that matters: it fixed SVG **tag-name**
+casing (revision (b), operator-approved). `motion.fedisplacementmap` was rendering an
+inert generic `SVGElement` — the filter primitive was silently ignored. That was never
+in the original plan and would have blocked Plan 005.
+
+## Done criteria — every one re-run at `8f51399`, not trusted
+
+| #   | Criterion                                           | Result                                                        |
+| --- | --------------------------------------------------- | ------------------------------------------------------------- |
+| 1   | `pnpm check` exits 0                                | **PASS** — 0 errors, 32 pre-existing warnings                 |
+| 2   | `pnpm test`; new `svg.spec.ts` cases pass           | **PASS** — 66 files, 745/745                                  |
+| 3   | `pnpm exec playwright test e2e/svg`                 | **PASS** — full suite re-run: 315 passed, 2 skipped, 0 failed |
+| 4   | Demo route exists and is linked                     | **PASS** — `src/routes/+page.svelte`                          |
+| 5   | Docs page exists w/ nav entry; sitemap regenerated  | **PASS on intent** — see Plan defect 1                        |
+| 6   | No modified files outside the in-scope list         | **PASS** — scope audit `3b16d0a...8f51399` exact              |
+| 7   | Batch README status row updated                     | **PASS** — 002 → DONE                                         |
+| 8   | Tag-casing asserted on a **client-created** element | **PASS** — independently verified non-vacuous (below)         |
+
+The 2 e2e skips (`e2e/drag/single-frame.spec.ts:20` `test.fixme`,
+`e2e/motion/svg-path-length.test.ts:149` `test.skip`) are pre-existing — neither file
+is touched by this branch. `trunk check` → no issues across 16 modified files.
+
+## Finding 8 (prior checkpoint) — verified closed, by experiment
+
+The earlier checkpoint found the tag-casing tests vacuous: they asserted on the
+first-paint node, which the HTML parser creates and silently case-corrects, and which
+Svelte reuses when hydrating
+(`svelte/src/internal/client/dom/blocks/svelte-element.js:74`).
+
+The executor's fix adds `await remount(page)` before asserting. Guard did **not** take
+that on trust. In a throwaway `git worktree` (the real tree untouched), the fix was
+reverted (`this={renderTag}` → `this={tag}`, 4 sites) and the test re-run:
+
+```text
+1 failed
+  › renders camelCase SVG tags with their case-sensitive spec spelling
+  expect(info.tagName).toBe('feDisplacementMap')   // spec.ts:186
+```
+
+The test now genuinely detects the bug it was written for. Worktree removed; the real
+working tree was never modified.
+
+## Findings 1-7 — all closed
+
+- **1, 2** (e2e polled `getAttribute('cx')` for style-routed keys; `Number("12.5px")`
+  → `NaN`): fixed. e2e reads `getComputedStyle(...).getPropertyValue(prop)` and
+  `parseFloat` throughout.
+- **3** (vacuous static-attribute assertion): fixed with the reasoning inlined —
+  `spec.ts:292-294` reads the style channel and comments _"Asserting the attribute is
+  unchanged would pass even if the subscription were broken."_
+- **4** (React camelCase allowlist would let `stroke-width={mv}` render
+  `[object Object]`): fixed; kebab spellings allowlisted and unit-tested.
+- **5** (SSR emitted inert `strokeDashoffset`): fixed via the upstream casing gate.
+- **6** (gate-vs-`attr`-prefix ordering — `attrX` must never emit `attr-x`): fixed at
+  `svg.ts:169-170`, `resolveSVGAttrKey` **then** the gate; unit-pinned at
+  `svg.spec.ts:542-544` (`not.toHaveProperty('attr-x')`).
+- **7** (v1 ruling mandated a read-back test with no caller): respected —
+  `grep -c getAttribute src/lib/utils/svg.ts` → **0**. No dead read-back path was built.
+
+## Upstream fidelity
+
+`camelCaseAttributes` and `camelToDash` are **imported from `motion-dom`**
+(`svg.ts:1-7`), not vendored, so upstream additions track on version bumps — exactly
+what the v2 ruling required. Installed `motion-dom` is `12.42.2`, the version the
+ruling was made against.
+
+## Plan defect 1 — criterion 5's sitemap command no longer exists (not executor drift)
+
+Step 4 says `Regenerate sitemap: pnpm --filter docs sitemap:manifest`. That script is
+gone: `docs/package.json` has no sitemap script, `docs/src/lib/sitemap-manifest.json`
+is gitignored (`docs/.gitignore:36`) and emitted by a docs vite plugin at build time.
+
+Guard verified the **intent** rather than the command: the on-disk manifest contains
+`svg-animation` (2 entries — docs + examples), and `pnpm --filter docs check` → 0
+errors. So the criterion's purpose is satisfied and no work is missing. The plan text
+is stale, not the work. Not amended — guard does not amend without operator agreement,
+and nothing here needed lowering to reach PASS.
+
+**Recommended (optional) amendment**: reword criterion 5 to "docs page + nav entry
+exist; sitemap manifest regenerates on build and contains the new routes."
+
+## Quality notes (unprompted improvements worth keeping)
+
+- The old `renders attrScale as the scale attribute` test asserted `scale` on a
+  `<rect>`, where the attribute is inert. Replaced with a `feDisplacementMap` case that
+  reads `scale.baseVal` through the SVG IDL, plus `expect(scale).not.toContain('px')`
+  pinning the unitless `numberValueTypes` entry.
+- The docs page teaches the two-channel split honestly, including the devtools trap:
+  _"the attribute you see in devtools is the initial server-rendered value"_
+  (`+page.svx:46-65`). A user debugging a "stuck" `cx` will find the answer.
+- `SVG_TAG_CASING` covers the full SVG 2 case-sensitive element set; the omitted names
+  (`altGlyph*`, `glyphRef`, `font-face-*`) are SVG 1.1 elements removed from SVG 2.
+
+## Process notes
+
+- The plan was twice amended by the **advisor** rather than guard (the "upstream
+  ruling"). Not tampering — the executor never touched the plan, and the operator
+  surfaced both. Recorded because v1 of that ruling shipped three defects that only
+  independent verification caught (a wrong entry count, an omitted public export, and
+  the `attr-x` ordering bug).
+- Two commits were made with `--no-verify` (`af90f5a`, `b932936`) under explicit
+  operator authorization, because the repo's pre-commit `svelte-check` cannot pass on a
+  knowingly-red test-first commit. Both messages record the reason.
+- `8f51399` was committed by the maintainer concurrently with guard's checkpoint rather
+  than by guard. No content impact — the snapshot is complete and the tree is clean.
+
+### Late edit — caught at the PR preflight
+
+After the gates passed at `8f51399`, the `pr` preflight found the tree dirty again: two
+docs files had been edited under guard. Publication was stopped rather than pushed over
+unreviewed work. The diff was read (`docs/.../demos/Default.svelte`,
+`docs/.../svg-animation/+page.svx`): cosmetic typography only — `<strong>`/`<code>` in
+the embedded demo were losing to `.prose-v2`'s rules on cascade order, plus dropping
+`isSmall`. `git diff --name-only -- src/ e2e/` → **0 files**, so no source gate was
+invalidated. Snapshotted as `54b7620`; the two gates it could affect were re-run:
+`pnpm --filter docs check` → 0 errors, `trunk check` → no issues (17 files).
+
+## Publication
+
+Work is committed at `54b7620` and published as
+[PR #441](https://github.com/humanspeak/svelte-motion/pull/441) (`Closes #435`).
+Guard stops here. **Merging remains the operator's call.**

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard-report.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard-report.md
@@ -1,16 +1,84 @@
 # Guard close-out report — 002 Bind MotionValues to SVG presentation attributes
 
-- **Verdict**: **PASS**
-- **Date**: 2026-07-09
+- **Verdict**: **NO-PASS** — retracted from PASS on 2026-07-09 after a CodeRabbit
+  review surfaced a functional bug that every done criterion missed. See
+  **Blocker 1**. PR #441 is open but **must not merge** until it is fixed.
+- **Date**: 2026-07-09 (revised same day)
 - **Plan**: `002-svg-motionvalue-attributes.md` (`Planned at` `9557778`, revision (b))
 - **Snapshot reviewed**: `54b7620` on `feat/svg-motion-value-attributes`
   (source gates run at `8f51399`; `54b7620` is a docs-only follow-up — see Late edit)
 - **Base**: `3b16d0a` (merge-base with `main`)
 - **PR**: <https://github.com/humanspeak/svelte-motion/pull/441> (open, unmerged)
 
+## Blocker 1 — filter-primitive attributes still render `[object Object]`
+
+**This is the exact failure `Why this matters` exists to eliminate, on the exact
+elements Plan 005 depends on.** Found by CodeRabbit, reproduced by guard.
+
+`SVG_ATTRIBUTE_PROPERTIES` (`svg.ts:34-69`) never claims the filter-primitive
+attributes, so a `MotionValue` on one falls through to `staticAttrs` and hits the raw
+spread. Reproduced against the real module:
+
+```text
+stdDeviation    claimed: false      numOctaves  claimed: false
+baseFrequency   claimed: false      dx / dy     claimed: false   (feOffset)
+radius          claimed: false      cx          claimed: true
+
+extractSVGMotionValueAttributes({ stdDeviation: motionValue(4) })
+  motionValueAttrs: []
+  staticAttrs     : ['stdDeviation']
+  rendered as     : stdDeviation="[object Object]"
+```
+
+Why every gate missed it: the demo drives `feDisplacementMap` through **`attrScale`**,
+which takes the `attr`-prefix branch and works. No demo, e2e, or unit case ever passes a
+MotionValue on a bare filter-primitive key through classification.
+
+The plan's own v2 ruling named these keys: _"the filter-primitive entries
+(`baseFrequency`, `numOctaves`, `stdDeviation`) are exactly what Plan 005's
+`feTurbulence` work will drive through this path."_ They reach the SSR casing gate
+correctly and were unit-tested there — but they never get **claimed**, so the gate is
+never called for them.
+
+**Fix**: extend the allowlist with the filter-primitive keys, or resolve against
+`camelCaseAttributes` before the final `isSVGMotionValueAttribute` check.
+
+## Blocker 2 — two tests create false confidence
+
+- `svg.spec.ts:547` ("should honor upstream camelCase entries beyond the ones we
+  hand-picked") passes `stdDeviation`/`baseFrequency`/`numOctaves` **directly** to
+  `computeSSRSVGAttrValues`, bypassing `extractSVGMotionValueAttributes`. It reads as
+  filter-primitive coverage and is why Blocker 1 hid in plain sight. Route the same keys
+  through classification.
+- `+page.svelte:297` binds the `highlight` class to the **`mv-circle`** `<svg>`, while
+  `attr-rect` lives in a separate `<svg>` at `:374-390`. The e2e
+  _"an unrelated re-render does not clobber attribute-routed values"_
+  (`spec.ts:~330-337`) toggles it and then asserts on `attr-rect` — so it can pass even
+  if the clobbering bug returns. Move the class onto the `attr-rect` subtree or a shared
+  ancestor.
+
+Non-blocking nits from the same review: `role="toolbar"` missing on the demo's
+`aria-label`led `div`; docs snippets aren't copy-paste self-contained; an SSR doc comment
+at `spec.ts:33-36` describes output that `computeSSRSVGAttrValues` doesn't produce;
+`attrY`/`attrScale` lack the JSDoc `@example` that `attrX` has (repo convention requires
+`@param`/`@returns`/`@example` on `src/lib/utils/*.ts`).
+
+## What guard got wrong
+
+Every done criterion passed and the work still fails `Why this matters` on filter
+primitives. That is "in-scope but beside the point," and the final gate did not catch
+it: guard verified the _channel split_ and the _casing gate_ exhaustively, and checked
+that `attrScale` reached `feDisplacementMap`, but never asked whether a bare
+filter-primitive key survives classification. The `attrScale` demo made the filter path
+look covered. A green suite is not coverage — this is the same lesson Findings 3 and 8
+taught, missed a third time.
+
 ## Does it deliver `Why this matters`?
 
-Yes. The plan existed because a `MotionValue` passed as any non-path SVG attribute
+Partially — see Blocker 1. For shape geometry and the `attr*` family, yes. For filter
+primitives, no.
+
+The plan existed because a `MotionValue` passed as any non-path SVG attribute
 was spread raw and stringified as `[object Object]`, and because `attrX/attrY/attrScale`
 did not exist. Both are closed, and the e2e asserts the absence of `[object Object]`
 in the hydrated DOM _and_ in the raw SSR payload (`request.get`, not a hydrated
@@ -137,4 +205,14 @@ invalidated. Snapshotted as `54b7620`; the two gates it could affect were re-run
 
 Work is committed at `54b7620` and published as
 [PR #441](https://github.com/humanspeak/svelte-motion/pull/441) (`Closes #435`).
-Guard stops here. **Merging remains the operator's call.**
+The PR was opened under the original PASS and is **now blocked** — do not merge until
+Blockers 1 and 2 are resolved.
+
+**What flips this back to PASS**: the allowlist claims filter-primitive attributes
+(`stdDeviation`, `baseFrequency`, `numOctaves`, `dx`, `dy`, `radius`, …) — ideally by
+resolving against `camelCaseAttributes` rather than another hand-maintained list — with
+a unit case driving them through `extractSVGMotionValueAttributes` (not just the SSR
+helper), an e2e asserting a MotionValue-driven `stdDeviation` never renders
+`[object Object]`, and the `highlight` toggle moved onto the `attr-rect` subtree.
+
+Guard stops here and does not fix the code. **Merging remains the operator's call.**

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard-report.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard-report.md
@@ -112,20 +112,30 @@ src/lib/utils/svg.ts` → **0**), 8 (tag test asserted on a parser-created node)
 
 ## Plan defect 1 — criterion 5's sitemap command no longer exists (not executor drift)
 
-Step 4 says `pnpm --filter docs sitemap:manifest`; no such script exists.
+Step 4 said `pnpm --filter docs sitemap:manifest`; no such script exists.
 `docs/src/lib/sitemap-manifest.json` is gitignored (`docs/.gitignore:36`) and emitted by
 a docs vite plugin at build. Verified on intent: the manifest contains `svg-animation`
-(2 entries) and docs check is clean. Plan text is stale, the work is not. **Not amended**
-— nothing needed lowering to reach PASS.
+(2 entries) and docs check is clean. Plan text was stale, the work was not.
 
-## Environment hazard worth fixing (outside this plan)
+**Amended after the verdict** (revision (c), `Planned at` → `599372b`), with the
+operator's agreement. The sequence is the point: the criterion's intent was verified
+independently and PASS was granted _first_, with the defect recorded as "PASS on intent".
+The plan was then corrected to describe the repo as it is. No bar was lowered to reach a
+verdict — that inversion is the one thing this process exists to prevent.
 
-`playwright.config.ts:21` sets `reuseExistingServer: !process.env.CI`. During this gate,
-a stale preview server left over on port 4198 caused a worktree run with the fix
-**reverted** to pass — it was silently served the old, fixed build. Guard caught it via
-`lsof` and re-ran with `CI=1`, which produced the correct failures. Any local e2e run can
-be validated against a stale build this way. The port pin (4198) prevents cross-repo
-collisions but not stale-server reuse.
+## Environment hazard — found at this gate, now fixed (`1fca5bb`)
+
+`playwright.config.ts:21` set `reuseExistingServer: !process.env.CI`, which
+short-circuits the rebuild in the webServer `command`. During this gate a stale preview
+server on port 4198 caused a worktree run with the fix **reverted** to pass — it was
+silently served the old, fixed build. Guard caught it via `lsof` and re-ran under `CI=1`
+to get the true failures. Any local e2e run could be validated against a stale build this
+way; the 4198 pin prevents cross-repo collisions but not stale-server reuse.
+
+Reuse is now opt-in (`PW_REUSE_SERVER=1`); unset with the port occupied, the run aborts
+with "already used". CI is unaffected. `playwright.config.ts` is **outside** plan 002's
+in-scope list — included at the operator's request, authored by a dispatched executor,
+reviewed by guard. Recorded so the scope-audit exception is explicit, not silent.
 
 ## Quality notes
 

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
@@ -189,3 +189,84 @@ Row 002 `TODO` → `IN PROGRESS`, with a pointer to this log.
 - `guard parity 2` again once implementation lands; `final` gates the PR.
 
 ---
+
+## Checkpoint 2026-07-09 — `guard parity 2` (casing ruling v2 + executor test fixes)
+
+- **Verdict**: ON TRACK (still pre-implementation)
+- **Snapshots**: `5c307fe` (plan ruling v2 + README), `b932936` (executor's test
+  fixes). `b932936` used `--no-verify` under the same standing operator
+  authorization as `af90f5a` — tests remain knowingly red (29 failed / 22 passed,
+  all on absent `svg.ts` helpers), so pre-commit `svelte-check` cannot pass.
+- **Plan `Planned at`**: `af90f5a`. Drift check → empty; `svg.ts` still untouched.
+
+### Plan amendment authored outside guard — process note, not a violation
+
+The "Upstream ruling on Step 2.3 SSR attribute casing" was written into the plan
+by the **advisor** (plan author), not by guard and not by the operator. Per
+separation of powers only guard amends the plan, with operator agreement. This is
+**not tampering**: the executor did not touch the plan (its edits are confined to
+`svg.spec.ts` + the e2e spec, both in scope), and the operator surfaced the ruling
+deliberately. Recorded because a ruling that arrives pre-approved invites adoption
+without re-derivation — and v1 of this one carried three defects.
+
+### Guard verification of the ruling (evidence, not assertion)
+
+Every v1 citation re-read against `~/Github/motion` and the **installed** package
+(`node_modules/motion-dom` → `12.42.2`, matching the version ruled against):
+
+| Claim                                                                          | Result                                                                                                                                              |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `renderSVG` gates writes on `!camelCaseAttributes.has(k) ? camelToDash(k) : k` | CONFIRMED — `render/svg/utils/render.ts:15-19`, verbatim                                                                                            |
+| `SVGVisualElement.readValueFromInstance` applies the same gate                 | CONFIRMED — `SVGVisualElement.ts:39-40`                                                                                                             |
+| `camelToDash` is a pure uppercase replacer; `'stroke-width'` untouched         | CONFIRMED — `render/dom/utils/camel-to-dash.ts:1-3`                                                                                                 |
+| `camelCaseAttributes` is a public export                                       | CONFIRMED — `index.ts:302`; **and reachable from the installed package** (`import { camelCaseAttributes } from 'motion-dom'` → `.size === 23`)      |
+| "26 entries"                                                                   | **FALSE — 23.** Source count and live `.size` agree                                                                                                 |
+| `camelToDash` also exported                                                    | **OMITTED by v1** — it is (`'camelToDash' in md` → true); without this the executor hand-rolls the dash-caser, the exact vendoring v1 warns against |
+
+### Finding 6 (guard-found, now normative point 4) — gate-vs-prefix ordering
+
+The gate MUST run **after** `resolveSVGAttrKey` strips the `attr` prefix. Probed
+against the real exports:
+
+```text
+attrX -> attr-x      attrScale -> attr-scale      viewBox -> viewBox
+strokeDashoffset -> stroke-dashoffset             stroke-width -> stroke-width
+```
+
+`attrX` is not in `camelCaseAttributes`, so gating first emits the inert attribute
+`attr-x` instead of `x`. Both orderings pass a naive `strokeDashoffset` test, so
+nothing in the prior test plan caught it. Now point 4 with its own unit case.
+
+### Finding 7 (guard-found, now conditional point 5) — v1 mandated dead code
+
+v1's read-path requirement ("add a unit case covering one read-back through the
+gate") had no caller to test: `svg.ts` is unimplemented, and the only
+SVG-attribute `getAttribute` calls in `src/lib/` are hardcoded kebab strings in
+the out-of-scope path pipeline (`_MotionContainer.svelte:882,888`). Requiring the
+test would have forced the executor to build a read-back path it does not need.
+Now conditional: the invariant binds _if_ a read-back is introduced, and the plan
+explicitly says not to build one to satisfy the point.
+
+All three corrections were adopted by the advisor into ruling **v2** (`5c307fe`),
+which credits the guard verification. Points 1-3 stand as confirmation.
+
+### Executor status — Findings 1-3 resolved
+
+- e2e now reads the bound channel: `getComputedStyle(...).getPropertyValue(prop)`
+  for `cx`/`r`/`stroke-*`, `getAttribute` for the `attr*` family; `parseFloat`
+  replaces `Number` throughout (`motion-value-attributes.spec.ts`).
+- First-paint assertion tightened `!Number.isNaN(...)` → `Number.isFinite(...)`.
+- Unit: kebab-case allowlist cases added; SSR emitter cases pin `viewBox`
+  unchanged and `strokeDashoffset` → `stroke-dashoffset`.
+- Finding 3's vacuous static assertion — **not yet re-verified**; check at `final`
+  that it reads the same channel the live element uses.
+
+### Next after v2
+
+- Executor implements Steps 1-5. `svg.ts` must import both `camelCaseAttributes`
+  and `camelToDash` from `motion-dom` (no vendored copies), and order
+  resolve-then-gate.
+- At `final`: confirm Finding 3's fix, the point-4 ordering unit case exists, and
+  that point 5 stayed unbuilt (no gratuitous read-back path).
+
+---

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
@@ -376,3 +376,27 @@ remount. Now normative in the plan's test plan and a new done criterion.
   that point 5 stayed unbuilt.
 
 ---
+
+## Checkpoint 2026-07-09 — `guard parity 2 final` — PASS
+
+- **Verdict**: **PASS** — close-out report written to
+  `002-svg-motionvalue-attributes.guard-report.md`; PR #441 opened.
+- **Snapshot**: `54b7620` (source gates at `8f51399`; `54b7620` is docs-only).
+- **Drift check** `9557778..HEAD` on in-scope source → empty.
+- **Scope audit** `3b16d0a...54b7620` → every file in the plan's in-scope list.
+- **Done criteria, all re-run**: check 0 errors; unit 745/745; full e2e 315 passed /
+  2 skipped (both pre-existing, in untouched files) / 0 failed; docs check 0 errors;
+  `trunk check` clean; demo linked; README row DONE; tag-casing asserted post-remount.
+- **Finding 8 closed by experiment** — in a throwaway worktree the fix was reverted
+  (`this={renderTag}` → `this={tag}`) and the tag test **failed** at `spec.ts:186`.
+  The test is genuinely non-vacuous. Real tree never mutated; worktree removed.
+- **Findings 1-7 closed**; point 5 respected (`grep -c getAttribute svg.ts` → 0, no
+  dead read-back path built).
+- **Plan defect 1** (criterion 5's `sitemap:manifest` script no longer exists; manifest
+  is gitignored + vite-plugin-generated, and contains `svg-animation`) — verified on
+  intent, **not amended**. No criterion was weakened to reach PASS.
+- **Late edit caught at PR preflight**: tree went dirty after the gates; publication was
+  stopped, the diff read (docs-only, 0 files under `src/`/`e2e/`), snapshotted as
+  `54b7620`, and the two affected gates re-run before pushing.
+
+---

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
@@ -270,3 +270,109 @@ which credits the guard verification. Points 1-3 stand as confirmation.
   that point 5 stayed unbuilt (no gratuitous read-back path).
 
 ---
+
+## Checkpoint 2026-07-09 — `guard parity 2` — PLAN AMENDED (tag-casing scope addition)
+
+- **Verdict**: PLAN AMENDED + ON TRACK, with one coverage finding (Finding 8).
+- **Snapshot**: `9557778` — implementation, demo, e2e, tag-casing fix.
+- **`Planned at`** re-stamped `af90f5a` → `9557778` (revision (b)).
+- **Done criteria re-run at the snapshot** (not trusted, re-executed):
+
+| Criterion                                  | Result                                      |
+| ------------------------------------------ | ------------------------------------------- |
+| `pnpm check`                               | PASS — 0 errors, 32 pre-existing warnings   |
+| `pnpm test src/lib/utils/svg.spec.ts`      | PASS — 63/63                                |
+| `pnpm exec playwright test e2e/svg`        | PASS — 22/22                                |
+| Demo linked from `src/routes/+page.svelte` | PASS — 1 reference                          |
+| Docs page + nav + sitemap                  | **NOT DONE** — Step 4 not started           |
+| No files outside in-scope list             | PASS — scope audit `af90f5a..9557778` exact |
+| README row updated                         | PASS                                        |
+
+### Scope addition — operator-approved, recorded as revision (b)
+
+Operator approved fixing SVG tag-name casing inside 002. Cause confirmed at
+source: `src/lib/html/Fedisplacementmap.svelte:11` hardcodes
+`tag="fedisplacementmap"` (all 32 case-sensitive SVG elements have the same
+generated shape). All touched files were already in 002's in-scope list, so this
+is a behavior addition, not an out-of-scope edit. Plan Scope, Test plan, and
+Done criteria amended to match; `SVG_TAG_CASING` + `resolveSVGTagName` named.
+
+### Evidence — the bug and the fix are both real
+
+Probed in Chromium (`createElementNS`, SVG namespace):
+
+```text
+createElementNS(NS,'fedisplacementmap') -> SVGElement                  ('scale' in el === false)
+createElementNS(NS,'feDisplacementMap') -> SVGFEDisplacementMapElement ('scale' in el === true)
+```
+
+Live probe against the preview build at `9557778`, marking the first-paint node
+with an expando and toggling `{#if mounted}`:
+
+```text
+first paint (parser-created): {"tag":"feDisplacementMap","ctor":"SVGFEDisplacementMapElement","scale":"12"}
+after remount (JS-created)  : {"tag":"feDisplacementMap","ctor":"SVGFEDisplacementMapElement","freshNode":true,"baseVal":12}
+```
+
+`freshNode: true` proves the remounted element is created by `createElementNS`,
+not reused — and it comes back correctly cased with a working `scale.baseVal`.
+The fix works on the path that matters.
+
+### Finding 8 — the three new tag-casing e2e tests are vacuous as written
+
+`e2e/svg/motion-value-attributes.spec.ts:155,168,190` all begin `page.goto(ROUTE)`
+and assert on the **first-paint** node. That node is created by the HTML parser,
+not by Svelte, and the parser silently corrects SVG tag case:
+
+```text
+div.innerHTML = '<svg><filter><fedisplacementmap/></filter></svg>'
+  -> children[0].constructor.name === 'SVGFEDisplacementMapElement'   (tagName 'feDisplacementMap')
+```
+
+Svelte then **reuses** that node rather than re-creating it —
+`node_modules/svelte/src/internal/client/dom/blocks/svelte-element.js:74`:
+
+```js
+element = hydrating ? /** @type {Element} */ (element) : create_element(next_tag, ns)
+```
+
+The route has no `ssr`/`csr` override, so `page.goto` always SSRs then hydrates.
+Consequence: **revert `renderTag` and all three tests still pass.** They assert
+the HTML parser's behavior, not ours. This is the same class as Finding 3 — a
+green check standing in for a problem it cannot detect.
+
+The fix costs almost nothing: `displacement-map` already lives inside the
+`{#if mounted}` block (`+page.svelte:282-430`), and the existing
+`reattaches cleanly after unmount and remount` test (`spec.ts:289`) already
+round-trips that toggle — it just asserts on `mv-circle` only. Assert `tagName`,
+`constructor.name`, and the presence of the `scale` IDL property **after** the
+remount. Now normative in the plan's test plan and a new done criterion.
+
+### On track at this checkpoint
+
+- `resolveSVGTagName` unit cases (`svg.spec.ts`) cover filter primitives, `clipPath`,
+  `linearGradient`, `radialGradient`, `textPath`, `foreignObject`,
+  `animateTransform`, plus lowercase/non-SVG/already-cased passthrough. Real
+  assertions. All 32 map keys are reachable through `isSVGTag` (verified — no key
+  is stranded behind a false `isSVGTag` check).
+- `SVG_TAG_CASING` covers the full SVG 2 case-sensitive element set; the omitted
+  names (`altGlyph*`, `glyphRef`, `color-profile`, `font-face-*`) are SVG 1.1
+  elements removed from SVG 2. Correct omission.
+- Replacing the old `renders attrScale as the scale attribute` test (which asserted
+  `scale` on a `<rect>`, where it is inert) with a `feDisplacementMap` case is a
+  genuine improvement: `scale` is only a real presentation attribute there, and the
+  test now checks `scale.baseVal` through the SVG IDL, not just the string.
+- The `expect(scale).not.toContain('px')` assertion correctly pins the unitless
+  `numberValueTypes` entry — a real regression guard against style-routing.
+- SSR payload verified live: `curl` of the route returns `feDisplacementMap` ×5,
+  so the server emitter is correct independently of the parser's forgiveness.
+- Scope audit `af90f5a..9557778` — all 7 touched files in the plan's in-scope list.
+
+### Next after revision (b)
+
+- Executor: fold the tag assertion into the remount test (Finding 8), then Step 4
+  (docs page + nav + sitemap), the only remaining unmet done criterion.
+- At `final`: re-check Finding 3, Finding 8, the point-4 ordering unit case, and
+  that point 5 stayed unbuilt.
+
+---

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
@@ -1,0 +1,138 @@
+# Guard log — 002 Bind MotionValues to SVG presentation attributes
+
+Running oversight log for plan 002. One entry per checkpoint, append-only.
+
+---
+
+## Checkpoint 2026-07-09 — `guard parity 2` (red-test review, pre-implementation)
+
+- **Verdict**: DRIFTING — the red tests encode a false assumption about which
+  DOM channel `svgEffect` writes to. Two e2e tests can never pass against a
+  correct implementation; one unit allowlist locks in React spellings Svelte
+  authors never write.
+- **Snapshot**: none — the `commit` skill's pre-commit hook refused (see Block).
+  Reviewed against the working tree at branch tip `3b16d0a`
+  (`feat/svg-motion-value-attributes`).
+- **Plan `Planned at`**: `634983b`. Drift check
+  (`git diff --stat 634983b..HEAD -- src/lib/utils/svg.ts src/lib/html/_MotionContainer.svelte src/lib/types.ts`)
+  → empty. No source drift; "Current state" excerpts still hold.
+- **Work under review**: `src/lib/utils/svg.spec.ts` (+205), `e2e/svg/motion-value-attributes.spec.ts` (new).
+  No implementation yet. Tests are red for the right reason:
+  `pnpm test src/lib/utils/svg.spec.ts` → 23 failed / 22 passed, every failure
+  `TypeError: <helper> is not a function` or missing `SVG_ATTRIBUTE_PROPERTIES`.
+
+### Block — snapshot commit refused by repo guardrail
+
+`.husky/pre-commit` runs `svelte-check`, which fails on the red spec
+(`svg.spec.ts:8,9,11,13,14` — "Module './svg' has no exported member ...").
+A test-first commit is therefore impossible here without `--no-verify`; guard
+does not force past guardrails. Working tree was restored exactly as found
+(`git reset`, no commit created). Red tests can be committed only alongside
+the implementation that makes them green.
+
+### Evidence — `svgEffect` routes `cx` to `element.style`, not `setAttribute`
+
+Upstream `motion-dom/src/effects/svg/index.ts` (`addSVGValue`):
+
+```ts
+if (key.startsWith("path"))  return addSVGPathValue(...)
+else if (key.startsWith("attr")) return addAttrValue(element, state, convertAttrKey(key), value)
+const handler = key in element.style ? addStyleValue : addAttrValue
+```
+
+Probed in the real e2e browser (Chromium, `page.evaluate`, `k in circle.style`):
+
+| key                                                              | `in element.style` | svgEffect route                  |
+| ---------------------------------------------------------------- | ------------------ | -------------------------------- |
+| `cx` `cy` `r` `rx` `ry` `x` `y` `width` `height` `d`             | **true**           | `addStyleValue`                  |
+| `strokeDashoffset` `strokeWidth` `stopColor` `*Opacity` `offset` | **true**           | `addStyleValue`                  |
+| `points` `viewBox` `x1` `y1` `x2` `y2`                           | false              | `addAttrValue`                   |
+| `attrX` `attrY` `attrScale`                                      | n/a (prefix)       | `addAttrValue` → `x`/`y`/`scale` |
+
+Same probe: after `c.style.cx = '40px'`, `c.getAttribute('cx')` still returns
+`"5"` while `getComputedStyle(c).cx === "40px"`. The attribute is never touched.
+
+### Finding 1 — e2e `updates the cx attribute when the MotionValue changes` cannot pass
+
+`e2e/svg/motion-value-attributes.spec.ts:33-45` polls `circle.getAttribute('cx')`
+and asserts it grows. With the plan's prescribed `svgEffect` (Step 2), `cx` is
+style-routed: the attribute keeps its SSR value forever and the poll times out.
+The test asserts on the wrong channel. Fix: assert
+`getComputedStyle(el).cx`, or drive the demo through a genuinely
+attribute-routed key (`x1`/`x2`/`points`) or `attrX`.
+
+### Finding 2 — e2e `drives a progress ring via r and stroke-dashoffset` cannot pass
+
+`spec.ts:53-62`. `readOffset()` falls back to
+`getComputedStyle(el).strokeDashoffset`, which returns `"12.5px"` (probed).
+`Number("12.5px")` → `NaN`. Before and after are both `NaN`, and
+`expect(NaN).not.toBe(NaN)` **fails** (`toBe` is `Object.is`, and
+`Object.is(NaN, NaN) === true`). The test can never go green regardless of
+implementation. Fix: `parseFloat`, and assert on the style channel directly.
+Same root cause as Finding 1 — `r` is style-routed too.
+
+### Finding 3 — `leaves plain numeric attributes static` passes vacuously
+
+`spec.ts:106-115` asserts `static-circle`'s `cx` stays `"5"` after a click. Since
+no implementation ever writes the `cx` _attribute_ (Finding 1), this assertion
+holds even if the MotionValue subscription is completely broken. It cannot
+distinguish the plan's "zero subscription overhead" intent from total failure.
+Gamed-by-accident criterion; needs to assert on the same channel the live
+element uses.
+
+### Finding 4 — allowlist locks in React spellings; the idiomatic Svelte ones leak
+
+`svg.spec.ts:227-240` requires `SVG_ATTRIBUTE_PROPERTIES` to contain
+`stopColor`, `stopOpacity`, `fillOpacity`, `strokeOpacity`, `strokeWidth` — the
+JSX names, copied from the plan (`002-...md:136-141`), which copied upstream's
+React-facing list. Svelte templates take the DOM spelling: a user writes
+`<motion.circle stroke-width={mv}>`, not `strokeWidth`. As specced, that prop
+misses the allowlist, never gets claimed out of the raw spread, and renders
+`stroke-width="[object Object]"` — precisely the failure the plan's _Why this
+matters_ exists to kill. Probe shows `'stroke-width' in element.style === true`,
+so kebab keys route correctly through `svgEffect` once claimed; the allowlist
+just has to contain them. This one is a **plan defect**, not executor drift —
+the plan dictated the list. Recommended amendment: allowlist both spellings
+(or normalize before lookup), and add a unit case per kebab key.
+
+### Finding 5 — `computeSSRSVGAttrValues` has no camel→kebab coverage
+
+`svg.spec.ts:388-410` only exercises `cx`/`r`/`attrX`/`attrScale`. `resolveSVGAttrKey`
+as specced only strips the `attr` prefix, so a `strokeDashoffset` MotionValue
+would SSR as the attribute `strokeDashoffset` — not a real SVG attribute
+(SVG attribute names are case-sensitive), so it is inert and the value flashes on
+hydration. The plan's Step 2.3 ("hydration doesn't flash") is unmet and untested.
+Add a case: `computeSSRSVGAttrValues({ strokeWidth: motionValue(4) })` →
+`{ 'stroke-width': '4' }`.
+
+### On track
+
+- Unit tests for `resolveSVGAttrKey` (`svg.spec.ts:246-263`) correctly mirror
+  upstream's `/^attr([A-Z])/` (`effects/svg/index.ts:58-62`), including the
+  `attribute` / `attr` / `attrx` negatives. Real assertions, right semantics.
+- `extractSVGMotionValueAttributes` keeping MotionValue keys **un-renamed**
+  (`svg.spec.ts:305-317`) is correct and non-obvious: pre-renaming `attrScale`→
+  `scale` would make `svgEffect` take the `key in element.style` branch instead of
+  the `startsWith("attr")` branch. This is _more_ right than plan Step 1's
+  "Include attrX/attrY/attrScale mapping to x/y/scale here", which reads as if the
+  rename should happen at extraction. Plan text is imprecise; the test is correct.
+- No-overlap-with-`SVG_PATH_PROPERTIES` (`svg.spec.ts:255`) and
+  "don't claim path props even when they hold MotionValues" (`svg.spec.ts:327-333`)
+  correctly protect the out-of-scope path pipeline.
+- Non-mutation and empty-bag cases present. e2e `attrX`/`attrY`/`attrScale` tests
+  (`spec.ts:65-104`) assert the right channel (`addAttrValue`) and correctly check
+  that no CSS transform is produced.
+- SSR e2e (`spec.ts:117-128`) is a genuine `request.get` against the server payload,
+  not a hydrated snapshot. Correct approach.
+
+### Next
+
+- Operator decides Finding 4 (plan defect → amendment) before the executor
+  rewrites the tests. Findings 1-3 and 5 are executor-side test fixes; the plan
+  does not change for them.
+- Plan's Test-plan bullet "no `[object Object]` in DOM" is well served; the
+  "attribute updates" bullet must be restated as "the bound channel updates".
+- No implementation exists yet, so no scope audit was possible beyond the two
+  test files. Both are in the plan's in-scope list (`002-...md:105,110`).
+
+---

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
@@ -136,3 +136,49 @@ Add a case: `computeSSRSVGAttrValues({ strokeWidth: motionValue(4) })` →
   test files. Both are in the plan's in-scope list (`002-...md:105,110`).
 
 ---
+
+## Checkpoint 2026-07-09 — `guard parity 2` — PLAN AMENDED
+
+- **Verdict**: PLAN AMENDED (operator agreed)
+- **Snapshot**: `af90f5a` — the executor's red tests, committed with `--no-verify`
+  under **explicit operator authorization**, overriding the block recorded in the
+  previous entry. The pre-commit `svelte-check` fails by design on a test-first
+  commit (helpers not yet exported from `svg.ts`); the operator judged this a
+  known-red snapshot and directed guard to bypass. Recorded here because guard
+  does not otherwise pass guardrails.
+- **`Planned at`** re-stamped `634983b` → `af90f5a`, so the drift check
+  re-baselines against the amended intent.
+
+### What changed in the plan, and why
+
+Root cause of Findings 1-5: the plan spoke of a single "attribute" channel.
+`svgEffect` has two (`effects/svg/index.ts:44-52`), and the split is decided by
+`key in element.style` — which is `true` for `cx cy r rx ry x y width height d`
+and the `stroke-*`/`*Opacity`/`stopColor`/`offset` family in Chromium. Those are
+written to `element.style`; only `points viewBox x1..y2` and `attr*` reach
+`setAttribute`. Every wrong-channel test traced back to plan text.
+
+| Plan section       | Amendment                                                                                                                              | Finding         |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| Step 1 (allowlist) | Must carry kebab-case DOM spellings (`stroke-width`, …), not just React's camelCase                                                    | 4               |
+| Step 1 (attr keys) | Do **not** rename `attr*` on the MotionValue side; expose `resolveSVGAttrKey` for static + SSR use only                                | (was imprecise) |
+| Step 2.3 (SSR)     | Emit DOM attribute names; kebab for hyphenated keys, else the attribute is inert and flashes on hydration                              | 5               |
+| Step 3 (e2e)       | Poll the **bound channel**; `parseFloat` not `Number` on computed styles; static-attr assertion must not read a channel nothing writes | 1, 2, 3         |
+| Test plan          | Cover one key per channel (`attrX` + `cx`); require a kebab-case unit case                                                             | 1-5             |
+
+Findings 1-3 and 5 remain **executor-side test fixes** — the amendment tells the
+executor what to assert, it does not lower any bar. No done criterion was
+weakened, none removed. Finding 4 widened the _implementation_ requirement
+(more keys must be claimed), which is a strictly higher bar than the original.
+
+### Batch README
+
+Row 002 `TODO` → `IN PROGRESS`, with a pointer to this log.
+
+### Next after amendment
+
+- Executor picks up the revised plan: rewrite the three wrong-channel e2e tests,
+  add the kebab-case unit cases, then implement Steps 1-5.
+- `guard parity 2` again once implementation lands; `final` gates the PR.
+
+---

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
@@ -498,3 +498,39 @@ PR #441 was opened under the earlier PASS and is now re-validated at `1f593e2`.
 Guard stops. Merging is the operator's call.
 
 ---
+
+## Checkpoint 2026-07-09 — `guard parity 2` — PLAN AMENDED (rev (c)) + infra fix
+
+- **Verdict**: PLAN AMENDED. The PASS at `1f593e2` stands, unchanged.
+- **Snapshot**: `1fca5bb`.
+
+### Revision (c) — plan defect corrected _after_ the verdict, not to reach it
+
+Step 4 instructed `pnpm --filter docs sitemap:manifest`; no such script exists.
+`docs/src/lib/sitemap-manifest.json` is gitignored (`docs/.gitignore:36`) and emitted by
+a docs vite plugin at build. Step 4 and done-criterion 5 now describe that reality.
+
+The ordering matters and is the whole reason this is not laundering: criterion 5's
+**intent** was verified independently (built manifest contains `svg-animation`, 2
+entries; docs check 0 errors) _before_ PASS was granted, with the criterion recorded as
+"PASS on intent" and the defect named. The plan text was wrong about the repo; the work
+was not wrong about the plan. `Planned at` re-stamped `9557778` → `599372b`.
+
+### e2e stale-server hazard — fixed (out of scope, operator-approved)
+
+`playwright.config.ts:21` had `reuseExistingServer: !process.env.CI`, which
+short-circuits the rebuild in the webServer `command`. A stale preview on 4198 is
+reused, so the suite validates against **old code**. Reproduced at this plan's own final
+gate: a worktree run with the fix reverted **passed**, served the previous fixed build;
+`lsof` found the leftover server, and `CI=1` produced the true failures.
+
+Reuse is now opt-in via `PW_REUSE_SERVER=1`. Unset + occupied port → the run aborts with
+"already used" rather than quietly lying. CI behavior is unchanged (it never set the new
+var, and previously derived `false` from the CI check). Test-infra only; no library code.
+
+`playwright.config.ts` is **not** in plan 002's in-scope list. It is included at the
+operator's request and recorded here so the scope audit's exception is explicit rather
+than silent. Authored by a dispatched executor and reviewed by guard, per separation of
+powers.
+
+---

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
@@ -148,6 +148,13 @@ Add a case: `computeSSRSVGAttrValues({ strokeWidth: motionValue(4) })` →
   does not otherwise pass guardrails.
 - **`Planned at`** re-stamped `634983b` → `af90f5a`, so the drift check
   re-baselines against the amended intent.
+- **Evidence preserved**: `assets/svg-channel-probe.mjs` — the Chromium probe
+  behind this amendment, runnable from the repo root. Re-run it if a Chromium
+  bump is suspected of moving a key between channels. Output on Chromium
+  149.0.7827.55: `cx cy r rx ry x y width height d` + `stroke-*`/`*Opacity`/
+  `stopColor`/`offset` style-routed; `points viewBox x1 y1 x2 y2` attr-routed;
+  `element.style.cx = '40px'` leaves `getAttribute('cx') === "5"`;
+  `Number("12.5px") === NaN`.
 
 ### What changed in the plan, and why
 

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
@@ -447,3 +447,54 @@ for them.
   doc comment at `spec.ts:33-36`, and missing `@example` JSDoc on `attrY`/`attrScale`.
 
 ---
+
+## Checkpoint 2026-07-09 — `guard parity 2 final` (re-run) — PASS
+
+- **Verdict**: **PASS**. Supersedes the same-day NO-PASS; both blockers closed.
+- **Snapshot**: `1f593e2`. Tree clean at gate time — nothing to snapshot.
+- **Drift** `9557778..HEAD` on in-scope source → only `svg.ts` + `types.ts`, both the
+  fix itself. **Scope audit** `3b16d0a...1f593e2` → every file in the in-scope list.
+- **Done criteria, all re-run**: check 0 errors; unit **752/752** (+7); full e2e
+  **317 passed / 2 skipped (pre-existing) / 0 failed**; docs check 0 errors; trunk clean;
+  demo linked; README DONE; tag-casing non-vacuous (verified at the prior gate).
+
+### Blocker 1 closed — verified by reverting the fix
+
+`isSVGMotionValueAttribute` resolves path-props → `attr`-prefix → **imported**
+`camelCaseAttributes` → local allowlist. Order is load-bearing: `pathLength` is in
+`camelCaseAttributes`, so the path rejection must come first; pinned at
+`svg.spec.ts:528` and passing. No vendored copy (`baseFrequency` appears once, in JSDoc).
+`dx`/`dy`/`radius` added explicitly, with a unit case asserting they are _absent_ from
+the upstream set so nobody later assumes the import covers them.
+
+Worktree revert (lookup + 3 keys removed) → both new e2e tests **failed**. Non-vacuous.
+
+### Blocker 2 closed — both tests verified non-vacuous
+
+SSR unit case now routes through `extractSVGMotionValueAttributes` (red at `22ed10e`,
+green after the fix). The clobber e2e marks `attr-rect`'s subtree with `data-highlight`
+and **asserts its own premise** via `closest('[data-highlight="true"]')` before checking
+`x`; reverting only the fixture makes it fail.
+
+### A relaxed assertion, examined and accepted
+
+The SSR check was widened to case-insensitive. Guard verified the justification instead
+of the diff: Svelte's SSR spread really does lowercase attribute names (live payload:
+`<feGaussianBlur … stddeviation="2">`), and Chromium's HTML parser maps it back
+(`getAttributeNames() -> [...,'stdDeviation']`, `stdDeviationX.baseVal === 2`). No inert
+attribute, no flash. The test still forbids `std-deviation=`, the casing nothing rescues.
+Property preserved, only the over-specific spelling dropped. Accepted.
+
+### Environment hazard (outside the plan)
+
+`playwright.config.ts:21` — `reuseExistingServer: !process.env.CI`. A stale preview
+server on 4198 made a _fix-reverted_ worktree run **pass**, serving the old fixed build.
+Caught with `lsof`; re-ran under `CI=1` to get the true failures. Local e2e can silently
+validate against a stale build. Worth hardening; not a 002 blocker.
+
+### Publication
+
+PR #441 was opened under the earlier PASS and is now re-validated at `1f593e2`.
+Guard stops. Merging is the operator's call.
+
+---

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.guard.md
@@ -400,3 +400,50 @@ remount. Now normative in the plan's test plan and a new done criterion.
   `54b7620`, and the two affected gates re-run before pushing.
 
 ---
+
+## Checkpoint 2026-07-09 — `guard parity 2 final` (revised) — NO-PASS, PASS RETRACTED
+
+- **Verdict**: **NO-PASS**. The prior PASS is retracted. PR #441 stays open but must
+  not merge.
+- **Trigger**: a CodeRabbit review (`--base main`, 17 files) reported 1 major +
+  4 minor + 3 trivial findings. Guard reproduced the major one and two minors.
+- **Blocker 1 (major, reproduced)**: `SVG_ATTRIBUTE_PROPERTIES` (`svg.ts:34-69`) never
+  claims filter-primitive attributes. Against the real module:
+
+```text
+extractSVGMotionValueAttributes({ stdDeviation: motionValue(4) })
+  motionValueAttrs: []          staticAttrs: ['stdDeviation']
+  rendered as: stdDeviation="[object Object]"
+isSVGMotionValueAttribute -> stdDeviation:false baseFrequency:false numOctaves:false
+                             dx:false dy:false radius:false   (cx:true)
+```
+
+This is the plan's headline failure mode, on precisely the elements Plan 005 needs.
+The v2 ruling had even named `baseFrequency`/`numOctaves`/`stdDeviation` as 005's
+path. They pass the SSR casing gate but are never _claimed_, so the gate never runs
+for them.
+
+- **Blocker 2 (two masking tests, both reproduced)**:
+    - `svg.spec.ts:547` feeds those keys straight to `computeSSRSVGAttrValues`, bypassing
+      classification — it looks like filter-primitive coverage and is why Blocker 1
+      survived the gate.
+    - `+page.svelte:297` binds `highlight` to the `mv-circle` `<svg>`; `attr-rect` is a
+      separate `<svg>` at `:374-390`. The "unrelated re-render does not clobber" e2e
+      toggles the former and asserts on the latter, so it passes even if the bug returns.
+
+- **Guard's own miss**: all 8 done criteria passed and the work still fails
+  `Why this matters` for filter primitives — textbook "in-scope but beside the point."
+  The `attrScale` → `feDisplacementMap` demo made the filter path look exercised; no
+  test ever pushed a bare filter-primitive key through classification. Third time this
+  plan produced a green check standing in for an unverified property (cf. Findings 3, 8).
+
+- **Flips to PASS when**: the allowlist claims filter-primitive attrs (preferably by
+  resolving against `camelCaseAttributes` instead of another hand-maintained list); a
+  unit case drives them through `extractSVGMotionValueAttributes`; an e2e asserts a
+  MotionValue-driven `stdDeviation` never renders `[object Object]`; the `highlight`
+  toggle moves onto the `attr-rect` subtree.
+
+- Non-blocking: missing `role="toolbar"`, non-self-contained docs snippets, a wrong SSR
+  doc comment at `spec.ts:33-36`, and missing `@example` JSDoc on `attrY`/`attrScale`.
+
+---

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.md
@@ -292,3 +292,85 @@ Stop and report back (do not improvise) if:
   subscription overhead.
 - Deferred: MotionValue-driven `transform` attribute on SVG (upstream handles
   via transform box tricks); `useMotionValueEvent`-style attr listeners.
+
+## Amendment — Upstream ruling on Step 2.3 SSR attribute casing (2026-07-09)
+
+**Question put to the plan author**: Step 2.3 requires SSR to emit DOM
+attribute names (`strokeDashoffset` → `stroke-dashoffset`), but naive
+dash-casing breaks `viewBox` → `view-box` (inert). The executor gated
+dash-casing on motion-dom's exported `camelCaseAttributes` set and pinned
+tests for `viewBox` (unchanged), `strokeDashoffset` (kebab), and
+`'stroke-width'` (untouched), plus an SSR e2e asserting the payload contains
+`stroke-dashoffset="…"` and not `strokeDashoffset=`.
+
+**Ruling: APPROVED — the gate is upstream's own mechanism, verbatim.**
+Verified against `~/Github/motion` at v12.42.2:
+
+1. **Write path** — `packages/motion-dom/src/render/svg/utils/render.ts:15-19`:
+   every rendered SVG attr goes through
+   `!camelCaseAttributes.has(key) ? camelToDash(key) : key`. Dash-case
+   everything except the allowlist. This is the exact semantic Step 2.3's SSR
+   emitter must mirror.
+2. **The allowlist** — `packages/motion-dom/src/render/svg/utils/camel-case-attrs.ts:4-28`
+   (**23 entries** — verified against both the source and the installed
+   package's `camelCaseAttributes.size`; use 23 as the drift-check reference on
+   version bumps): `viewBox`, `baseFrequency`, `numOctaves`, `stdDeviation`,
+   `gradientTransform`, `pathLength`, `markerWidth/Height`,
+   `keySplines`/`keyTimes`, `textLength`, …. It is a deliberate public export
+   (`motion-dom/src/index.ts:302`, confirmed reachable at the installed
+   version) — **import it; do not vendor a copy**, so upstream additions track
+   automatically on version bumps. **`camelToDash` is likewise a public
+   motion-dom export (verified on the installed package) — import it too;
+   hand-rolling the dash-caser is the same vendoring mistake one function
+   over.** Note the filter-primitive entries (`baseFrequency`, `numOctaves`,
+   `stdDeviation`) are exactly what Plan 005's `feTurbulence` work will drive
+   through this path.
+3. **Already-kebab keys are safe by construction** —
+   `packages/motion-dom/src/render/dom/utils/camel-to-dash.ts` is a pure
+   uppercase-letter replacer; `'stroke-width'` passes through unchanged. The
+   pinned test matches upstream behavior.
+4. **NEW NORMATIVE REQUIREMENT — gate ordering vs `attr` prefix.** The casing
+   gate MUST run **after** `resolveSVGAttrKey` strips the `attr` prefix, never
+   before. `attrX` is not in `camelCaseAttributes`, so gating it first emits
+   the inert attribute `attr-x` instead of `x` (probed on the installed
+   package: `attrX → attr-x`, `attrScale → attr-scale`). This is upstream's
+   own ordering: `buildSVGAttrs`
+   (`packages/motion-dom/src/render/svg/utils/build-attrs.ts:23-25,82-85`)
+   destructures `attrX/attrY/attrScale` into `attrs.x/y/scale` _before_
+   `renderSVG` ever applies the gate. Both orderings pass a naive
+   `strokeDashoffset` test, so this needs its own unit case:
+   `attrX` through resolve-then-gate → `x` (and never `attr-x`).
+5. **Read-path symmetry (conditional).** Upstream applies the _same_ gate
+   before reading: `packages/motion-dom/src/render/svg/SVGVisualElement.ts:39`
+   runs the gate before `instance.getAttribute(key)`. **This plan's current
+   scope has no attribute read-back path** (the only SVG-attribute
+   `getAttribute` calls in `src/lib/` are hardcoded kebab strings in the
+   path pipeline, `_MotionContainer.svelte:882,888`, out of scope here) — so
+   no read-back code or test is required. The requirement is conditional: IF
+   the implementation introduces any attribute read-back (initial-value
+   resolution, SSR/hydration reconciliation), it MUST apply the identical
+   gate, after `attr`-prefix resolution per point 4, or a value written as
+   `stroke-dashoffset` read back via `getAttribute('strokeDashoffset')`
+   returns `null`. Do not build a read-back path just to satisfy this point.
+
+Context: upstream never needs this conversion in its _React SSR_ path because
+React JSX normalizes SVG attribute casing at the framework layer; motion-dom's
+imperative `renderSVG` is the upstream analogue of our Svelte SSR emitter, so
+its semantics are the correct reference.
+
+**Correction record (v2, 2026-07-09, same day):** the guard verified the v1
+ruling and found three defects, all confirmed by the plan author against
+source and the installed package before this revision: (a) the allowlist has
+23 entries, not 26 as v1 stated; (b) v1 omitted that `camelToDash` is itself
+a public export — now in point 2; (c) v1 missed the gate-vs-`attr`-prefix
+ordering hazard — now normative point 4 with its own unit case; and v1's
+read-path requirement mandated a unit test for a read-back path that does not
+exist in scope — now conditional point 5. Points 1-3's citations were
+verified exact by the guard.
+
+— _Ruled by the plan author (Claude Fable 5, advisor session of 2026-07-08/09),
+against upstream source `~/Github/motion` v12.42.2, at maintainer request;
+v2 corrections adopted after independent guard verification. The guard should
+treat points 1-3 as confirmation of the executor's current implementation,
+point 4 as a new requirement (with unit case) to verify before DONE, and
+point 5 as conditional-only._

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.md
@@ -23,6 +23,20 @@
 > camelCase; (b) Step 1's attr-key wording; (c) the test plan now asserts on the
 > **bound channel** rather than assuming an attribute. See
 > `002-svg-motionvalue-attributes.guard.md`, checkpoint 2026-07-09.
+>
+> Revision 2026-07-09 (b): **scope addition, operator-approved.** SVG tag names
+> are case-sensitive, but our generated components hardcode a lowercase `tag`
+> (`Fedisplacementmap.svelte:11` → `tag="fedisplacementmap"`), so
+> `createElementNS(NS, 'fedisplacementmap')` returns an inert generic
+> `SVGElement` instead of `SVGFEDisplacementMapElement` and the filter primitive
+> is silently ignored. Now in scope: `SVG_TAG_CASING` + `resolveSVGTagName` in
+> `svg.ts`, applied in `_MotionContainer.svelte` before render. **The fix is only
+> observable on client-created elements** — the HTML parser auto-corrects SVG tag
+> case, and Svelte reuses the parsed node when hydrating
+> (`svelte/src/internal/client/dom/blocks/svelte-element.js:74`:
+> `element = hydrating ? element : create_element(next_tag, ns)`), so a
+> first-paint assertion after `page.goto` passes with **or without** the fix.
+> See the tag-casing test-plan bullet.
 
 ## Status
 
@@ -31,8 +45,8 @@
 - **Risk**: MED
 - **Depends on**: none
 - **Category**: direction (upstream parity)
-- **Planned at**: commit `af90f5a`, 2026-07-09 (re-stamped on the 2026-07-09 revision;
-  originally `634983b`, 2026-07-08)
+- **Planned at**: commit `9557778`, 2026-07-09 (re-stamped on revision (b);
+  previously `af90f5a`; originally `634983b`, 2026-07-08)
 - **Issue**: <https://github.com/humanspeak/svelte-motion/issues/435>
 
 ## Why this matters
@@ -114,7 +128,8 @@ do not change the port config).
 
 **In scope** (the only files you should modify/create):
 
-- `src/lib/utils/svg.ts` (attribute classification helpers)
+- `src/lib/utils/svg.ts` (attribute classification helpers; plus `SVG_TAG_CASING` /
+  `resolveSVGTagName` per revision (b))
 - `src/lib/utils/svg.spec.ts` (extend)
 - `src/lib/html/_MotionContainer.svelte` (MotionValue-attr subscription + attrX/Y/Scale mapping)
 - `src/lib/types.ts` (attrX/attrY/attrScale types)
@@ -258,6 +273,15 @@ clean; `pnpm exec playwright test e2e/svg` → pass.
   payload carries a numeric value).
 - Cover at least one key from each channel, so a regression in either routing
   branch is caught: `attrX` (attribute) and `cx` (style).
+- **Tag casing (revision (b)) must be asserted on a client-created element.** The
+  HTML parser silently corrects `<fedisplacementmap>` → `feDisplacementMap` when
+  it parses SSR markup, and Svelte's hydration reuses that node rather than
+  calling `create_element` (`svelte-element.js:74`). So `page.goto(ROUTE)` then
+  reading `tagName` passes **even with the fix reverted** — a vacuous assertion.
+  Assert after the `{#if mounted}` toggle round-trips (the remount path calls
+  `createElementNS` with the tag verbatim), checking `tagName`,
+  `constructor.name === 'SVGFEDisplacementMapElement'`, and that the `scale` IDL
+  property exists — a lowercase tag yields a generic `SVGElement` with no `scale`.
 - Pattern: model unit tests after existing `src/lib/utils/svg.spec.ts` blocks;
   e2e after `e2e/svg/` existing specs.
 
@@ -270,6 +294,8 @@ clean; `pnpm exec playwright test e2e/svg` → pass.
 - [ ] Docs page exists with nav entry; sitemap regenerated
 - [ ] `git status` shows no modified files outside the in-scope list
 - [ ] Batch README status row updated
+- [ ] Tag-casing assertion runs against a **client-created** element (post-remount),
+      not first paint — see the test plan
 
 ## STOP conditions
 

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.md
@@ -37,6 +37,15 @@
 > `element = hydrating ? element : create_element(next_tag, ns)`), so a
 > first-paint assertion after `page.goto` passes with **or without** the fix.
 > See the tag-casing test-plan bullet.
+>
+> Revision 2026-07-09 (c): **plan defect, corrected after the work passed.** Step 4
+> told the executor to run `pnpm --filter docs sitemap:manifest`; that script does
+> not exist. `docs/src/lib/sitemap-manifest.json` is gitignored
+> (`docs/.gitignore:36`) and emitted by a docs vite plugin at build time. The
+> criterion's intent — the new routes appear in the sitemap — was verified
+> independently (manifest contains `svg-animation`, 2 entries) **before** the PASS
+> was granted, so this edit records reality; it did not lower a bar to reach a
+> verdict. Step 4 and done-criterion 5 reworded.
 
 ## Status
 
@@ -45,8 +54,8 @@
 - **Risk**: MED
 - **Depends on**: none
 - **Category**: direction (upstream parity)
-- **Planned at**: commit `9557778`, 2026-07-09 (re-stamped on revision (b);
-  previously `af90f5a`; originally `634983b`, 2026-07-08)
+- **Planned at**: commit `599372b`, 2026-07-09 (re-stamped on revision (c);
+  previously `9557778`, `af90f5a`; originally `634983b`, 2026-07-08)
 - **Issue**: <https://github.com/humanspeak/svelte-motion/issues/435>
 
 ## Why this matters
@@ -247,7 +256,10 @@ Create `e2e/svg/motion-value-attributes.spec.ts` (model after an existing spec i
   `docs/src/lib/examples/svg-animation/`, example route under
   `docs/src/routes/examples/svg-animation/`, nav entry in
   `docs/src/lib/docsNav.ts`.
-- Regenerate sitemap: `pnpm --filter docs sitemap:manifest`.
+- Sitemap: nothing to run. `docs/src/lib/sitemap-manifest.json` is gitignored
+  (`docs/.gitignore:36`) and emitted by a docs vite plugin on build; the
+  `sitemap:manifest` script this plan originally named no longer exists. Confirm
+  the built manifest contains the new routes.
 - Match the structure of an existing docs page, e.g.
   `docs/src/routes/docs/transform-template/`.
 
@@ -291,7 +303,8 @@ clean; `pnpm exec playwright test e2e/svg` → pass.
 - [ ] `pnpm test` exits 0; new svg.spec.ts cases exist and pass
 - [ ] `pnpm exec playwright test e2e/svg` exits 0 incl. new spec
 - [ ] Demo route exists and is linked from `src/routes/+page.svelte`
-- [ ] Docs page exists with nav entry; sitemap regenerated
+- [ ] Docs page exists with nav entry; the build-generated sitemap manifest
+      contains the new routes (see Step 4 — there is no `sitemap:manifest` script)
 - [ ] `git status` shows no modified files outside the in-scope list
 - [ ] Batch README status row updated
 - [ ] Tag-casing assertion runs against a **client-created** element (post-remount),

--- a/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.md
+++ b/.agents/.plans/upstream-parity-top3/002-svg-motionvalue-attributes.md
@@ -7,10 +7,22 @@
 > in the `README.md` that sits alongside this plan file
 > (`.agents/.plans/upstream-parity-top3/README.md`).
 >
-> **Drift check (run first)**: `git diff --stat 634983b..HEAD -- src/lib/utils/svg.ts src/lib/html/_MotionContainer.svelte src/lib/types.ts`
+> **Drift check (run first)**: `git diff --stat af90f5a..HEAD -- src/lib/utils/svg.ts src/lib/html/_MotionContainer.svelte src/lib/types.ts`
 > If any in-scope file changed since this plan was written, compare the
 > "Current state" excerpts against the live code before proceeding; on a
 > mismatch, treat it as a STOP condition.
+>
+> Revision 2026-07-09: `svgEffect` writes MotionValue-bound props to **two
+> different DOM channels**, and the original plan wrongly implied a single
+> "attribute" one. Verified in Chromium: `cx cy r rx ry x y width height d`
+> and `stroke-*`/`*Opacity`/`stopColor`/`offset` are CSS properties, so
+> `key in element.style` is true and they are written to `element.style` —
+> `getAttribute('cx')` never changes. Only `points viewBox x1 y1 x2 y2` and the
+> `attrX/attrY/attrScale` family are written with `setAttribute`. Amended:
+> (a) the allowlist must carry kebab-case DOM spellings, not just React's
+> camelCase; (b) Step 1's attr-key wording; (c) the test plan now asserts on the
+> **bound channel** rather than assuming an attribute. See
+> `002-svg-motionvalue-attributes.guard.md`, checkpoint 2026-07-09.
 
 ## Status
 
@@ -19,7 +31,8 @@
 - **Risk**: MED
 - **Depends on**: none
 - **Category**: direction (upstream parity)
-- **Planned at**: commit `634983b`, 2026-07-08
+- **Planned at**: commit `af90f5a`, 2026-07-09 (re-stamped on the 2026-07-09 revision;
+  originally `634983b`, 2026-07-08)
 - **Issue**: <https://github.com/humanspeak/svelte-motion/issues/435>
 
 ## Why this matters
@@ -133,19 +146,33 @@ do not change the port config).
 
 Add to `src/lib/utils/svg.ts`:
 
-- An `SVG_ATTRIBUTE_PROPERTIES` set covering the attribute-animatable keys
-  upstream supports: `cx, cy, r, rx, ry, x, y, x1, y1, x2, y2, width, height,
-points, d, offset, stopColor, stopOpacity, fillOpacity, strokeOpacity,
-strokeWidth, viewBox` (cross-check against upstream
-  `build-attrs.ts`/`camel-case-attrs.ts` and include what upstream includes —
-  cite the upstream file in the JSDoc).
+- An `SVG_ATTRIBUTE_PROPERTIES` set covering the animatable keys upstream
+  supports: `cx, cy, r, rx, ry, x, y, x1, y1, x2, y2, width, height, points, d,
+offset, stopColor, stopOpacity, fillOpacity, strokeOpacity, strokeWidth,
+viewBox` (cross-check against upstream `build-attrs.ts`/`camel-case-attrs.ts`
+  and include what upstream includes — cite the upstream file in the JSDoc).
+- **The set must also carry the kebab-case DOM spellings** of every hyphenated
+  key — `stop-color, stop-opacity, fill-opacity, stroke-opacity, stroke-width,
+stroke-dashoffset, stroke-dasharray` — or normalize the key before lookup.
+  Upstream's list is React-facing; Svelte templates take the DOM spelling, so a
+  user writes `<motion.circle stroke-width={mv}>`. A kebab key that misses the
+  allowlist is never claimed out of the raw spread and renders
+  `stroke-width="[object Object]"` — the exact bug this plan exists to kill.
+  (`'stroke-width' in element.style` is `true` in Chromium, so once claimed it
+  routes correctly through `svgEffect` with no extra work.)
 - A helper `extractSVGMotionValueAttributes(rest: Record<string, unknown>)` that
   returns `{ motionValueAttrs, staticAttrs }` — splitting entries whose value is
-  a MotionValue from plain values. Include `attrX`/`attrY`/`attrScale` mapping to
-  `x`/`y`/`scale` here.
+  a MotionValue from plain values.
+  **Do not rename `attrX`/`attrY`/`attrScale` on the MotionValue side.**
+  `svgEffect` does its own `/^attr([A-Z])/` conversion
+  (`effects/svg/index.ts:44-62`); pre-renaming `attrScale` → `scale` makes it hit
+  the `key in element.style` branch and become a CSS style instead of an
+  attribute. Expose the rename as a separate `resolveSVGAttrKey(key)` helper, and
+  apply it only to **static** attr-prefixed props and to SSR output.
 
 **Verify**: `pnpm test src/lib/utils/svg.spec.ts` → passes (write the unit tests
-in the same step: classification, attrX→x mapping, non-MotionValue passthrough).
+in the same step: classification incl. at least one kebab-case key, attrX→x
+mapping via `resolveSVGAttrKey`, non-MotionValue passthrough).
 
 ### Step 2: Subscribe MotionValue attributes in `_MotionContainer.svelte`
 
@@ -161,7 +188,12 @@ In the SVG branch of `_MotionContainer.svelte`:
    `styleEffect` in the file, ~line 617).
 3. SSR: render the MotionValue's **current** value as the initial attribute so
    server output is correct and hydration doesn't flash (`[object Object]` must
-   never appear in SSR output either).
+   never appear in SSR output either). Emit the **DOM attribute name**: strip the
+   `attr` prefix (`attrX` → `x`) and use the kebab spelling for hyphenated keys
+   (`strokeDashoffset` → `stroke-dashoffset`). SVG attribute names are
+   case-sensitive, so a `strokeDashoffset` attribute is inert and the value will
+   flash on hydration. Style-routed keys (`cx`, `r`, …) SSR correctly as
+   presentation attributes: the client-set CSS property simply wins afterwards.
 
 **Verify**: `pnpm check` → 0 errors. Then the demo (Step 3) shows a moving circle.
 
@@ -176,8 +208,19 @@ Create `src/routes/tests/svg/motion-value-attributes/+page.svelte`:
 Create `e2e/svg/motion-value-attributes.spec.ts` (model after an existing spec in
 `e2e/svg/`):
 
-- Assert the rendered attribute is numeric (never `[object Object]`).
-- Mutate the MotionValue (click the button), poll the attribute, assert it changes.
+- Assert the rendered value is numeric (never `[object Object]`).
+- Mutate the MotionValue (click the button), poll the **bound channel**, assert it
+  changes. Read the channel the key actually routes to — `getAttribute(key)` for
+  `points`/`viewBox`/`x1..y2`/`attrX`/`attrY`/`attrScale`, and
+  `getComputedStyle(el)[key]` for `cx`/`cy`/`r`/`x`/`y`/`width`/`height`/`d`/
+  `stroke-*`. Polling `getAttribute('cx')` will never observe a change and the
+  test will hang until timeout.
+- Computed styles carry units (`getComputedStyle(el).strokeDashoffset` → `"12.5px"`).
+  Parse with `parseFloat`, not `Number` — `Number("12.5px")` is `NaN`, and
+  `expect(NaN).not.toBe(NaN)` **fails** because `toBe` is `Object.is`.
+- The "plain numeric attribute stays static" assertion must read the same channel
+  the live element uses; asserting `getAttribute('cx')` is unchanged passes
+  vacuously even when the subscription is entirely broken.
 
 **Verify**: `pnpm exec playwright test e2e/svg` → all pass.
 
@@ -202,12 +245,19 @@ clean; `pnpm exec playwright test e2e/svg` → pass.
 
 ## Test plan
 
-- Unit (`src/lib/utils/svg.spec.ts`): attribute classification; attrX/attrY/attrScale
-  → x/y/scale mapping; MotionValue extraction leaves static attrs untouched;
-  path props are NOT claimed by the new set (no double handling).
+- Unit (`src/lib/utils/svg.spec.ts`): attribute classification, **including at least
+  one kebab-case key (`stroke-width`)**; attrX/attrY/attrScale → x/y/scale mapping
+  via `resolveSVGAttrKey`; MotionValue-side keys stay un-renamed so `svgEffect` can
+  route them; MotionValue extraction leaves static attrs untouched; path props are
+  NOT claimed by the new set (no double handling); SSR helper emits DOM attribute
+  names (`strokeDashoffset` → `stroke-dashoffset`, `attrX` → `x`).
 - e2e (`e2e/svg/motion-value-attributes.spec.ts`): no `[object Object]` in DOM;
-  attribute updates when MotionValue changes; SSR/hydration initial value correct
-  (load page with JS, assert first paint attribute is numeric).
+  **the bound channel updates** when the MotionValue changes (attribute for
+  attr-routed keys, computed style for style-routed keys — see Step 3);
+  SSR/hydration initial value correct (fetch the route server-side, assert the
+  payload carries a numeric value).
+- Cover at least one key from each channel, so a regression in either routing
+  branch is caught: `attrX` (attribute) and `cx` (style).
 - Pattern: model unit tests after existing `src/lib/utils/svg.spec.ts` blocks;
   e2e after `e2e/svg/` existing specs.
 

--- a/.agents/.plans/upstream-parity-top3/README.md
+++ b/.agents/.plans/upstream-parity-top3/README.md
@@ -13,13 +13,13 @@ the A2 projection issues) — see "Superseded issues" below.
 
 ## Execution order & status
 
-| Plan | Title                                                                | Priority   | Effort | Depends on | Docs update?                                                               | Status      |
-| ---- | -------------------------------------------------------------------- | ---------- | ------ | ---------- | -------------------------------------------------------------------------- | ----------- |
-| 001  | Re-type `animate` for AugmentedMotionValue (kill all 10 casts)       | P1 — FIRST | S–M    | —          | Small — delete casts from docs examples; check prose                       | DONE        |
-| 002  | SVG MotionValue attribute binding + attrX/attrY/attrScale            | P1         | M      | —          | **YES — new docs page** (`docs/svg-animation`)                             | IN PROGRESS |
-| 003  | Full transform composition during drag (buildTransform semantics)    | P1         | M      | —          | No public docs; in-code decision comments must be updated                  | TODO        |
-| 004  | Motion-dom projection authoritative (page-space, retire legacy FLIP) | P1         | L      | 003        | **YES — update** `docs/layout-animations`; shared-layout page as follow-up | TODO        |
-| 005  | Apple Intelligence wavy glow border — flagship example (smooth)      | P2 — LAST  | M      | 002        | **YES — new example page** (`examples/ai-glow-border`) + nav + sitemap     | TODO        |
+| Plan | Title                                                                | Priority   | Effort | Depends on | Docs update?                                                               | Status |
+| ---- | -------------------------------------------------------------------- | ---------- | ------ | ---------- | -------------------------------------------------------------------------- | ------ |
+| 001  | Re-type `animate` for AugmentedMotionValue (kill all 10 casts)       | P1 — FIRST | S–M    | —          | Small — delete casts from docs examples; check prose                       | DONE   |
+| 002  | SVG MotionValue attribute binding + attrX/attrY/attrScale            | P1         | M      | —          | **YES — new docs page** (`docs/svg-animation`)                             | DONE   |
+| 003  | Full transform composition during drag (buildTransform semantics)    | P1         | M      | —          | No public docs; in-code decision comments must be updated                  | TODO   |
+| 004  | Motion-dom projection authoritative (page-space, retire legacy FLIP) | P1         | L      | 003        | **YES — update** `docs/layout-animations`; shared-layout page as follow-up | TODO   |
+| 005  | Apple Intelligence wavy glow border — flagship example (smooth)      | P2 — LAST  | M      | 002        | **YES — new example page** (`examples/ai-glow-border`) + nav + sitemap     | TODO   |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) |
 REJECTED (with one-line rationale)
@@ -35,9 +35,16 @@ REJECTED (with one-line rationale)
   emit `attr-x`), with its own unit case. Point 5 (read-path symmetry) is
   conditional-only; no read-back path exists in scope.
 - 002: revision (b) 2026-07-09, operator-approved scope addition — SVG tag-name
-  casing (`fedisplacementmap` → `feDisplacementMap`). Steps 1-3 implemented and
-  green; Step 4 (docs page) outstanding. 005 depends on this: `feTurbulence` /
-  `feDisplacementMap` were unreachable before the fix.
+  casing (`fedisplacementmap` → `feDisplacementMap`). 005 depends on this:
+  `feTurbulence` / `feDisplacementMap` were unreachable before the fix.
+- 002: **DONE** 2026-07-09. All five steps complete. Step 4 shipped
+  `docs/svg-animation` (+ `examples/svg-animation`, nav entry under Animation);
+  the sitemap manifest and demo loaders are gitignored and regenerate from the
+  docs vite plugins on build, so the plan's `sitemap:manifest` command no longer
+  exists. Final gates: `pnpm check` 0 errors, unit 745/745, full e2e 314 passed
+  / 2 skipped (both skips pre-existing), docs check 0 errors, `trunk check`
+  clean. Guard Finding 8 addressed — the tag-casing e2e now asserts after the
+  `{#if mounted}` remount and was confirmed to FAIL with the fix reverted.
 
 ## Dependency notes
 

--- a/.agents/.plans/upstream-parity-top3/README.md
+++ b/.agents/.plans/upstream-parity-top3/README.md
@@ -27,6 +27,13 @@ REJECTED (with one-line rationale)
 - 002: red tests landed; plan amended 2026-07-09 (two DOM channels — style vs
   attribute; kebab-case allowlist). Executor to revise tests, then implement.
   See `002-svg-motionvalue-attributes.guard.md`.
+- 002: upstream ruling 2026-07-09 appended to the plan ("Amendment — Upstream
+  ruling on Step 2.3 SSR attribute casing"), **corrected to v2 same day after
+  guard verification**: `camelCaseAttributes` gate APPROVED as
+  upstream-verbatim (23 entries; import `camelToDash` too). NEW normative
+  point 4 — the gate runs AFTER `attr`-prefix resolution (`attrX` must never
+  emit `attr-x`), with its own unit case. Point 5 (read-path symmetry) is
+  conditional-only; no read-back path exists in scope.
 
 ## Dependency notes
 

--- a/.agents/.plans/upstream-parity-top3/README.md
+++ b/.agents/.plans/upstream-parity-top3/README.md
@@ -34,6 +34,10 @@ REJECTED (with one-line rationale)
   point 4 — the gate runs AFTER `attr`-prefix resolution (`attrX` must never
   emit `attr-x`), with its own unit case. Point 5 (read-path symmetry) is
   conditional-only; no read-back path exists in scope.
+- 002: revision (b) 2026-07-09, operator-approved scope addition — SVG tag-name
+  casing (`fedisplacementmap` → `feDisplacementMap`). Steps 1-3 implemented and
+  green; Step 4 (docs page) outstanding. 005 depends on this: `feTurbulence` /
+  `feDisplacementMap` were unreachable before the fix.
 
 ## Dependency notes
 

--- a/.agents/.plans/upstream-parity-top3/README.md
+++ b/.agents/.plans/upstream-parity-top3/README.md
@@ -13,16 +13,20 @@ the A2 projection issues) — see "Superseded issues" below.
 
 ## Execution order & status
 
-| Plan | Title                                                                | Priority   | Effort | Depends on | Docs update?                                                               | Status |
-| ---- | -------------------------------------------------------------------- | ---------- | ------ | ---------- | -------------------------------------------------------------------------- | ------ |
-| 001  | Re-type `animate` for AugmentedMotionValue (kill all 10 casts)       | P1 — FIRST | S–M    | —          | Small — delete casts from docs examples; check prose                       | DONE   |
-| 002  | SVG MotionValue attribute binding + attrX/attrY/attrScale            | P1         | M      | —          | **YES — new docs page** (`docs/svg-animation`)                             | TODO   |
-| 003  | Full transform composition during drag (buildTransform semantics)    | P1         | M      | —          | No public docs; in-code decision comments must be updated                  | TODO   |
-| 004  | Motion-dom projection authoritative (page-space, retire legacy FLIP) | P1         | L      | 003        | **YES — update** `docs/layout-animations`; shared-layout page as follow-up | TODO   |
-| 005  | Apple Intelligence wavy glow border — flagship example (smooth)      | P2 — LAST  | M      | 002        | **YES — new example page** (`examples/ai-glow-border`) + nav + sitemap     | TODO   |
+| Plan | Title                                                                | Priority   | Effort | Depends on | Docs update?                                                               | Status      |
+| ---- | -------------------------------------------------------------------- | ---------- | ------ | ---------- | -------------------------------------------------------------------------- | ----------- |
+| 001  | Re-type `animate` for AugmentedMotionValue (kill all 10 casts)       | P1 — FIRST | S–M    | —          | Small — delete casts from docs examples; check prose                       | DONE        |
+| 002  | SVG MotionValue attribute binding + attrX/attrY/attrScale            | P1         | M      | —          | **YES — new docs page** (`docs/svg-animation`)                             | IN PROGRESS |
+| 003  | Full transform composition during drag (buildTransform semantics)    | P1         | M      | —          | No public docs; in-code decision comments must be updated                  | TODO        |
+| 004  | Motion-dom projection authoritative (page-space, retire legacy FLIP) | P1         | L      | 003        | **YES — update** `docs/layout-animations`; shared-layout page as follow-up | TODO        |
+| 005  | Apple Intelligence wavy glow border — flagship example (smooth)      | P2 — LAST  | M      | 002        | **YES — new example page** (`examples/ai-glow-border`) + nav + sitemap     | TODO        |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) |
 REJECTED (with one-line rationale)
+
+- 002: red tests landed; plan amended 2026-07-09 (two DOM channels — style vs
+  attribute; kebab-case allowlist). Executor to revise tests, then implement.
+  See `002-svg-motionvalue-attributes.guard.md`.
 
 ## Dependency notes
 

--- a/.agents/.plans/upstream-parity-top3/assets/svg-channel-probe.mjs
+++ b/.agents/.plans/upstream-parity-top3/assets/svg-channel-probe.mjs
@@ -1,0 +1,98 @@
+/**
+ * Plan 002 evidence — which SVG keys does `svgEffect` write as attributes,
+ * and which as CSS properties?
+ *
+ * Upstream `motion-dom/src/effects/svg/index.ts` (`addSVGValue`) picks the
+ * channel at runtime:
+ *
+ *     if (key.startsWith('path'))  -> addSVGPathValue
+ *     else if (key.startsWith('attr')) -> addAttrValue(convertAttrKey(key))
+ *     const handler = key in element.style ? addStyleValue : addAttrValue
+ *
+ * So the split depends on `key in element.style` **in the target browser**, not
+ * on anything in this repo. This probe answers that question against the same
+ * Chromium the e2e suite drives, and is the basis for the 2026-07-09 amendment
+ * to `002-svg-motionvalue-attributes.md` (see the guard log).
+ *
+ * Run from the repo root:
+ *     node .agents/.plans/upstream-parity-top3/assets/svg-channel-probe.mjs
+ *
+ * Expected: cx/cy/r/rx/ry/x/y/width/height/d and the stroke-*, *Opacity,
+ * stopColor, offset families are CSS properties (style-routed). Only
+ * points/viewBox/x1/y1/x2/y2 -- plus the attrX/attrY/attrScale prefix family --
+ * reach setAttribute. Re-run this if a Chromium bump is suspected of moving a
+ * key from one channel to the other.
+ */
+import { chromium } from '@playwright/test'
+
+/** Keys to classify, in the order they appear in SVG_ATTRIBUTE_PROPERTIES. */
+const KEYS = [
+    'cx',
+    'cy',
+    'r',
+    'rx',
+    'ry',
+    'x',
+    'y',
+    'width',
+    'height',
+    'd',
+    'points',
+    'viewBox',
+    'x1',
+    'y1',
+    'x2',
+    'y2',
+    'strokeDashoffset',
+    'strokeWidth',
+    'stopColor',
+    'stopOpacity',
+    'fillOpacity',
+    'strokeOpacity',
+    'offset',
+    'stroke-width',
+    'stroke-dashoffset'
+]
+
+const browser = await chromium.launch()
+const page = await browser.newPage()
+await page.setContent('<svg><circle id="c" cx="5" cy="5" r="3"/></svg>')
+
+const result = await page.evaluate((keys) => {
+    const circle = document.getElementById('c')
+    const inStyle = Object.fromEntries(keys.map((key) => [key, key in circle.style]))
+
+    // Computed styles carry units -- this is why the e2e specs must parseFloat.
+    circle.style.strokeDashoffset = 12.5
+    const computedDashoffset = getComputedStyle(circle).strokeDashoffset
+
+    // A style-routed write never touches the attribute: polling getAttribute('cx')
+    // for a change will hang until the test times out.
+    circle.style.cx = '40px'
+
+    return {
+        inStyle,
+        computedDashoffset,
+        cxAttributeAfterStyleWrite: circle.getAttribute('cx'),
+        cxComputedAfterStyleWrite: getComputedStyle(circle).cx
+    }
+}, KEYS)
+
+const styleRouted = KEYS.filter((key) => result.inStyle[key])
+const attrRouted = KEYS.filter((key) => !result.inStyle[key])
+
+console.log(`chromium ${browser.version()}\n`)
+console.log(`style-routed (addStyleValue): ${styleRouted.join(' ')}`)
+console.log(`attr-routed  (addAttrValue) : ${attrRouted.join(' ')}\n`)
+console.log(`element.style.strokeDashoffset = 12.5 -> computed ${result.computedDashoffset}`)
+console.log(
+    `  Number(${JSON.stringify(result.computedDashoffset)}) === ${Number(result.computedDashoffset)}`
+)
+console.log(
+    `element.style.cx = '40px' -> getAttribute('cx') = ${JSON.stringify(result.cxAttributeAfterStyleWrite)}`
+)
+console.log(
+    `                          -> computed cx        = ${JSON.stringify(result.cxComputedAfterStyleWrite)}`
+)
+
+await browser.close()

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -58,6 +58,7 @@ export const docsSections: NavSection[] = [
         items: [
             { title: 'Layout Animations', href: '/docs/layout-animations', icon: Move },
             { title: 'layoutDependency', href: '/docs/layout-dependency', icon: Gauge },
+            { title: 'SVG Animation', href: '/docs/svg-animation', icon: Wand },
             { title: 'transformTemplate', href: '/docs/transform-template', icon: Code },
             { title: 'Variants', href: '/docs/variants', icon: Layers },
             { title: 'View Transitions', href: '/docs/view', icon: Sparkles }

--- a/docs/src/lib/examples/svg-animation/demos/Default.svelte
+++ b/docs/src/lib/examples/svg-animation/demos/Default.svelte
@@ -1,0 +1,280 @@
+<script lang="ts">
+    import { CircleDot, RotateCcw } from '@lucide/svelte'
+    import { motion, useSpring, useTransform } from '@humanspeak/svelte-motion'
+
+    const RADIUS = 54
+    const CIRCUMFERENCE = 2 * Math.PI * RADIUS
+
+    /** A single spring drives every bound attribute below. */
+    const progress = useSpring(0, { stiffness: 120, damping: 20 })
+
+    /** Style-routed: `stroke-dashoffset` is a CSS property, so it lands on element.style. */
+    const dashOffset = useTransform(progress, [0, 1], [CIRCUMFERENCE, 0])
+
+    /** Style-routed: the dot's `cx` sweeps across the track. */
+    const dotCx = useTransform(progress, [0, 1], [16, 284])
+
+    /** Attribute-routed: `x2` is not a CSS property, so it lands on setAttribute. */
+    const lineX2 = useTransform(progress, [0, 1], [16, 284])
+
+    let percent = $state(0)
+    const setProgress = (value: number) => {
+        percent = Math.round(value * 100)
+        progress.set(value)
+    }
+</script>
+
+<!-- dk-strip: docs-kit positioning shell - stripped from the published code. -->
+<div class="dk-demo-shell">
+    <div class="toolbar" aria-label="Progress controls">
+        <button type="button" onclick={() => setProgress(0.25)}>25%</button>
+        <button type="button" onclick={() => setProgress(0.5)}>50%</button>
+        <button type="button" class="primary" onclick={() => setProgress(1)}>
+            <CircleDot size={15} />
+            Complete
+        </button>
+        <button type="button" onclick={() => setProgress(0)}>
+            <RotateCcw size={15} />
+            Reset
+        </button>
+    </div>
+
+    <div class="stage">
+        <div class="intro">
+            <span>one MotionValue</span>
+            <strong>Bound straight to SVG attributes — no keyframes</strong>
+        </div>
+
+        <div class="panels">
+            <section class="panel">
+                <div class="panel-head">
+                    <span>stroke-dashoffset</span>
+                    <strong>progress ring</strong>
+                </div>
+                <svg viewBox="0 0 140 140" class="ring" role="img" aria-label="{percent}% complete">
+                    <circle cx="70" cy="70" r={RADIUS} class="ring-track" />
+                    <motion.circle
+                        cx={70}
+                        cy={70}
+                        r={RADIUS}
+                        class="ring-value"
+                        stroke-dasharray={CIRCUMFERENCE}
+                        stroke-dashoffset={dashOffset}
+                        transform="rotate(-90 70 70)"
+                    />
+                    <text x="70" y="78" class="ring-label">{percent}%</text>
+                </svg>
+            </section>
+
+            <section class="panel">
+                <div class="panel-head">
+                    <span>cx &amp; x2</span>
+                    <strong>both DOM channels</strong>
+                </div>
+                <svg viewBox="0 0 300 90" class="track" role="presentation">
+                    <line x1="16" y1="62" x2="284" y2="62" class="track-rail" />
+                    <motion.line x1={16} y1={62} x2={lineX2} y2={62} class="track-fill" />
+                    <motion.circle cx={dotCx} cy={62} r={9} class="track-dot" />
+                </svg>
+                <p class="hint">
+                    <code>cx</code> is a CSS property, so Motion writes it to
+                    <code>element.style</code>. <code>x2</code> is not, so it is written with
+                    <code>setAttribute</code>. Same MotionValue, different channels.
+                </p>
+            </section>
+        </div>
+    </div>
+</div>
+
+<style>
+    .dk-demo-shell {
+        width: 100%;
+        min-height: clamp(420px, calc(100vh - 240px), 560px);
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+        padding: 18px;
+        background: #0d1518;
+        color: #eef6fb;
+    }
+
+    .toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 8px;
+    }
+
+    button {
+        height: 36px;
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        padding: 0 14px;
+        border: 1px solid #46616a;
+        border-radius: 6px;
+        background: #142127;
+        color: #eef6fb;
+        font-size: 13px;
+        font-weight: 780;
+        cursor: pointer;
+    }
+
+    button.primary {
+        border-color: #5eead4;
+        background: #0f766e;
+    }
+
+    .stage {
+        position: relative;
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+        padding: 20px;
+        overflow: hidden;
+        border: 1px solid #2b4650;
+        background:
+            linear-gradient(90deg, rgba(94, 234, 212, 0.1) 1px, transparent 1px),
+            linear-gradient(0deg, rgba(94, 234, 212, 0.1) 1px, transparent 1px), #071114;
+        background-size: 44px 44px;
+    }
+
+    .intro {
+        position: relative;
+        z-index: 3;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: 6px 12px;
+    }
+
+    .intro span,
+    .panel-head span {
+        color: #67e8f9;
+        font-size: 11px;
+        font-weight: 850;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+    }
+
+    .intro strong {
+        color: #ecfeff;
+        font-size: 18px;
+        line-height: 1.1;
+    }
+
+    .panels {
+        position: relative;
+        z-index: 2;
+        flex: 1;
+        min-height: 0;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+        align-content: start;
+        gap: 14px;
+    }
+
+    .panel {
+        position: relative;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 16px;
+        border: 1px solid rgba(134, 184, 199, 0.42);
+        background: rgba(13, 27, 33, 0.74);
+    }
+
+    .panel-head {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 4px 12px;
+    }
+
+    .panel-head strong {
+        color: #ecfeff;
+        font-size: 16px;
+        line-height: 1.05;
+    }
+
+    .ring {
+        width: 100%;
+        max-width: 190px;
+        margin: auto;
+    }
+
+    .ring-track {
+        fill: none;
+        stroke: rgba(186, 230, 253, 0.16);
+        stroke-width: 12;
+    }
+
+    .ring-label {
+        fill: #ecfeff;
+        font-size: 24px;
+        font-weight: 800;
+        text-anchor: middle;
+    }
+
+    /* motion.* render their own elements, so Svelte's scoping never reaches them. */
+    :global(.ring-value) {
+        fill: none;
+        stroke: #5eead4;
+        stroke-width: 12;
+        stroke-linecap: round;
+        filter: drop-shadow(0 0 12px rgba(94, 234, 212, 0.45));
+    }
+
+    :global(.track-fill) {
+        stroke: #38bdf8;
+        stroke-width: 4;
+        stroke-linecap: round;
+    }
+
+    :global(.track-dot) {
+        fill: #fb7185;
+        filter: drop-shadow(0 0 10px rgba(251, 113, 133, 0.5));
+    }
+
+    .track {
+        width: 100%;
+        margin: auto 0;
+    }
+
+    .track-rail {
+        stroke: rgba(186, 230, 253, 0.24);
+        stroke-width: 4;
+        stroke-linecap: round;
+    }
+
+    .hint {
+        margin: 0;
+        color: #9fb9c4;
+        font-size: 12px;
+        line-height: 1.5;
+    }
+
+    .hint code {
+        color: #5eead4;
+    }
+
+    @media (max-width: 900px) {
+        .dk-demo-shell {
+            padding: 1rem;
+        }
+
+        .intro {
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 6px;
+        }
+
+        .panels {
+            grid-template-columns: minmax(0, 1fr);
+        }
+    }
+</style>

--- a/docs/src/lib/examples/svg-animation/demos/Default.svelte
+++ b/docs/src/lib/examples/svg-animation/demos/Default.svelte
@@ -31,7 +31,7 @@
 -->
 <!-- dk-strip: docs-kit positioning shell - stripped from the published code. -->
 <div class="dk-demo-shell">
-    <div class="toolbar" aria-label="Progress controls">
+    <div class="toolbar" role="toolbar" aria-label="Progress controls">
         <button type="button" onclick={() => setProgress(0.25)}>25%</button>
         <button type="button" onclick={() => setProgress(0.5)}>50%</button>
         <button type="button" class="primary" onclick={() => setProgress(1)}>

--- a/docs/src/lib/examples/svg-animation/demos/Default.svelte
+++ b/docs/src/lib/examples/svg-animation/demos/Default.svelte
@@ -24,6 +24,11 @@
     }
 </script>
 
+<!--
+  Uses <span> rather than <strong>/<code>: docs pages wrap embedded demos in
+  `.prose-v2`, whose `strong`/`code` rules match this markup at equal specificity
+  and win on cascade order, repainting the text in the page's ink colour.
+-->
 <!-- dk-strip: docs-kit positioning shell - stripped from the published code. -->
 <div class="dk-demo-shell">
     <div class="toolbar" aria-label="Progress controls">
@@ -41,17 +46,22 @@
 
     <div class="stage">
         <div class="intro">
-            <span>one MotionValue</span>
-            <strong>Bound straight to SVG attributes — no keyframes</strong>
+            <span class="eyebrow">one MotionValue</span>
+            <span class="title">Bound straight to SVG attributes — no keyframes</span>
         </div>
 
         <div class="panels">
             <section class="panel">
                 <div class="panel-head">
-                    <span>stroke-dashoffset</span>
-                    <strong>progress ring</strong>
+                    <span class="eyebrow">stroke-dashoffset</span>
+                    <span class="panel-title">progress ring</span>
                 </div>
-                <svg viewBox="0 0 140 140" class="ring" role="img" aria-label="{percent}% complete">
+                <svg
+                    viewBox="0 0 140 140"
+                    class="progress-ring"
+                    role="img"
+                    aria-label="{percent}% complete"
+                >
                     <circle cx="70" cy="70" r={RADIUS} class="ring-track" />
                     <motion.circle
                         cx={70}
@@ -68,8 +78,8 @@
 
             <section class="panel">
                 <div class="panel-head">
-                    <span>cx &amp; x2</span>
-                    <strong>both DOM channels</strong>
+                    <span class="eyebrow">cx &amp; x2</span>
+                    <span class="panel-title">both DOM channels</span>
                 </div>
                 <svg viewBox="0 0 300 90" class="track" role="presentation">
                     <line x1="16" y1="62" x2="284" y2="62" class="track-rail" />
@@ -77,9 +87,10 @@
                     <motion.circle cx={dotCx} cy={62} r={9} class="track-dot" />
                 </svg>
                 <p class="hint">
-                    <code>cx</code> is a CSS property, so Motion writes it to
-                    <code>element.style</code>. <code>x2</code> is not, so it is written with
-                    <code>setAttribute</code>. Same MotionValue, different channels.
+                    <span class="mono">cx</span> is a CSS property, so Motion writes it to
+                    <span class="mono">element.style</span>. <span class="mono">x2</span> is not, so
+                    it is written with <span class="mono">setAttribute</span>. Same MotionValue,
+                    different channels.
                 </p>
             </section>
         </div>
@@ -88,14 +99,53 @@
 
 <style>
     .dk-demo-shell {
+        /* Light theme by default; overridden under `html.dark` below. */
+        --demo-bg: #f1f5f9;
+        --demo-stage-bg: #ffffff;
+        --demo-grid: rgba(15, 118, 110, 0.08);
+        --demo-panel-bg: rgba(248, 250, 252, 0.9);
+        --demo-border: #cbd5e1;
+        --demo-panel-border: #d5dee7;
+        --demo-ink: #0f172a;
+        --demo-ink-soft: #475569;
+        --demo-accent: #0f766e;
+        --demo-ring: #0d9488;
+        --demo-line: #0284c7;
+        --demo-dot: #e11d48;
+        --demo-rail: rgba(15, 23, 42, 0.14);
+        --demo-track: rgba(15, 23, 42, 0.1);
+        --demo-btn-bg: #ffffff;
+        --demo-btn-border: #cbd5e1;
+        --demo-glow: transparent;
+
         width: 100%;
         min-height: clamp(420px, calc(100vh - 240px), 560px);
         display: flex;
         flex-direction: column;
         gap: 14px;
         padding: 18px;
-        background: #0d1518;
-        color: #eef6fb;
+        background: var(--demo-bg);
+        color: var(--demo-ink);
+    }
+
+    :global(html.dark) .dk-demo-shell {
+        --demo-bg: #0d1518;
+        --demo-stage-bg: #071114;
+        --demo-grid: rgba(94, 234, 212, 0.1);
+        --demo-panel-bg: rgba(13, 27, 33, 0.74);
+        --demo-border: #2b4650;
+        --demo-panel-border: rgba(134, 184, 199, 0.42);
+        --demo-ink: #ecfeff;
+        --demo-ink-soft: #9fb9c4;
+        --demo-accent: #67e8f9;
+        --demo-ring: #5eead4;
+        --demo-line: #38bdf8;
+        --demo-dot: #fb7185;
+        --demo-rail: rgba(186, 230, 253, 0.24);
+        --demo-track: rgba(186, 230, 253, 0.16);
+        --demo-btn-bg: #142127;
+        --demo-btn-border: #46616a;
+        --demo-glow: rgba(94, 234, 212, 0.45);
     }
 
     .toolbar {
@@ -111,18 +161,24 @@
         align-items: center;
         gap: 7px;
         padding: 0 14px;
-        border: 1px solid #46616a;
+        border: 1px solid var(--demo-btn-border);
         border-radius: 6px;
-        background: #142127;
-        color: #eef6fb;
+        background: var(--demo-btn-bg);
+        color: var(--demo-ink);
         font-size: 13px;
         font-weight: 780;
         cursor: pointer;
     }
 
     button.primary {
-        border-color: #5eead4;
+        border-color: var(--demo-ring);
+        background: var(--demo-accent);
+        color: #f0fdfa;
+    }
+
+    :global(html.dark) button.primary {
         background: #0f766e;
+        color: #ecfeff;
     }
 
     .stage {
@@ -134,10 +190,10 @@
         gap: 18px;
         padding: 20px;
         overflow: hidden;
-        border: 1px solid #2b4650;
+        border: 1px solid var(--demo-border);
         background:
-            linear-gradient(90deg, rgba(94, 234, 212, 0.1) 1px, transparent 1px),
-            linear-gradient(0deg, rgba(94, 234, 212, 0.1) 1px, transparent 1px), #071114;
+            linear-gradient(90deg, var(--demo-grid) 1px, transparent 1px),
+            linear-gradient(0deg, var(--demo-grid) 1px, transparent 1px), var(--demo-stage-bg);
         background-size: 44px 44px;
     }
 
@@ -150,18 +206,18 @@
         gap: 6px 12px;
     }
 
-    .intro span,
-    .panel-head span {
-        color: #67e8f9;
+    .eyebrow {
+        color: var(--demo-accent);
         font-size: 11px;
         font-weight: 850;
         letter-spacing: 0.16em;
         text-transform: uppercase;
     }
 
-    .intro strong {
-        color: #ecfeff;
+    .title {
+        color: var(--demo-ink);
         font-size: 18px;
+        font-weight: 750;
         line-height: 1.1;
     }
 
@@ -183,8 +239,8 @@
         flex-direction: column;
         gap: 12px;
         padding: 16px;
-        border: 1px solid rgba(134, 184, 199, 0.42);
-        background: rgba(13, 27, 33, 0.74);
+        border: 1px solid var(--demo-panel-border);
+        background: var(--demo-panel-bg);
     }
 
     .panel-head {
@@ -195,13 +251,14 @@
         gap: 4px 12px;
     }
 
-    .panel-head strong {
-        color: #ecfeff;
+    .panel-title {
+        color: var(--demo-ink);
         font-size: 16px;
+        font-weight: 750;
         line-height: 1.05;
     }
 
-    .ring {
+    .progress-ring {
         width: 100%;
         max-width: 190px;
         margin: auto;
@@ -209,35 +266,34 @@
 
     .ring-track {
         fill: none;
-        stroke: rgba(186, 230, 253, 0.16);
+        stroke: var(--demo-track);
         stroke-width: 12;
     }
 
     .ring-label {
-        fill: #ecfeff;
+        fill: var(--demo-ink);
         font-size: 24px;
         font-weight: 800;
         text-anchor: middle;
     }
 
     /* motion.* render their own elements, so Svelte's scoping never reaches them. */
-    :global(.ring-value) {
+    .dk-demo-shell :global(.ring-value) {
         fill: none;
-        stroke: #5eead4;
+        stroke: var(--demo-ring);
         stroke-width: 12;
         stroke-linecap: round;
-        filter: drop-shadow(0 0 12px rgba(94, 234, 212, 0.45));
+        filter: drop-shadow(0 0 12px var(--demo-glow));
     }
 
-    :global(.track-fill) {
-        stroke: #38bdf8;
+    .dk-demo-shell :global(.track-fill) {
+        stroke: var(--demo-line);
         stroke-width: 4;
         stroke-linecap: round;
     }
 
-    :global(.track-dot) {
-        fill: #fb7185;
-        filter: drop-shadow(0 0 10px rgba(251, 113, 133, 0.5));
+    .dk-demo-shell :global(.track-dot) {
+        fill: var(--demo-dot);
     }
 
     .track {
@@ -246,20 +302,25 @@
     }
 
     .track-rail {
-        stroke: rgba(186, 230, 253, 0.24);
+        stroke: var(--demo-rail);
         stroke-width: 4;
         stroke-linecap: round;
     }
 
     .hint {
         margin: 0;
-        color: #9fb9c4;
+        color: var(--demo-ink-soft);
         font-size: 12px;
-        line-height: 1.5;
+        line-height: 1.6;
     }
 
-    .hint code {
-        color: #5eead4;
+    .mono {
+        padding: 1px 4px;
+        border-radius: 3px;
+        background: var(--demo-track);
+        color: var(--demo-ring);
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 11px;
     }
 
     @media (max-width: 900px) {

--- a/docs/src/routes/docs/svg-animation/+page.svx
+++ b/docs/src/routes/docs/svg-animation/+page.svx
@@ -70,6 +70,12 @@ Svelte templates take the DOM spelling of hyphenated attributes, so write
 `stroke-width`, not `strokeWidth`:
 
 ```svelte
+<script lang="ts">
+  import { motion, useSpring } from '@humanspeak/svelte-motion'
+
+  const strokeWidth = useSpring(4)
+</script>
+
 <motion.circle cx={60} cy={60} r={20} stroke-width={strokeWidth} />
 ```
 
@@ -140,6 +146,12 @@ lowercase. `motion.fedisplacementmap` renders a correctly-cased
 `<feDisplacementMap>`:
 
 ```svelte
+<script lang="ts">
+  import { motion, useSpring } from '@humanspeak/svelte-motion'
+
+  const warp = useSpring(12)
+</script>
+
 <filter id="warp">
   <feTurbulence type="turbulence" baseFrequency="0.04" numOctaves="2" result="noise" />
   <motion.fedisplacementmap in="SourceGraphic" in2="noise" attrScale={warp} />

--- a/docs/src/routes/docs/svg-animation/+page.svx
+++ b/docs/src/routes/docs/svg-animation/+page.svx
@@ -37,7 +37,7 @@ component re-render when the value changes.
 </svg>
 ```
 
-<Example isSmall exampleUrl="/examples/svg-animation">
+<Example exampleUrl="/examples/svg-animation">
   <SvgAnimationExample />
 </Example>
 

--- a/docs/src/routes/docs/svg-animation/+page.svx
+++ b/docs/src/routes/docs/svg-animation/+page.svx
@@ -1,0 +1,150 @@
+---
+title: 'SVG Animation'
+description: 'Bind MotionValues to SVG presentation attributes, draw paths, and use attrX/attrY/attrScale.'
+---
+
+<script>
+  import Example from '$lib/components/general/Example.svelte';
+  import SvgAnimationExample from '$lib/examples/svg-animation/demos/Default.svelte';
+  import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+  const seo = getSeoContext()
+  if (seo) {
+      seo.title = 'SVG Animation | Docs | Svelte Motion'
+      seo.description = 'Drive SVG presentation attributes with MotionValues, animate pathLength, and reach SVG attributes with attrX, attrY, and attrScale.'
+      seo.ogTitle = 'SVG Animation'
+      seo.ogTagline = 'MotionValues bound straight to SVG attributes'
+      seo.ogFeatures = ['SVG', 'MotionValue', 'pathLength', 'attrX']
+      seo.ogSlug = 'docs-svg-animation'
+  }
+</script>
+
+# SVG Animation
+
+Any `MotionValue` can drive an SVG presentation attribute directly. Pass it as a
+prop and Motion subscribes to it — no `animate` prop, no keyframes, and no
+component re-render when the value changes.
+
+```svelte
+<script lang="ts">
+  import { motion, useSpring } from '@humanspeak/svelte-motion'
+
+  const cx = useSpring(40)
+</script>
+
+<svg viewBox="0 0 300 120">
+  <motion.circle {cx} cy={60} r={12} fill="#60a5fa" />
+</svg>
+```
+
+<Example isSmall exampleUrl="/examples/svg-animation">
+  <SvgAnimationExample />
+</Example>
+
+## Two DOM channels
+
+Motion writes a bound attribute to one of two places, chosen per key at runtime:
+
+- Keys that are **CSS properties** in the browser — `cx`, `cy`, `r`, `rx`, `ry`,
+  `width`, `height`, `d`, and the `stroke-*` family — are written to
+  `element.style`.
+- Everything else — `points`, `viewBox`, `x1`/`y1`/`x2`/`y2` — is written with
+  `setAttribute`.
+
+This matters when you inspect the DOM or write a test. A bound `cx` never
+changes the element's `cx` **attribute**; it moves the computed style instead.
+The attribute you see in devtools is the initial server-rendered value.
+
+```ts
+// After cx.set(60):
+getComputedStyle(circle).cx    // "60px"  <- the live value
+circle.getAttribute('cx')      // "40"    <- the SSR seed, frozen
+```
+
+Both render identically. CSS geometry properties win over the matching
+presentation attribute, which is exactly why the initial attribute can stay put.
+
+## Prop names use the DOM spelling
+
+Svelte templates take the DOM spelling of hyphenated attributes, so write
+`stroke-width`, not `strokeWidth`:
+
+```svelte
+<motion.circle cx={60} cy={60} r={20} stroke-width={strokeWidth} />
+```
+
+Both spellings are accepted, but the kebab-case form is the one you would write
+for a plain `<circle>`, and it is what the rendered markup uses.
+
+## Server rendering
+
+A bound attribute is server-rendered with the MotionValue's current value, so
+the first paint is correct and nothing flashes on hydration. Attribute names are
+emitted with their DOM spelling — `strokeDashoffset` becomes
+`stroke-dashoffset`, while genuinely camelCase names like `viewBox` are left
+alone.
+
+## attrX, attrY, and attrScale
+
+`x`, `y`, and `scale` are ambiguous: each is both an SVG attribute and a CSS
+transform that Motion already owns. Passing `x` moves the element with a
+transform. To reach the **attribute** instead, use `attrX`, `attrY`, or
+`attrScale`:
+
+```svelte
+<script lang="ts">
+  import { motion, useMotionValue } from '@humanspeak/svelte-motion'
+
+  const attrX = useMotionValue(10)
+</script>
+
+<svg viewBox="0 0 300 120">
+  <!-- renders x="10", not transform: translateX(10px) -->
+  <motion.rect {attrX} attrY={10} width={40} height={40} />
+</svg>
+```
+
+<div class="not-prose my-6 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 text-sm">
+
+**`scale` is not a presentation attribute on shape elements.** `attrScale` on a
+`<rect>` writes the attribute faithfully, and the rect ignores it — nothing
+moves. It is a real attribute on `<feDisplacementMap>`, where it drives the
+displacement amount. This mirrors Framer Motion's behavior.
+
+</div>
+
+## Drawing paths
+
+`pathLength`, `pathSpacing`, and `pathOffset` are handled separately, as
+normalized 0–1 values. They animate the underlying `stroke-dasharray` and
+`stroke-dashoffset` for you:
+
+```svelte
+<motion.path
+  d="M 10 100 Q 100 10 190 100"
+  stroke="#5eead4"
+  fill="none"
+  initial={{ pathLength: 0 }}
+  animate={{ pathLength: 1 }}
+  transition={{ duration: 1.5 }}
+/>
+```
+
+Set `pathLength` to `0.5` and half the path is drawn, regardless of its actual
+length in user units.
+
+## Filter primitives
+
+SVG tag names are case-sensitive, and motion components are addressed in
+lowercase. `motion.fedisplacementmap` renders a correctly-cased
+`<feDisplacementMap>`:
+
+```svelte
+<filter id="warp">
+  <feTurbulence type="turbulence" baseFrequency="0.04" numOctaves="2" result="noise" />
+  <motion.fedisplacementmap in="SourceGraphic" in2="noise" attrScale={warp} />
+</filter>
+```
+
+The same holds for `motion.lineargradient`, `motion.clippath`,
+`motion.textpath`, and the rest of the camelCase SVG elements.

--- a/docs/src/routes/docs/svg-animation/+page.svx
+++ b/docs/src/routes/docs/svg-animation/+page.svx
@@ -76,7 +76,16 @@ Svelte templates take the DOM spelling of hyphenated attributes, so write
   const strokeWidth = useSpring(4)
 </script>
 
-<motion.circle cx={60} cy={60} r={20} stroke-width={strokeWidth} />
+<svg viewBox="0 0 120 120">
+  <motion.circle
+    cx={60}
+    cy={60}
+    r={20}
+    fill="none"
+    stroke="#5eead4"
+    stroke-width={strokeWidth}
+  />
+</svg>
 ```
 
 Both spellings are accepted, but the kebab-case form is the one you would write
@@ -152,10 +161,31 @@ lowercase. `motion.fedisplacementmap` renders a correctly-cased
   const warp = useSpring(12)
 </script>
 
-<filter id="warp">
-  <feTurbulence type="turbulence" baseFrequency="0.04" numOctaves="2" result="noise" />
-  <motion.fedisplacementmap in="SourceGraphic" in2="noise" attrScale={warp} />
-</filter>
+<svg viewBox="0 0 300 120">
+  <filter id="warp">
+    <feTurbulence type="turbulence" baseFrequency="0.04" numOctaves="2" result="noise" />
+    <motion.fedisplacementmap in="SourceGraphic" in2="noise" attrScale={warp} />
+  </filter>
+  <rect x="40" y="25" width="220" height="70" fill="#38bdf8" filter="url(#warp)" />
+</svg>
+```
+
+Filter-primitive attributes are bindable like any other. `stdDeviation`,
+`baseFrequency`, `numOctaves`, `dx`, `dy`, and `radius` all take a MotionValue:
+
+```svelte
+<script lang="ts">
+  import { motion, useSpring } from '@humanspeak/svelte-motion'
+
+  const blur = useSpring(2)
+</script>
+
+<svg viewBox="0 0 300 120">
+  <filter id="soften">
+    <motion.fegaussianblur in="SourceGraphic" stdDeviation={blur} />
+  </filter>
+  <rect x="40" y="25" width="220" height="70" fill="#4ade80" filter="url(#soften)" />
+</svg>
 ```
 
 The same holds for `motion.lineargradient`, `motion.clippath`,

--- a/docs/src/routes/docs/svg-animation/+page.ts
+++ b/docs/src/routes/docs/svg-animation/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => ({
+    title: 'SVG Animation',
+    description:
+        'Bind MotionValues to SVG presentation attributes, draw paths, and use attrX/attrY/attrScale.'
+})

--- a/docs/src/routes/examples/svg-animation/+page.svelte
+++ b/docs/src/routes/examples/svg-animation/+page.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        type ExampleSection,
+        formatSheetLabel
+    } from '@humanspeak/docs-kit'
+    import { Route, Signal, Wand } from '@lucide/svelte'
+    import { demoCodeSample } from '$lib/demo-loaders'
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import SvgAnimationDefault from '$lib/examples/svg-animation/demos/Default.svelte'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'SVG Animation' }
+        ]
+    }
+    if (seo) {
+        seo.title = 'SVG Animation | Examples | Svelte Motion'
+        seo.description = 'Bind MotionValues straight to SVG presentation attributes.'
+        seo.ogTitle = 'SVG Animation'
+        seo.h1 = { title: 'SVG Animation', mode: 'sr-only' }
+        seo.ogTagline = 'MotionValues bound straight to SVG attributes'
+        seo.ogFeatures = ['SVG', 'MotionValue', 'useSpring', 'useTransform']
+        seo.ogSlug = 'examples-svg-animation'
+    }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    const sections: ExampleSection[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'SVG',
+            title: { prefix: 'one spring, ', accent: 'three attributes', end: '.' },
+            description:
+                'A single useSpring drives the ring’s stroke-dashoffset, the dot’s cx, and the line’s x2. No keyframes and no re-render: Motion subscribes to the value and writes each attribute on the channel it belongs to.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [
+                { k: 'api', v: 'motion.circle' },
+                { k: 'input', v: 'useSpring' },
+                { k: 'channels', v: 'style + attribute' }
+            ],
+            sourceUrl: `${SOURCE_URL}svg-animation/demos/Default.svelte`
+        }
+    ]
+</script>
+
+{#snippet defaultSection()}
+    <SvgAnimationDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <Signal />
+            <span>
+                One <code>useSpring</code> feeds every bound attribute through
+                <code>useTransform</code>, so they stay in lockstep.
+            </span>
+        </li>
+        <li>
+            <Route />
+            <span>
+                <code>cx</code> and <code>stroke-dashoffset</code> are CSS properties, so they are
+                written to <code>element.style</code>.
+            </span>
+        </li>
+        <li>
+            <Wand />
+            <span>
+                <code>x2</code> is not a CSS property, so it is written with
+                <code>setAttribute</code> — same value, different channel.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'svg-animation/demos/Default.svelte',
+                'svg-animation-default',
+                'Default.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel={formatSheetLabel(i, sections.length)}
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/e2e/svg/motion-value-attributes.spec.ts
+++ b/e2e/svg/motion-value-attributes.spec.ts
@@ -29,13 +29,29 @@ const computed = (locator: Locator, property: string): Promise<string> =>
 const computedNumber = async (locator: Locator, property: string): Promise<number> =>
     parseFloat(await computed(locator, property))
 
+/**
+ * Attribute values can carry units too. `addAttrValue` writes through
+ * `getValueAsType(v, numberValueTypes[key])`, and `numberValueTypes.x` is a px
+ * type — so `attrX` renders `x="25px"` (a valid SVG length). Keys with no entry,
+ * like `x2` and `scale`, stay unitless.
+ */
+const attrNumber = async (locator: Locator, name: string): Promise<number> =>
+    parseFloat((await locator.getAttribute(name)) ?? '')
+
+/**
+ * Matches a stringified MotionValue in *attribute position*. The demo page names
+ * the failure mode in its own prose, so a bare substring check on the document
+ * would trip over the copy rather than a real defect.
+ */
+const STRINGIFIED_MOTION_VALUE = /="\[object Object\]"/
+
 test.describe('SVG MotionValue attributes', () => {
     test('never stringifies a MotionValue into the DOM', async ({ page }) => {
         await page.goto(ROUTE)
         await expect(page.getByTestId('mv-circle')).toBeVisible()
 
         const html = await page.content()
-        expect(html).not.toContain('[object Object]')
+        expect(html).not.toMatch(STRINGIFIED_MOTION_VALUE)
     })
 
     test('renders a numeric cx on first paint', async ({ page }) => {
@@ -126,13 +142,13 @@ test.describe('SVG MotionValue attributes', () => {
         const rect = page.getByTestId('attr-rect')
         await expect(rect).toBeVisible()
 
-        const before = Number(await rect.getAttribute('x'))
+        const before = await attrNumber(rect, 'x')
         expect(Number.isFinite(before)).toBe(true)
 
         await page.getByTestId('bump-attr-x').click()
 
         await expect
-            .poll(async () => Number(await rect.getAttribute('x')), { timeout: 5000 })
+            .poll(async () => attrNumber(rect, 'x'), { timeout: 5000 })
             .toBeGreaterThan(before)
     })
 
@@ -151,17 +167,19 @@ test.describe('SVG MotionValue attributes', () => {
         await page.goto(ROUTE)
 
         const line = page.getByTestId('chart-line')
-        await expect(line).toBeVisible()
+        // A horizontal line has a zero-height bounding box, so Playwright reports it
+        // as hidden. Attachment is the meaningful check here.
+        await expect(line).toBeAttached()
 
         // x1/y1/x2/y2 are not in element.style, so svgEffect writes them via
         // setAttribute even though they carry no `attr` prefix.
-        const before = Number(await line.getAttribute('x2'))
+        const before = await attrNumber(line, 'x2')
         expect(Number.isFinite(before)).toBe(true)
 
         await page.getByTestId('bump-cx').click()
 
         await expect
-            .poll(async () => Number(await line.getAttribute('x2')), { timeout: 5000 })
+            .poll(async () => attrNumber(line, 'x2'), { timeout: 5000 })
             .toBeGreaterThan(before)
     })
 
@@ -192,12 +210,65 @@ test.describe('SVG MotionValue attributes', () => {
         expect(await computedNumber(staticCircle, 'cx')).toBe(5)
     })
 
+    test('does not re-render the attribute spread when a bound value changes', async ({ page }) => {
+        await page.goto(ROUTE)
+
+        const circle = page.getByTestId('mv-circle')
+        await expect(circle).toBeVisible()
+
+        // `cx` is style-routed, so its attribute is a one-time SSR seed. If the
+        // spread tracked the MotionValue (this library's values are Svelte-augmented,
+        // so a tracked `.get()` would), the attribute would follow the style and the
+        // whole attrs object would recompute every frame of an animation.
+        const seed = await circle.getAttribute('cx')
+
+        await page.getByTestId('bump-cx').click()
+        await expect.poll(async () => computedNumber(circle, 'cx'), { timeout: 5000 }).toBe(60)
+
+        expect(await circle.getAttribute('cx')).toBe(seed)
+    })
+
+    test('an unrelated re-render does not clobber attribute-routed values', async ({ page }) => {
+        await page.goto(ROUTE)
+
+        const rect = page.getByTestId('attr-rect')
+        await expect(rect).toBeVisible()
+
+        await page.getByTestId('bump-attr-x').click()
+        await expect.poll(async () => attrNumber(rect, 'x'), { timeout: 5000 }).toBe(25)
+
+        // Force a Svelte re-render of the attribute spread via an unrelated class change.
+        await page.getByTestId('toggle-highlight').check()
+
+        // svgEffect owns `x`; the spread must not reset it to the initial seed.
+        await expect.poll(async () => attrNumber(rect, 'x'), { timeout: 2000 }).toBe(25)
+    })
+
+    test('reattaches cleanly after unmount and remount', async ({ page }) => {
+        await page.goto(ROUTE)
+        await expect(page.getByTestId('mv-circle')).toBeVisible()
+
+        await page.getByTestId('toggle-mounted').uncheck()
+        await expect(page.getByTestId('mv-circle')).toHaveCount(0)
+
+        await page.getByTestId('toggle-mounted').check()
+        const circle = page.getByTestId('mv-circle')
+        await expect(circle).toBeVisible()
+
+        expect(await page.content()).not.toMatch(STRINGIFIED_MOTION_VALUE)
+        await expect.poll(async () => computedNumber(circle, 'cx'), { timeout: 5000 }).toBe(40)
+
+        // Subscriptions survive the remount.
+        await page.getByTestId('bump-cx').click()
+        await expect.poll(async () => computedNumber(circle, 'cx'), { timeout: 5000 }).toBe(60)
+    })
+
     test('server-rendered markup carries the resolved attribute values', async ({ request }) => {
         const response = await request.get(ROUTE)
         expect(response.ok()).toBe(true)
 
         const html = await response.text()
-        expect(html).not.toContain('[object Object]')
+        expect(html).not.toMatch(STRINGIFIED_MOTION_VALUE)
 
         // The SSR payload must already carry a numeric cx so hydration doesn't flash.
         const circle = html.match(/<circle[^>]*data-testid="mv-circle"[^>]*>/)?.[0]

--- a/e2e/svg/motion-value-attributes.spec.ts
+++ b/e2e/svg/motion-value-attributes.spec.ts
@@ -152,15 +152,57 @@ test.describe('SVG MotionValue attributes', () => {
             .toBeGreaterThan(before)
     })
 
-    test('renders attrScale as the scale attribute', async ({ page }) => {
+    test('renders camelCase SVG tags with their case-sensitive spec spelling', async ({ page }) => {
         await page.goto(ROUTE)
 
-        const rect = page.getByTestId('attr-rect')
-        await expect(rect).toBeVisible()
+        const map = page.getByTestId('displacement-map')
+        await expect(map).toBeAttached()
 
-        const scale = await rect.getAttribute('scale')
+        // SVG tag names are case-sensitive. A lowercase `fedisplacementmap` parses as
+        // an inert generic SVGElement, so the filter primitive is silently ignored.
+        const info = await map.evaluate((el) => ({
+            tagName: el.tagName,
+            ctor: el.constructor.name
+        }))
+        expect(info.tagName).toBe('feDisplacementMap')
+        expect(info.ctor).toBe('SVGFEDisplacementMapElement')
+    })
+
+    test('renders attrScale as the scale attribute on feDisplacementMap', async ({ page }) => {
+        await page.goto(ROUTE)
+
+        // `scale` is inert on shape elements — it is only a real presentation
+        // attribute on <feDisplacementMap>. It is also a CSS transform property, so
+        // a plain `scale` prop would be style-routed; `attrScale` is the escape hatch.
+        const map = page.getByTestId('displacement-map')
+        await expect(map).toBeAttached()
+
+        const scale = await map.getAttribute('scale')
         expect(scale).not.toBeNull()
         expect(Number.isFinite(Number(scale))).toBe(true)
+
+        // No px unit: `scale` has a unitless entry in numberValueTypes.
+        expect(scale).not.toContain('px')
+    })
+
+    test('updates the feDisplacementMap scale attribute when attrScale changes', async ({
+        page
+    }) => {
+        await page.goto(ROUTE)
+
+        const map = page.getByTestId('displacement-map')
+        await expect(map).toBeAttached()
+        expect(await attrNumber(map, 'scale')).toBe(12)
+
+        await page.getByTestId('slider-attr-scale').fill('30')
+
+        await expect.poll(async () => attrNumber(map, 'scale'), { timeout: 5000 }).toBe(30)
+
+        // The live SVG DOM sees it, not just the attribute string.
+        const baseVal = await map.evaluate(
+            (el) => (el as SVGFEDisplacementMapElement).scale.baseVal
+        )
+        expect(baseVal).toBe(30)
     })
 
     test('updates x2 on the attribute channel for a non-attr-prefixed key', async ({ page }) => {

--- a/e2e/svg/motion-value-attributes.spec.ts
+++ b/e2e/svg/motion-value-attributes.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from '@playwright/test'
+
+const ROUTE = '/tests/svg/motion-value-attributes'
+
+/**
+ * A MotionValue bound to an SVG presentation attribute must be subscribed to,
+ * not spread raw onto the element (which stringifies as `[object Object]`).
+ *
+ * Upstream parity: motion-dom `svgEffect` routes non-path/non-attr keys through
+ * `key in element.style ? addStyleValue : addAttrValue`, and renders
+ * `attrX`/`attrY`/`attrScale` as the `x`/`y`/`scale` attributes.
+ */
+test.describe('SVG MotionValue attributes', () => {
+    test('never stringifies a MotionValue into the DOM', async ({ page }) => {
+        await page.goto(ROUTE)
+        await expect(page.getByTestId('mv-circle')).toBeVisible()
+
+        const html = await page.content()
+        expect(html).not.toContain('[object Object]')
+    })
+
+    test('renders a numeric cx on first paint', async ({ page }) => {
+        await page.goto(ROUTE)
+
+        const circle = page.getByTestId('mv-circle')
+        await expect(circle).toBeVisible()
+
+        const cx = await circle.getAttribute('cx')
+        expect(cx).not.toBeNull()
+        expect(Number.isNaN(Number(cx))).toBe(false)
+    })
+
+    test('updates the cx attribute when the MotionValue changes', async ({ page }) => {
+        await page.goto(ROUTE)
+
+        const circle = page.getByTestId('mv-circle')
+        await expect(circle).toBeVisible()
+
+        const before = Number(await circle.getAttribute('cx'))
+        await page.getByTestId('bump-cx').click()
+
+        await expect
+            .poll(async () => Number(await circle.getAttribute('cx')), { timeout: 5000 })
+            .toBeGreaterThan(before)
+    })
+
+    test('drives a progress ring via r and stroke-dashoffset', async ({ page }) => {
+        await page.goto(ROUTE)
+
+        const ring = page.getByTestId('progress-ring')
+        await expect(ring).toBeVisible()
+
+        const readOffset = async () =>
+            Number(
+                (await ring.getAttribute('stroke-dashoffset')) ??
+                    (await ring.evaluate((el) => getComputedStyle(el).strokeDashoffset))
+            )
+
+        const before = await readOffset()
+        await page.getByTestId('advance-progress').click()
+
+        await expect.poll(readOffset, { timeout: 5000 }).not.toBe(before)
+    })
+
+    test('renders attrX/attrY as the x/y attributes, not CSS transforms', async ({ page }) => {
+        await page.goto(ROUTE)
+
+        const rect = page.getByTestId('attr-rect')
+        await expect(rect).toBeVisible()
+
+        expect(await rect.getAttribute('x')).not.toBeNull()
+        expect(await rect.getAttribute('y')).not.toBeNull()
+        expect(await rect.getAttribute('attrX')).toBeNull()
+        expect(await rect.getAttribute('attrY')).toBeNull()
+
+        // attrX is an attribute channel, distinct from the CSS transform.
+        const transform = await rect.evaluate((el) => getComputedStyle(el).transform)
+        expect(transform === 'none' || transform === '').toBe(true)
+    })
+
+    test('updates the x attribute when the attrX MotionValue changes', async ({ page }) => {
+        await page.goto(ROUTE)
+
+        const rect = page.getByTestId('attr-rect')
+        await expect(rect).toBeVisible()
+
+        const before = Number(await rect.getAttribute('x'))
+        await page.getByTestId('bump-attr-x').click()
+
+        await expect
+            .poll(async () => Number(await rect.getAttribute('x')), { timeout: 5000 })
+            .toBeGreaterThan(before)
+    })
+
+    test('renders attrScale as the scale attribute', async ({ page }) => {
+        await page.goto(ROUTE)
+
+        const rect = page.getByTestId('attr-rect')
+        await expect(rect).toBeVisible()
+
+        const scale = await rect.getAttribute('scale')
+        expect(scale).not.toBeNull()
+        expect(Number.isNaN(Number(scale))).toBe(false)
+    })
+
+    test('leaves plain numeric attributes static, with no subscription', async ({ page }) => {
+        await page.goto(ROUTE)
+
+        const staticCircle = page.getByTestId('static-circle')
+        await expect(staticCircle).toBeVisible()
+        expect(await staticCircle.getAttribute('cx')).toBe('5')
+
+        await page.getByTestId('bump-cx').click()
+        await expect(staticCircle).toHaveAttribute('cx', '5')
+    })
+
+    test('server-rendered markup carries the resolved attribute values', async ({ request }) => {
+        const response = await request.get(ROUTE)
+        expect(response.ok()).toBe(true)
+
+        const html = await response.text()
+        expect(html).not.toContain('[object Object]')
+
+        // The SSR payload must already carry a numeric cx so hydration doesn't flash.
+        const circle = html.match(/<circle[^>]*data-testid="mv-circle"[^>]*>/)?.[0]
+        expect(circle, 'mv-circle should be present in the SSR payload').toBeTruthy()
+        expect(circle).toMatch(/cx="\d+(\.\d+)?"/)
+    })
+})

--- a/e2e/svg/motion-value-attributes.spec.ts
+++ b/e2e/svg/motion-value-attributes.spec.ts
@@ -336,8 +336,55 @@ test.describe('SVG MotionValue attributes', () => {
         // Force a Svelte re-render of the attribute spread via an unrelated class change.
         await page.getByTestId('toggle-highlight').check()
 
+        // The toggle must re-render the subtree containing the element under test.
+        // Highlighting an unrelated <svg> leaves this test passing even if the bug
+        // returns, because `attr-rect`'s spread is never re-evaluated.
+        await expect
+            .poll(async () => rect.evaluate((el) => !!el.closest('[data-highlight="true"]')), {
+                timeout: 2000
+            })
+            .toBe(true)
+
         // svgEffect owns `x`; the spread must not reset it to the initial seed.
         await expect.poll(async () => attrNumber(rect, 'x'), { timeout: 2000 }).toBe(25)
+    })
+
+    test('binds a MotionValue to a filter primitive attribute', async ({ page }) => {
+        await page.goto(ROUTE)
+
+        const blur = page.getByTestId('blur-filter')
+        await expect(blur).toBeAttached()
+
+        // Plan 005 drives feTurbulence/feOffset/feGaussianBlur from MotionValues.
+        // An unclaimed key falls through to the raw spread and stringifies.
+        expect(await blur.getAttribute('stdDeviation')).not.toBe('[object Object]')
+
+        const before = await attrNumber(blur, 'stdDeviation')
+        expect(Number.isFinite(before)).toBe(true)
+
+        await page.getByTestId('slider-blur').fill('6')
+        await expect.poll(async () => attrNumber(blur, 'stdDeviation'), { timeout: 5000 }).toBe(6)
+
+        // The live SVG DOM parses it, not just the attribute string.
+        const baseVal = await blur.evaluate(
+            (el) => (el as SVGFEGaussianBlurElement).stdDeviationX.baseVal
+        )
+        expect(baseVal).toBe(6)
+    })
+
+    test('server-renders a filter primitive attribute without stringifying it', async ({
+        request
+    }) => {
+        const response = await request.get(ROUTE)
+        expect(response.ok()).toBe(true)
+
+        const html = await response.text()
+        const blur = html.match(/<feGaussianBlur[^>]*data-testid="blur-filter"[^>]*>/)?.[0]
+
+        expect(blur, 'blur-filter should be present in the SSR payload').toBeTruthy()
+        expect(blur).not.toMatch(STRINGIFIED_MOTION_VALUE)
+        // camelCase must survive the SSR casing gate: `std-deviation` is inert.
+        expect(blur).toMatch(/stdDeviation="[\d.]+"/)
     })
 
     test('reattaches cleanly after unmount and remount', async ({ page }) => {

--- a/e2e/svg/motion-value-attributes.spec.ts
+++ b/e2e/svg/motion-value-attributes.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Locator, test } from '@playwright/test'
+import { expect, type Locator, type Page, test } from '@playwright/test'
 
 const ROUTE = '/tests/svg/motion-value-attributes'
 
@@ -152,31 +152,47 @@ test.describe('SVG MotionValue attributes', () => {
             .toBeGreaterThan(before)
     })
 
+    /**
+     * Forces the element to be created by `createElementNS` rather than by the HTML
+     * parser.
+     *
+     * The parser silently case-corrects `<fedisplacementmap>` when it reads SSR
+     * markup, and Svelte's hydration reuses that node instead of calling
+     * `create_element` (`svelte-element.js:74`). A `page.goto` + `tagName` check
+     * therefore passes even with the tag-casing fix reverted — verified by reverting
+     * it. Only the remount path runs `createElementNS` with the tag verbatim.
+     */
+    const remount = async (page: Page): Promise<void> => {
+        await page.getByTestId('toggle-mounted').uncheck()
+        await expect(page.getByTestId('displacement-map')).toHaveCount(0)
+        await page.getByTestId('toggle-mounted').check()
+        await expect(page.getByTestId('displacement-map')).toBeAttached()
+    }
+
     test('renders camelCase SVG tags with their case-sensitive spec spelling', async ({ page }) => {
         await page.goto(ROUTE)
+        await remount(page)
 
-        const map = page.getByTestId('displacement-map')
-        await expect(map).toBeAttached()
-
-        // SVG tag names are case-sensitive. A lowercase `fedisplacementmap` parses as
-        // an inert generic SVGElement, so the filter primitive is silently ignored.
-        const info = await map.evaluate((el) => ({
+        // SVG tag names are case-sensitive. A lowercase `fedisplacementmap` built by
+        // createElementNS is an inert generic SVGElement: the filter primitive is
+        // silently ignored and its `scale` does nothing.
+        const info = await page.getByTestId('displacement-map').evaluate((el) => ({
             tagName: el.tagName,
-            ctor: el.constructor.name
+            ctor: el.constructor.name,
+            // The IDL attribute only exists on the real interface.
+            hasScaleIDL: 'scale' in el
         }))
+
         expect(info.tagName).toBe('feDisplacementMap')
         expect(info.ctor).toBe('SVGFEDisplacementMapElement')
+        expect(info.hasScaleIDL).toBe(true)
     })
 
     test('renders attrScale as the scale attribute on feDisplacementMap', async ({ page }) => {
         await page.goto(ROUTE)
+        await remount(page)
 
-        // `scale` is inert on shape elements — it is only a real presentation
-        // attribute on <feDisplacementMap>. It is also a CSS transform property, so
-        // a plain `scale` prop would be style-routed; `attrScale` is the escape hatch.
         const map = page.getByTestId('displacement-map')
-        await expect(map).toBeAttached()
-
         const scale = await map.getAttribute('scale')
         expect(scale).not.toBeNull()
         expect(Number.isFinite(Number(scale))).toBe(true)
@@ -189,20 +205,58 @@ test.describe('SVG MotionValue attributes', () => {
         page
     }) => {
         await page.goto(ROUTE)
+        await remount(page)
 
         const map = page.getByTestId('displacement-map')
-        await expect(map).toBeAttached()
-        expect(await attrNumber(map, 'scale')).toBe(12)
+        await expect.poll(async () => attrNumber(map, 'scale'), { timeout: 5000 }).toBe(12)
 
         await page.getByTestId('slider-attr-scale').fill('30')
-
         await expect.poll(async () => attrNumber(map, 'scale'), { timeout: 5000 }).toBe(30)
 
-        // The live SVG DOM sees it, not just the attribute string.
+        // The live SVG DOM parses it, not just the attribute string. On an inert
+        // SVGElement `scale` is undefined, which is the point of the tag-casing fix.
         const baseVal = await map.evaluate(
             (el) => (el as SVGFEDisplacementMapElement).scale.baseVal
         )
         expect(baseVal).toBe(30)
+    })
+
+    test('writes attrScale to the rect but leaves the rect visually unchanged', async ({
+        page
+    }) => {
+        await page.goto(ROUTE)
+
+        const rect = page.getByTestId('attr-rect')
+        await expect(rect).toBeVisible()
+
+        const geometry = () =>
+            rect.evaluate((el) => {
+                const box = (el as SVGGraphicsElement).getBBox()
+                return {
+                    width: box.width,
+                    height: box.height,
+                    transform: getComputedStyle(el).transform,
+                    cssScale: getComputedStyle(el).scale
+                }
+            })
+
+        const before = await geometry()
+        expect(before.width).toBe(40)
+        expect(before.height).toBe(40)
+
+        await page.getByTestId('slider-attr-scale').fill('30')
+
+        // The attribute tracks the MotionValue...
+        await expect.poll(async () => attrNumber(rect, 'scale'), { timeout: 5000 }).toBe(30)
+
+        // ...but `scale` is not a presentation attribute on shape elements, so the
+        // rect ignores it. This is upstream's behavior: attrScale reaches the
+        // attribute channel and never becomes a CSS transform.
+        const after = await geometry()
+        expect(after.width).toBe(before.width)
+        expect(after.height).toBe(before.height)
+        expect(after.transform === 'none' || after.transform === '').toBe(true)
+        expect(after.cssScale === 'none' || after.cssScale === '').toBe(true)
     })
 
     test('updates x2 on the attribute channel for a non-attr-prefixed key', async ({ page }) => {

--- a/e2e/svg/motion-value-attributes.spec.ts
+++ b/e2e/svg/motion-value-attributes.spec.ts
@@ -30,10 +30,15 @@ const computedNumber = async (locator: Locator, property: string): Promise<numbe
     parseFloat(await computed(locator, property))
 
 /**
- * Attribute values can carry units too. `addAttrValue` writes through
- * `getValueAsType(v, numberValueTypes[key])`, and `numberValueTypes.x` is a px
- * type — so `attrX` renders `x="25px"` (a valid SVG length). Keys with no entry,
- * like `x2` and `scale`, stay unitless.
+ * Attribute values can carry units once the client takes over. `addAttrValue`
+ * writes through `getValueAsType(v, numberValueTypes[key])`, and
+ * `numberValueTypes.x` is a px type — so after hydration `attrX` reads
+ * `x="25px"` (a valid SVG length). Keys with no entry, like `x2`, `scale` and
+ * `stdDeviation`, stay unitless.
+ *
+ * The SSR seed is different: `computeSSRSVGAttrValues` stringifies the raw
+ * MotionValue and never appends a unit, so the server payload carries `x="10"`.
+ * Hence `parseFloat` rather than `Number` — it reads both.
  */
 const attrNumber = async (locator: Locator, name: string): Promise<number> =>
     parseFloat((await locator.getAttribute(name)) ?? '')
@@ -379,12 +384,20 @@ test.describe('SVG MotionValue attributes', () => {
         expect(response.ok()).toBe(true)
 
         const html = await response.text()
-        const blur = html.match(/<feGaussianBlur[^>]*data-testid="blur-filter"[^>]*>/)?.[0]
+        const blur = html.match(/<feGaussianBlur[^>]*data-testid="blur-filter"[^>]*>/i)?.[0]
 
         expect(blur, 'blur-filter should be present in the SSR payload').toBeTruthy()
         expect(blur).not.toMatch(STRINGIFIED_MOTION_VALUE)
-        // camelCase must survive the SSR casing gate: `std-deviation` is inert.
-        expect(blur).toMatch(/stdDeviation="[\d.]+"/)
+
+        // Svelte's SSR spread lowercases attribute names, so the payload carries
+        // `stddeviation="2"`. That is harmless: the HTML parser case-corrects SVG
+        // attribute names on the way in — the same adjustment table that fixes tag
+        // names — so the hydrated element exposes `stdDeviation` and a live
+        // `stdDeviationX.baseVal`. The client-DOM test above asserts that. What
+        // matters here is that a number, not a MotionValue, reaches the payload.
+        expect(blur).toMatch(/stddeviation="[\d.]+"/i)
+        // And never the dash-cased form, which no parser would rescue.
+        expect(blur).not.toMatch(/std-deviation=/i)
     })
 
     test('reattaches cleanly after unmount and remount', async ({ page }) => {

--- a/e2e/svg/motion-value-attributes.spec.ts
+++ b/e2e/svg/motion-value-attributes.spec.ts
@@ -209,5 +209,13 @@ test.describe('SVG MotionValue attributes', () => {
         expect(ring).toBeTruthy()
         expect(ring).toMatch(/stroke-dashoffset="[\d.-]+"/)
         expect(ring).not.toMatch(/strokeDashoffset=/)
+
+        // Gate ordering: `attrX` must resolve to `x` before dash-casing, never
+        // to the inert `attr-x`.
+        const rect = html.match(/<rect[^>]*data-testid="attr-rect"[^>]*>/)?.[0]
+        expect(rect).toBeTruthy()
+        expect(rect).toMatch(/\sx="[\d.]+"/)
+        expect(rect).not.toMatch(/attr-x=/)
+        expect(rect).not.toMatch(/attrX=/)
     })
 })

--- a/e2e/svg/motion-value-attributes.spec.ts
+++ b/e2e/svg/motion-value-attributes.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, type Locator, test } from '@playwright/test'
 
 const ROUTE = '/tests/svg/motion-value-attributes'
 
@@ -6,10 +6,29 @@ const ROUTE = '/tests/svg/motion-value-attributes'
  * A MotionValue bound to an SVG presentation attribute must be subscribed to,
  * not spread raw onto the element (which stringifies as `[object Object]`).
  *
- * Upstream parity: motion-dom `svgEffect` routes non-path/non-attr keys through
- * `key in element.style ? addStyleValue : addAttrValue`, and renders
- * `attrX`/`attrY`/`attrScale` as the `x`/`y`/`scale` attributes.
+ * Upstream parity: motion-dom `svgEffect` (effects/svg/index.ts) routes each key
+ * to one of two DOM channels:
+ *
+ * - `attr*`, `points`, `viewBox`, `x1/y1/x2/y2` -> `setAttribute`
+ * - `cx cy r x y width height d stroke-*` -> `element.style`, because
+ *   `key in element.style` is true for these in Chromium
+ *
+ * Tests must read the channel the key actually routes to. Polling
+ * `getAttribute('cx')` never observes a change and hangs until timeout.
  */
+
+/** Reads a resolved CSS property, e.g. `cx` -> `"40px"`. */
+const computed = (locator: Locator, property: string): Promise<string> =>
+    locator.evaluate((el, prop) => getComputedStyle(el).getPropertyValue(prop), property)
+
+/**
+ * Computed styles carry units (`"12.5px"`). `Number("12.5px")` is `NaN`, and
+ * `expect(NaN).not.toBe(NaN)` passes vacuously in the wrong direction because
+ * `toBe` is `Object.is`. Always `parseFloat`.
+ */
+const computedNumber = async (locator: Locator, property: string): Promise<number> =>
+    parseFloat(await computed(locator, property))
+
 test.describe('SVG MotionValue attributes', () => {
     test('never stringifies a MotionValue into the DOM', async ({ page }) => {
         await page.goto(ROUTE)
@@ -25,41 +44,64 @@ test.describe('SVG MotionValue attributes', () => {
         const circle = page.getByTestId('mv-circle')
         await expect(circle).toBeVisible()
 
+        // Style-routed keys still SSR as presentation attributes; the client-set
+        // CSS property wins afterwards.
         const cx = await circle.getAttribute('cx')
         expect(cx).not.toBeNull()
-        expect(Number.isNaN(Number(cx))).toBe(false)
+        expect(Number.isFinite(Number(cx))).toBe(true)
     })
 
-    test('updates the cx attribute when the MotionValue changes', async ({ page }) => {
+    test('updates cx on the style channel when the MotionValue changes', async ({ page }) => {
         await page.goto(ROUTE)
 
         const circle = page.getByTestId('mv-circle')
         await expect(circle).toBeVisible()
 
-        const before = Number(await circle.getAttribute('cx'))
+        const before = await computedNumber(circle, 'cx')
+        expect(Number.isFinite(before)).toBe(true)
+
         await page.getByTestId('bump-cx').click()
 
         await expect
-            .poll(async () => Number(await circle.getAttribute('cx')), { timeout: 5000 })
+            .poll(async () => computedNumber(circle, 'cx'), { timeout: 5000 })
             .toBeGreaterThan(before)
     })
 
-    test('drives a progress ring via r and stroke-dashoffset', async ({ page }) => {
+    test('drives a progress ring via stroke-dashoffset', async ({ page }) => {
         await page.goto(ROUTE)
 
         const ring = page.getByTestId('progress-ring')
         await expect(ring).toBeVisible()
 
-        const readOffset = async () =>
-            Number(
-                (await ring.getAttribute('stroke-dashoffset')) ??
-                    (await ring.evaluate((el) => getComputedStyle(el).strokeDashoffset))
-            )
+        const before = await computedNumber(ring, 'stroke-dashoffset')
+        expect(Number.isFinite(before)).toBe(true)
 
-        const before = await readOffset()
         await page.getByTestId('advance-progress').click()
 
-        await expect.poll(readOffset, { timeout: 5000 }).not.toBe(before)
+        await expect
+            .poll(async () => computedNumber(ring, 'stroke-dashoffset'), { timeout: 5000 })
+            .toBeLessThan(before)
+    })
+
+    test('binds a kebab-case stroke-width prop, the spelling Svelte authors write', async ({
+        page
+    }) => {
+        await page.goto(ROUTE)
+
+        const circle = page.getByTestId('kebab-circle')
+        await expect(circle).toBeVisible()
+
+        // The regression this feature exists to kill.
+        expect(await circle.getAttribute('stroke-width')).not.toBe('[object Object]')
+
+        const before = await computedNumber(circle, 'stroke-width')
+        expect(Number.isFinite(before)).toBe(true)
+
+        await page.getByTestId('bump-stroke-width').click()
+
+        await expect
+            .poll(async () => computedNumber(circle, 'stroke-width'), { timeout: 5000 })
+            .toBeGreaterThan(before)
     })
 
     test('renders attrX/attrY as the x/y attributes, not CSS transforms', async ({ page }) => {
@@ -74,7 +116,7 @@ test.describe('SVG MotionValue attributes', () => {
         expect(await rect.getAttribute('attrY')).toBeNull()
 
         // attrX is an attribute channel, distinct from the CSS transform.
-        const transform = await rect.evaluate((el) => getComputedStyle(el).transform)
+        const transform = await computed(rect, 'transform')
         expect(transform === 'none' || transform === '').toBe(true)
     })
 
@@ -85,6 +127,8 @@ test.describe('SVG MotionValue attributes', () => {
         await expect(rect).toBeVisible()
 
         const before = Number(await rect.getAttribute('x'))
+        expect(Number.isFinite(before)).toBe(true)
+
         await page.getByTestId('bump-attr-x').click()
 
         await expect
@@ -100,18 +144,52 @@ test.describe('SVG MotionValue attributes', () => {
 
         const scale = await rect.getAttribute('scale')
         expect(scale).not.toBeNull()
-        expect(Number.isNaN(Number(scale))).toBe(false)
+        expect(Number.isFinite(Number(scale))).toBe(true)
     })
 
-    test('leaves plain numeric attributes static, with no subscription', async ({ page }) => {
+    test('updates x2 on the attribute channel for a non-attr-prefixed key', async ({ page }) => {
+        await page.goto(ROUTE)
+
+        const line = page.getByTestId('chart-line')
+        await expect(line).toBeVisible()
+
+        // x1/y1/x2/y2 are not in element.style, so svgEffect writes them via
+        // setAttribute even though they carry no `attr` prefix.
+        const before = Number(await line.getAttribute('x2'))
+        expect(Number.isFinite(before)).toBe(true)
+
+        await page.getByTestId('bump-cx').click()
+
+        await expect
+            .poll(async () => Number(await line.getAttribute('x2')), { timeout: 5000 })
+            .toBeGreaterThan(before)
+    })
+
+    test('leaves a plain numeric cx static on the channel the live element reads', async ({
+        page
+    }) => {
         await page.goto(ROUTE)
 
         const staticCircle = page.getByTestId('static-circle')
+        const boundCircle = page.getByTestId('mv-circle')
         await expect(staticCircle).toBeVisible()
         expect(await staticCircle.getAttribute('cx')).toBe('5')
 
+        // Read the style channel, the one a bound cx would move. Asserting the
+        // attribute is unchanged would pass even if the subscription were broken.
+        const before = await computedNumber(staticCircle, 'cx')
+        expect(before).toBe(5)
+
+        const boundBefore = await computedNumber(boundCircle, 'cx')
         await page.getByTestId('bump-cx').click()
-        await expect(staticCircle).toHaveAttribute('cx', '5')
+
+        // Wait for the bound circle to actually move, so the static assertion
+        // below is made after a subscription flush rather than before one.
+        await expect
+            .poll(async () => computedNumber(boundCircle, 'cx'), { timeout: 5000 })
+            .toBeGreaterThan(boundBefore)
+
+        expect(await computedNumber(staticCircle, 'cx')).toBe(5)
     })
 
     test('server-rendered markup carries the resolved attribute values', async ({ request }) => {
@@ -125,5 +203,11 @@ test.describe('SVG MotionValue attributes', () => {
         const circle = html.match(/<circle[^>]*data-testid="mv-circle"[^>]*>/)?.[0]
         expect(circle, 'mv-circle should be present in the SSR payload').toBeTruthy()
         expect(circle).toMatch(/cx="\d+(\.\d+)?"/)
+
+        // Case-sensitive: a `strokeDashoffset` attribute would be inert.
+        const ring = html.match(/<circle[^>]*data-testid="progress-ring"[^>]*>/)?.[0]
+        expect(ring).toBeTruthy()
+        expect(ring).toMatch(/stroke-dashoffset="[\d.-]+"/)
+        expect(ring).not.toMatch(/strokeDashoffset=/)
     })
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,15 @@ export default defineConfig({
         command: 'npm run build && npm run preview -- --port 4198',
         port: 4198,
         timeout: 120000,
-        reuseExistingServer: !process.env.CI,
+        // Do not reuse an existing server by default. reuseExistingServer
+        // short-circuits the rebuild in `command`: a stale preview on 4198
+        // would silently validate the suite against OLD code, so a reverted
+        // fix can appear to pass — exactly when trustworthy results matter
+        // most. Instead, if 4198 is occupied the run fails fast with an
+        // "already used" error rather than rebuilding; kill the stale server
+        // (`pkill -f "vite preview"`). Set PW_REUSE_SERVER=1 to reuse a
+        // server you know is current and skip the rebuild.
+        reuseExistingServer: !!process.env.PW_REUSE_SERVER,
         stdout: 'pipe',
         stderr: 'pipe'
     },

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -106,6 +106,8 @@
     import {
         transformSVGPathProperties,
         computeNormalizedSVGInitialAttrs,
+        computeSSRSVGAttrValues,
+        extractSVGMotionValueAttributes,
         hasSVGPathProperties,
         isSVGPathElement,
         isSVGTag,
@@ -1466,9 +1468,45 @@
         )
     )
 
+    // MotionValue-bound SVG attributes (`cx`, `stroke-width`, `attrX`, …) must be
+    // pulled out of `rest` before it reaches the raw spread below, or they
+    // stringify as `[object Object]`. `svgEffect` drives them on the client;
+    // `computeSSRSVGAttrValues` seeds the server payload so hydration doesn't flash.
+    const svgAttrSplit = $derived(
+        isSVGTag(String(tag))
+            ? extractSVGMotionValueAttributes(rest as Record<string, unknown>)
+            : null
+    )
+    const svgMotionValueAttrs = $derived(svgAttrSplit?.motionValueAttrs ?? {})
+    const spreadAttrs = $derived<Record<string, unknown>>(
+        svgAttrSplit
+            ? {
+                  ...svgAttrSplit.staticAttrs,
+                  // `untrack`: this library's MotionValues are Svelte-augmented, so a
+                  // tracked `.get()` here would make the whole attribute spread a
+                  // dependency of every value change — re-rendering each frame of an
+                  // animation and letting Svelte race `svgEffect` on attr-routed keys.
+                  // The seed only needs to be correct at render time; `svgEffect` owns
+                  // the DOM afterwards.
+                  ...untrack(() => computeSSRSVGAttrValues(svgAttrSplit.motionValueAttrs))
+              }
+            : (rest as Record<string, unknown>)
+    )
+
+    $effect(() => {
+        if (!element) return
+
+        const values = svgMotionValueAttrs
+        if (!isNotEmpty(values)) return
+
+        // Keys stay verbatim: svgEffect applies its own `attr`-prefix conversion
+        // and picks the style-vs-attribute channel per key.
+        return svgEffect(element, values)
+    })
+
     // Derived attributes to keep both branches in sync (focusability, data flags, style, class)
     const derivedAttrs = $derived<Record<string, unknown>>({
-        ...(rest as Record<string, unknown>),
+        ...spreadAttrs,
         // Gate on the *resolved* whileTap, not the raw prop. With
         // variant-label support a truthy-but-unresolved value (unknown
         // key, empty array) would otherwise add `tabindex=0` for an

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -111,6 +111,7 @@
         hasSVGPathProperties,
         isSVGPathElement,
         isSVGTag,
+        resolveSVGTagName,
         SVG_NAMESPACE
     } from '$lib/utils/svg'
     import {
@@ -1467,6 +1468,11 @@
             transformTemplateProp
         )
     )
+
+    // SVG tag names are case-sensitive: our components pass `tag` all-lowercase, but
+    // `fedisplacementmap` in the SVG namespace is an inert generic SVGElement, not an
+    // SVGFEDisplacementMapElement. Canonicalize before rendering.
+    const renderTag = $derived(isSVGTag(String(tag)) ? resolveSVGTagName(String(tag)) : tag)
 
     // MotionValue-bound SVG attributes (`cx`, `stroke-width`, `attrX`, …) must be
     // pulled out of `rest` before it reaches the raw spread below, or they
@@ -2978,7 +2984,12 @@
 
 {#if isVoidTag}
     {#if isSVGTag(String(tag))}
-        <svelte:element this={tag} bind:this={element} xmlns={SVG_NAMESPACE} {...derivedAttrs} />
+        <svelte:element
+            this={renderTag}
+            bind:this={element}
+            xmlns={SVG_NAMESPACE}
+            {...derivedAttrs}
+        />
         <!-- trunk-ignore(eslint/svelte/no-at-html-tags): optimized appear emits a JSON-escaped SSR bootstrap script, not user-authored HTML. -->
         {@html renderedOptimizedAppearScript}
     {:else}
@@ -2987,7 +2998,7 @@
         {@html renderedOptimizedAppearScript}
     {/if}
 {:else if isSVGTag(String(tag))}
-    <svelte:element this={tag} bind:this={element} xmlns={SVG_NAMESPACE} {...derivedAttrs}>
+    <svelte:element this={renderTag} bind:this={element} xmlns={SVG_NAMESPACE} {...derivedAttrs}>
         {#if motionValueChild}
             {motionValueChildText ?? motionValueChildInitialText}
         {:else}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,5 @@
 import type { MotionValueChild } from '$lib/utils/motionValueChild'
-import type { MotionStyle, TransformTemplate } from '$lib/utils/style'
+import type { MotionStyle, MotionStyleValue, TransformTemplate } from '$lib/utils/style'
 import type { AnimationOptions, DOMKeyframesDefinition } from 'motion'
 import type { Snippet } from 'svelte'
 
@@ -622,6 +622,20 @@ export type MotionProps = {
     onPanEnd?: MotionOnPanEnd
     /** Inline styles as a CSS string or Motion-style object with live MotionValue entries. */
     style?: string | MotionStyle
+    /**
+     * Renders as the SVG `x` **attribute**, distinct from the CSS `x` transform.
+     * Use on SVG elements where `x` would otherwise be claimed as a transform.
+     *
+     * @example
+     * ```svelte
+     * <motion.rect attrX={xValue} attrY={yValue} />
+     * ```
+     */
+    attrX?: MotionStyleValue
+    /** Renders as the SVG `y` **attribute**, distinct from the CSS `y` transform. */
+    attrY?: MotionStyleValue
+    /** Renders as the SVG `scale` **attribute**, distinct from the CSS `scale` transform. */
+    attrScale?: MotionStyleValue
     /** CSS classes */
     class?: string
     /** Enable FLIP layout animations; string values select the upstream projection animation type. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -632,9 +632,26 @@ export type MotionProps = {
      * ```
      */
     attrX?: MotionStyleValue
-    /** Renders as the SVG `y` **attribute**, distinct from the CSS `y` transform. */
+    /**
+     * Renders as the SVG `y` **attribute**, distinct from the CSS `y` transform.
+     * Use on SVG elements where `y` would otherwise be claimed as a transform.
+     *
+     * @example
+     * ```svelte
+     * <motion.rect attrX={xValue} attrY={yValue} />
+     * ```
+     */
     attrY?: MotionStyleValue
-    /** Renders as the SVG `scale` **attribute**, distinct from the CSS `scale` transform. */
+    /**
+     * Renders as the SVG `scale` **attribute**, distinct from the CSS `scale`
+     * transform. Only meaningful on `<feDisplacementMap>`, where it drives the
+     * displacement amount; on shape elements the attribute is inert.
+     *
+     * @example
+     * ```svelte
+     * <motion.fedisplacementmap in="SourceGraphic" in2="noise" attrScale={warp} />
+     * ```
+     */
     attrScale?: MotionStyleValue
     /** CSS classes */
     class?: string

--- a/src/lib/utils/svg.spec.ts
+++ b/src/lib/utils/svg.spec.ts
@@ -487,6 +487,89 @@ describe('extractSVGMotionValueAttributes', () => {
     })
 })
 
+describe('filter-primitive attributes', () => {
+    // Plan 005 drives feTurbulence/feOffset/feGaussianBlur from MotionValues. An
+    // unclaimed key falls through to the raw spread and renders `[object Object]`,
+    // the exact failure this feature exists to eliminate.
+
+    it('should claim the camelCase filter keys that upstream lists', () => {
+        // Resolved against motion-dom's exported `camelCaseAttributes` rather than a
+        // hand-written list, so upstream additions track on version bumps.
+        for (const key of ['stdDeviation', 'baseFrequency', 'numOctaves']) {
+            expect(camelCaseAttributes.has(key)).toBe(true)
+            expect(isSVGMotionValueAttribute(key)).toBe(true)
+        }
+    })
+
+    it('should claim the lowercase filter keys upstream cannot cover', () => {
+        // `camelCaseAttributes` only lists camelCase names, so these need adding
+        // explicitly — they are not in it.
+        for (const key of ['dx', 'dy', 'radius']) {
+            expect(camelCaseAttributes.has(key)).toBe(false)
+            expect(isSVGMotionValueAttribute(key)).toBe(true)
+        }
+    })
+
+    it('should route filter keys into motionValueAttrs, never the raw spread', () => {
+        const values = {
+            stdDeviation: motionValue(4),
+            baseFrequency: motionValue(0.05),
+            numOctaves: motionValue(2),
+            dx: motionValue(3),
+            dy: motionValue(3),
+            radius: motionValue(1)
+        }
+        const { motionValueAttrs, staticAttrs } = extractSVGMotionValueAttributes({ ...values })
+
+        expect(Object.keys(motionValueAttrs).sort()).toEqual(Object.keys(values).sort())
+        expect(staticAttrs).toEqual({})
+    })
+
+    it('should still refuse pathLength even though camelCaseAttributes lists it', () => {
+        // `pathLength` IS in camelCaseAttributes. Resolving against that set must not
+        // hand the path pipeline's props to svgEffect's attribute writer, or
+        // stroke-dasharray gets written twice.
+        expect(camelCaseAttributes.has('pathLength')).toBe(true)
+        expect(isSVGMotionValueAttribute('pathLength')).toBe(false)
+
+        const pathLength = motionValue(0.5)
+        const { motionValueAttrs, staticAttrs } = extractSVGMotionValueAttributes({ pathLength })
+
+        expect(motionValueAttrs).toEqual({})
+        expect(staticAttrs).toEqual({ pathLength })
+    })
+
+    it('should keep static filter values out of motionValueAttrs', () => {
+        const { motionValueAttrs, staticAttrs } = extractSVGMotionValueAttributes({
+            stdDeviation: 4,
+            dx: 3
+        })
+
+        expect(motionValueAttrs).toEqual({})
+        expect(staticAttrs).toEqual({ stdDeviation: 4, dx: 3 })
+    })
+
+    it('should still reject unrelated keys that hold MotionValues', () => {
+        const custom = motionValue(1)
+        const { motionValueAttrs, staticAttrs } = extractSVGMotionValueAttributes({ custom })
+
+        expect(motionValueAttrs).toEqual({})
+        expect(staticAttrs).toEqual({ custom })
+    })
+
+    it('should SSR filter keys with their camelCase names preserved', () => {
+        const { motionValueAttrs } = extractSVGMotionValueAttributes({
+            stdDeviation: motionValue(4),
+            dx: motionValue(3)
+        })
+
+        expect(computeSSRSVGAttrValues(motionValueAttrs)).toEqual({
+            stdDeviation: '4',
+            dx: '3'
+        })
+    })
+})
+
 describe('computeSSRSVGAttrValues', () => {
     it('should render the current value of each MotionValue as a string', () => {
         expect(computeSSRSVGAttrValues({ cx: motionValue(10), r: motionValue(4.5) })).toEqual({
@@ -548,13 +631,21 @@ describe('computeSSRSVGAttrValues', () => {
         // Guards against vendoring a hand-written copy of the allowlist: these
         // filter-primitive keys only survive if motion-dom's own
         // `camelCaseAttributes` is the gate (camel-case-attrs.ts:4-28).
-        expect(
-            computeSSRSVGAttrValues({
-                stdDeviation: motionValue(2),
-                baseFrequency: motionValue(0.05),
-                numOctaves: motionValue(3)
-            })
-        ).toEqual({ stdDeviation: '2', baseFrequency: '0.05', numOctaves: '3' })
+        //
+        // Routed through `extractSVGMotionValueAttributes` on purpose. Handing the
+        // keys straight to the SSR helper bypasses classification, which is how a
+        // filter primitive rendering `[object Object]` survived a fully green suite.
+        const { motionValueAttrs } = extractSVGMotionValueAttributes({
+            stdDeviation: motionValue(2),
+            baseFrequency: motionValue(0.05),
+            numOctaves: motionValue(3)
+        })
+
+        expect(computeSSRSVGAttrValues(motionValueAttrs)).toEqual({
+            stdDeviation: '2',
+            baseFrequency: '0.05',
+            numOctaves: '3'
+        })
     })
 
     it('should never emit [object Object]', () => {

--- a/src/lib/utils/svg.spec.ts
+++ b/src/lib/utils/svg.spec.ts
@@ -11,8 +11,11 @@ import {
     isSVGMotionValueAttribute,
     isSVGPathElement,
     resolveSVGAttrKey,
+    resolveSVGTagName,
     SVG_ATTRIBUTE_PROPERTIES,
     SVG_PATH_PROPERTIES,
+    SVG_TAG_CASING,
+    SVG_TAGS,
     transformInitialSVGPathProperties,
     transformSVGPathProperties
 } from './svg'
@@ -204,6 +207,57 @@ describe('svg utilities', () => {
                 'stroke-dashoffset': '0'
             })
         })
+    })
+})
+
+describe('resolveSVGTagName', () => {
+    it('should restore the spec casing of filter primitives', () => {
+        // SVG tag names are case-sensitive; `fedisplacementmap` in the SVG namespace
+        // is an inert SVGElement, so its `scale` attribute does nothing.
+        expect(resolveSVGTagName('fedisplacementmap')).toBe('feDisplacementMap')
+        expect(resolveSVGTagName('feturbulence')).toBe('feTurbulence')
+        expect(resolveSVGTagName('fegaussianblur')).toBe('feGaussianBlur')
+        expect(resolveSVGTagName('fefunca')).toBe('feFuncA')
+    })
+
+    it('should restore the spec casing of non-filter camelCase elements', () => {
+        expect(resolveSVGTagName('clippath')).toBe('clipPath')
+        expect(resolveSVGTagName('lineargradient')).toBe('linearGradient')
+        expect(resolveSVGTagName('radialgradient')).toBe('radialGradient')
+        expect(resolveSVGTagName('textpath')).toBe('textPath')
+        expect(resolveSVGTagName('foreignobject')).toBe('foreignObject')
+        expect(resolveSVGTagName('animatetransform')).toBe('animateTransform')
+    })
+
+    it('should pass through all-lowercase SVG tags and non-SVG tags', () => {
+        expect(resolveSVGTagName('circle')).toBe('circle')
+        expect(resolveSVGTagName('path')).toBe('path')
+        expect(resolveSVGTagName('div')).toBe('div')
+    })
+
+    it('should be idempotent on already-correct casing', () => {
+        expect(resolveSVGTagName('feDisplacementMap')).toBe('feDisplacementMap')
+        expect(resolveSVGTagName('clipPath')).toBe('clipPath')
+    })
+
+    it('should only map tags that are recognized SVG elements', () => {
+        for (const lower of Object.keys(SVG_TAG_CASING)) {
+            expect(SVG_TAGS.has(lower)).toBe(true)
+        }
+    })
+
+    it('should produce a canonical name that lowercases back to its key', () => {
+        for (const [lower, canonical] of Object.entries(SVG_TAG_CASING)) {
+            expect(canonical.toLowerCase()).toBe(lower)
+        }
+    })
+
+    it('should create a live element for a canonicalized filter primitive', () => {
+        const el = document.createElementNS(
+            'http://www.w3.org/2000/svg',
+            resolveSVGTagName('fedisplacementmap')
+        )
+        expect(el.tagName).toBe('feDisplacementMap')
     })
 })
 

--- a/src/lib/utils/svg.spec.ts
+++ b/src/lib/utils/svg.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { motionValue } from 'motion-dom'
+import { camelCaseAttributes, camelToDash, motionValue } from 'motion-dom'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
     computeNormalizedSVGInitialAttrs,
@@ -204,6 +204,26 @@ describe('svg utilities', () => {
                 'stroke-dashoffset': '0'
             })
         })
+    })
+})
+
+describe('motion-dom casing primitives', () => {
+    it('should expose camelToDash and camelCaseAttributes as public exports', () => {
+        // Plan 002 amendment, point 2: import both; do not vendor a copy, so
+        // upstream additions track automatically on version bumps.
+        expect(typeof camelToDash).toBe('function')
+        expect(camelCaseAttributes).toBeInstanceOf(Set)
+    })
+
+    it('should carry 23 camelCase attribute entries (drift reference for version bumps)', () => {
+        // motion-dom v12.42.2, camel-case-attrs.ts:4-28. A change here means
+        // upstream extended the allowlist — re-verify the SSR casing gate.
+        expect(camelCaseAttributes.size).toBe(23)
+        expect(camelCaseAttributes.has('viewBox')).toBe(true)
+    })
+
+    it('should not dash-case an already-kebab key', () => {
+        expect(camelToDash('stroke-width')).toBe('stroke-width')
     })
 })
 
@@ -450,6 +470,37 @@ describe('computeSSRSVGAttrValues', () => {
         expect(computeSSRSVGAttrValues({ viewBox: motionValue('0 0 10 10') })).toEqual({
             viewBox: '0 0 10 10'
         })
+    })
+
+    it('should strip the attr prefix BEFORE applying the casing gate', () => {
+        // Plan 002 amendment, normative point 4. `attrX` is not in
+        // `camelCaseAttributes`, so gating first dash-cases it to the inert
+        // `attr-x`. Upstream's `buildSVGAttrs` destructures attrX/attrY/attrScale
+        // into attrs.x/y/scale *before* `renderSVG` applies the gate
+        // (build-attrs.ts:23-25,82-85 -> render.ts:15-19).
+        const attrs = computeSSRSVGAttrValues({
+            attrX: motionValue(3),
+            attrY: motionValue(4),
+            attrScale: motionValue(2)
+        })
+
+        expect(attrs).toEqual({ x: '3', y: '4', scale: '2' })
+        expect(attrs).not.toHaveProperty('attr-x')
+        expect(attrs).not.toHaveProperty('attr-y')
+        expect(attrs).not.toHaveProperty('attr-scale')
+    })
+
+    it('should honor upstream camelCase entries beyond the ones we hand-picked', () => {
+        // Guards against vendoring a hand-written copy of the allowlist: these
+        // filter-primitive keys only survive if motion-dom's own
+        // `camelCaseAttributes` is the gate (camel-case-attrs.ts:4-28).
+        expect(
+            computeSSRSVGAttrValues({
+                stdDeviation: motionValue(2),
+                baseFrequency: motionValue(0.05),
+                numOctaves: motionValue(3)
+            })
+        ).toEqual({ stdDeviation: '2', baseFrequency: '0.05', numOctaves: '3' })
     })
 
     it('should never emit [object Object]', () => {

--- a/src/lib/utils/svg.spec.ts
+++ b/src/lib/utils/svg.spec.ts
@@ -246,6 +246,24 @@ describe('SVG_ATTRIBUTE_PROPERTIES', () => {
         }
     })
 
+    it('should include the kebab-case DOM spellings a Svelte template actually uses', () => {
+        // Upstream's list is React-facing (JSX camelCase). Svelte templates take the
+        // DOM spelling, so `<motion.circle stroke-width={mv}>` is the common form. A
+        // kebab key missing from the allowlist is never claimed out of the raw spread
+        // and renders stroke-width="[object Object]" — the bug this feature kills.
+        for (const key of [
+            'stop-color',
+            'stop-opacity',
+            'fill-opacity',
+            'stroke-opacity',
+            'stroke-width',
+            'stroke-dashoffset',
+            'stroke-dasharray'
+        ]) {
+            expect(SVG_ATTRIBUTE_PROPERTIES.has(key)).toBe(true)
+        }
+    })
+
     it('should not overlap with SVG_PATH_PROPERTIES (no double handling)', () => {
         const overlap = [...SVG_PATH_PROPERTIES].filter((key) => SVG_ATTRIBUTE_PROPERTIES.has(key))
         expect(overlap).toEqual([])
@@ -285,6 +303,12 @@ describe('isSVGMotionValueAttribute', () => {
         expect(isSVGMotionValueAttribute('cx')).toBe(true)
         expect(isSVGMotionValueAttribute('attrX')).toBe(true)
         expect(isSVGMotionValueAttribute('attrScale')).toBe(true)
+    })
+
+    it('should accept kebab-case DOM spellings', () => {
+        expect(isSVGMotionValueAttribute('stroke-width')).toBe(true)
+        expect(isSVGMotionValueAttribute('stroke-dashoffset')).toBe(true)
+        expect(isSVGMotionValueAttribute('stop-color')).toBe(true)
     })
 
     it('should reject path props so the path pipeline keeps ownership', () => {
@@ -335,6 +359,18 @@ describe('extractSVGMotionValueAttributes', () => {
         expect(motionValueAttrs).toEqual({})
         expect(staticAttrs).toEqual({ x: 10, y: 20 })
         expect(staticAttrs).not.toHaveProperty('attrX')
+    })
+
+    it('should claim kebab-case keys without renaming them', () => {
+        // `'stroke-width' in element.style` is true in Chromium, so svgEffect routes
+        // the kebab key correctly on its own once we hand it over.
+        const strokeWidth = motionValue(2)
+        const { motionValueAttrs, staticAttrs } = extractSVGMotionValueAttributes({
+            'stroke-width': strokeWidth
+        })
+
+        expect(motionValueAttrs).toEqual({ 'stroke-width': strokeWidth })
+        expect(staticAttrs).toEqual({})
     })
 
     it('should not claim path props even when they hold MotionValues', () => {
@@ -389,6 +425,31 @@ describe('computeSSRSVGAttrValues', () => {
         expect(
             computeSSRSVGAttrValues({ attrX: motionValue(3), attrScale: motionValue(2) })
         ).toEqual({ x: '3', scale: '2' })
+    })
+
+    it('should emit kebab-case DOM names for hyphenated camelCase keys', () => {
+        // SVG attribute names are case-sensitive: a `strokeDashoffset` attribute is
+        // inert, so the value would flash on hydration.
+        expect(
+            computeSSRSVGAttrValues({
+                strokeDashoffset: motionValue(4),
+                stopColor: motionValue('red')
+            })
+        ).toEqual({ 'stroke-dashoffset': '4', 'stop-color': 'red' })
+    })
+
+    it('should leave already-kebab keys untouched', () => {
+        expect(computeSSRSVGAttrValues({ 'stroke-width': motionValue(2) })).toEqual({
+            'stroke-width': '2'
+        })
+    })
+
+    it('should preserve camelCase attribute names that must stay camelCase', () => {
+        // motion-dom's `camelCaseAttributes` set: naive dash-casing would emit the
+        // inert `view-box`.
+        expect(computeSSRSVGAttrValues({ viewBox: motionValue('0 0 10 10') })).toEqual({
+            viewBox: '0 0 10 10'
+        })
     })
 
     it('should never emit [object Object]', () => {

--- a/src/lib/utils/svg.spec.ts
+++ b/src/lib/utils/svg.spec.ts
@@ -1,11 +1,18 @@
 /**
  * @vitest-environment jsdom
  */
+import { motionValue } from 'motion-dom'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
     computeNormalizedSVGInitialAttrs,
+    computeSSRSVGAttrValues,
+    extractSVGMotionValueAttributes,
     hasSVGPathProperties,
+    isSVGMotionValueAttribute,
     isSVGPathElement,
+    resolveSVGAttrKey,
+    SVG_ATTRIBUTE_PROPERTIES,
+    SVG_PATH_PROPERTIES,
     transformInitialSVGPathProperties,
     transformSVGPathProperties
 } from './svg'
@@ -197,5 +204,207 @@ describe('svg utilities', () => {
                 'stroke-dashoffset': '0'
             })
         })
+    })
+})
+
+describe('SVG_ATTRIBUTE_PROPERTIES', () => {
+    it('should include the geometry attributes upstream animates', () => {
+        for (const key of [
+            'cx',
+            'cy',
+            'r',
+            'rx',
+            'ry',
+            'x',
+            'y',
+            'x1',
+            'y1',
+            'x2',
+            'y2',
+            'width',
+            'height',
+            'points',
+            'd',
+            'viewBox'
+        ]) {
+            expect(SVG_ATTRIBUTE_PROPERTIES.has(key)).toBe(true)
+        }
+    })
+
+    it('should include presentation attributes that svgEffect routes to style', () => {
+        // These live in `element.style`, so svgEffect sends them through addStyleValue.
+        // We still claim them out of the raw spread so they never stringify.
+        for (const key of [
+            'offset',
+            'stopColor',
+            'stopOpacity',
+            'fillOpacity',
+            'strokeOpacity',
+            'strokeWidth'
+        ]) {
+            expect(SVG_ATTRIBUTE_PROPERTIES.has(key)).toBe(true)
+        }
+    })
+
+    it('should not overlap with SVG_PATH_PROPERTIES (no double handling)', () => {
+        const overlap = [...SVG_PATH_PROPERTIES].filter((key) => SVG_ATTRIBUTE_PROPERTIES.has(key))
+        expect(overlap).toEqual([])
+    })
+
+    it('should not enumerate attr-prefixed keys (handled by prefix, not allowlist)', () => {
+        expect(SVG_ATTRIBUTE_PROPERTIES.has('attrX')).toBe(false)
+        expect(SVG_ATTRIBUTE_PROPERTIES.has('attrY')).toBe(false)
+        expect(SVG_ATTRIBUTE_PROPERTIES.has('attrScale')).toBe(false)
+    })
+})
+
+describe('resolveSVGAttrKey', () => {
+    it('should map attrX/attrY/attrScale to their SVG attribute names', () => {
+        // Upstream: buildSVGAttrs renders attrX -> attrs.x (build-attrs.ts:82-85)
+        expect(resolveSVGAttrKey('attrX')).toBe('x')
+        expect(resolveSVGAttrKey('attrY')).toBe('y')
+        expect(resolveSVGAttrKey('attrScale')).toBe('scale')
+    })
+
+    it('should pass non-attr keys through untouched', () => {
+        expect(resolveSVGAttrKey('cx')).toBe('cx')
+        expect(resolveSVGAttrKey('strokeWidth')).toBe('strokeWidth')
+        expect(resolveSVGAttrKey('viewBox')).toBe('viewBox')
+    })
+
+    it('should only strip the prefix when followed by an uppercase char', () => {
+        // Mirrors upstream's /^attr([A-Z])/ conversion; `attribute` must not become `ibute`.
+        expect(resolveSVGAttrKey('attribute')).toBe('attribute')
+        expect(resolveSVGAttrKey('attr')).toBe('attr')
+        expect(resolveSVGAttrKey('attrx')).toBe('attrx')
+    })
+})
+
+describe('isSVGMotionValueAttribute', () => {
+    it('should accept allowlisted attributes and attr-prefixed keys', () => {
+        expect(isSVGMotionValueAttribute('cx')).toBe(true)
+        expect(isSVGMotionValueAttribute('attrX')).toBe(true)
+        expect(isSVGMotionValueAttribute('attrScale')).toBe(true)
+    })
+
+    it('should reject path props so the path pipeline keeps ownership', () => {
+        expect(isSVGMotionValueAttribute('pathLength')).toBe(false)
+        expect(isSVGMotionValueAttribute('pathOffset')).toBe(false)
+        expect(isSVGMotionValueAttribute('pathSpacing')).toBe(false)
+    })
+
+    it('should reject unrelated props', () => {
+        expect(isSVGMotionValueAttribute('class')).toBe(false)
+        expect(isSVGMotionValueAttribute('onclick')).toBe(false)
+    })
+})
+
+describe('extractSVGMotionValueAttributes', () => {
+    it('should split MotionValue attributes from static attributes', () => {
+        const cx = motionValue(10)
+        const { motionValueAttrs, staticAttrs } = extractSVGMotionValueAttributes({
+            cx,
+            cy: 25,
+            fill: 'red'
+        })
+
+        expect(motionValueAttrs).toEqual({ cx })
+        expect(staticAttrs).toEqual({ cy: 25, fill: 'red' })
+    })
+
+    it('should keep MotionValue keys un-renamed so svgEffect can route them', () => {
+        // svgEffect does its own `attr` prefix conversion (effects/svg/index.ts).
+        // Pre-renaming attrX -> x would make it hit the `key in element.style`
+        // branch and become a CSS style instead of an attribute.
+        const scale = motionValue(2)
+        const { motionValueAttrs, staticAttrs } = extractSVGMotionValueAttributes({
+            attrScale: scale
+        })
+
+        expect(motionValueAttrs).toEqual({ attrScale: scale })
+        expect(motionValueAttrs).not.toHaveProperty('scale')
+        expect(staticAttrs).toEqual({})
+    })
+
+    it('should rename static attr-prefixed props to their attribute names', () => {
+        const { motionValueAttrs, staticAttrs } = extractSVGMotionValueAttributes({
+            attrX: 10,
+            attrY: 20
+        })
+
+        expect(motionValueAttrs).toEqual({})
+        expect(staticAttrs).toEqual({ x: 10, y: 20 })
+        expect(staticAttrs).not.toHaveProperty('attrX')
+    })
+
+    it('should not claim path props even when they hold MotionValues', () => {
+        const pathLength = motionValue(0.5)
+        const { motionValueAttrs, staticAttrs } = extractSVGMotionValueAttributes({ pathLength })
+
+        expect(motionValueAttrs).toEqual({})
+        expect(staticAttrs).toEqual({ pathLength })
+    })
+
+    it('should not claim MotionValues on non-attribute keys', () => {
+        const custom = motionValue(1)
+        const { motionValueAttrs, staticAttrs } = extractSVGMotionValueAttributes({ custom })
+
+        expect(motionValueAttrs).toEqual({})
+        expect(staticAttrs).toEqual({ custom })
+    })
+
+    it('should leave plain objects that are not MotionValues untouched', () => {
+        const notAValue = { get: () => 5 }
+        const { motionValueAttrs, staticAttrs } = extractSVGMotionValueAttributes({ cx: notAValue })
+
+        expect(motionValueAttrs).toEqual({})
+        expect(staticAttrs).toEqual({ cx: notAValue })
+    })
+
+    it('should handle an empty prop bag', () => {
+        expect(extractSVGMotionValueAttributes({})).toEqual({
+            motionValueAttrs: {},
+            staticAttrs: {}
+        })
+    })
+
+    it('should not mutate the input object', () => {
+        const cx = motionValue(10)
+        const rest = { cx, attrX: 4, fill: 'blue' }
+        extractSVGMotionValueAttributes(rest)
+
+        expect(rest).toEqual({ cx, attrX: 4, fill: 'blue' })
+    })
+})
+
+describe('computeSSRSVGAttrValues', () => {
+    it('should render the current value of each MotionValue as a string', () => {
+        expect(computeSSRSVGAttrValues({ cx: motionValue(10), r: motionValue(4.5) })).toEqual({
+            cx: '10',
+            r: '4.5'
+        })
+    })
+
+    it('should resolve attr-prefixed keys to their attribute names', () => {
+        expect(
+            computeSSRSVGAttrValues({ attrX: motionValue(3), attrScale: motionValue(2) })
+        ).toEqual({ x: '3', scale: '2' })
+    })
+
+    it('should never emit [object Object]', () => {
+        const attrs = computeSSRSVGAttrValues({ cx: motionValue(10), attrY: motionValue(2) })
+        for (const value of Object.values(attrs)) {
+            expect(value).not.toContain('[object Object]')
+        }
+    })
+
+    it('should omit attributes whose current value is null or undefined', () => {
+        expect(
+            computeSSRSVGAttrValues({ cx: motionValue(null), cy: motionValue(undefined) })
+        ).toEqual({})
+    })
+
+    it('should return an empty object when there are no MotionValue attrs', () => {
+        expect(computeSSRSVGAttrValues({})).toEqual({})
     })
 })

--- a/src/lib/utils/svg.ts
+++ b/src/lib/utils/svg.ts
@@ -1,10 +1,206 @@
-import { buildSVGPath } from 'motion-dom'
+import {
+    buildSVGPath,
+    camelCaseAttributes,
+    camelToDash,
+    isMotionValue,
+    type MotionValue
+} from 'motion-dom'
 
 /**
  * SVG-specific properties that need special handling during animation.
  * These properties are not standard CSS properties and need to be transformed.
  */
 export const SVG_PATH_PROPERTIES = new Set(['pathLength', 'pathOffset', 'pathSpacing'])
+
+/**
+ * SVG props that may be driven by a `MotionValue`.
+ *
+ * Mirrors the animatable surface of upstream's `buildSVGAttrs`
+ * (`motion-dom/src/render/svg/utils/build-attrs.ts`). Upstream is React-facing
+ * and only lists JSX camelCase spellings, so the hyphenated keys appear here in
+ * *both* forms: a Svelte template takes the DOM spelling, and a user writing
+ * `<motion.circle stroke-width={mv}>` must have that prop claimed out of the raw
+ * attribute spread or it renders `stroke-width="[object Object]"`.
+ *
+ * Membership means only "pull this out of the raw spread". It does **not** mean
+ * "this is a DOM attribute": `svgEffect` decides that per key at runtime via
+ * `key in element.style ? addStyleValue : addAttrValue`
+ * (`motion-dom/src/effects/svg/index.ts`). In Chromium `cx`, `r`, `width` and the
+ * `stroke-*` family are CSS properties and route to `element.style`, while
+ * `points`, `viewBox` and `x1`/`y1`/`x2`/`y2` route to `setAttribute`.
+ *
+ * Path props are deliberately excluded — the path pipeline owns them.
+ */
+export const SVG_ATTRIBUTE_PROPERTIES = new Set([
+    // Geometry
+    'cx',
+    'cy',
+    'r',
+    'rx',
+    'ry',
+    'x',
+    'y',
+    'x1',
+    'y1',
+    'x2',
+    'y2',
+    'width',
+    'height',
+    'points',
+    'd',
+    'offset',
+    'viewBox',
+    // Presentation (React/JSX camelCase spellings)
+    'stopColor',
+    'stopOpacity',
+    'fillOpacity',
+    'strokeOpacity',
+    'strokeWidth',
+    'strokeDashoffset',
+    'strokeDasharray',
+    // Presentation (DOM kebab spellings, as written in a Svelte template)
+    'stop-color',
+    'stop-opacity',
+    'fill-opacity',
+    'stroke-opacity',
+    'stroke-width',
+    'stroke-dashoffset',
+    'stroke-dasharray'
+])
+
+/**
+ * Strips the `attr` prefix from `attrX`/`attrY`/`attrScale`, yielding the SVG
+ * attribute name upstream renders them as (`x`/`y`/`scale`).
+ *
+ * Mirrors upstream's `/^attr([A-Z])/` conversion in
+ * `motion-dom/src/effects/svg/index.ts`, and the `attrX -> attrs.x` destructuring
+ * in `build-attrs.ts:23-25,82-85`.
+ *
+ * Apply this to **static** props and to SSR output only. MotionValue-bound props
+ * must reach `svgEffect` un-renamed, because it performs this conversion itself;
+ * pre-renaming `attrScale` to `scale` would instead make it match the
+ * `key in element.style` branch and become a CSS style.
+ *
+ * @param {string} key The incoming prop name.
+ * @returns {string} The resolved SVG attribute name.
+ * @example
+ * resolveSVGAttrKey('attrX') // 'x'
+ * resolveSVGAttrKey('attribute') // 'attribute' — prefix needs an uppercase char
+ */
+export const resolveSVGAttrKey = (key: string): string => {
+    return key.replace(/^attr([A-Z])/, (_, firstChar: string) => firstChar.toLowerCase())
+}
+
+/**
+ * Determines whether a prop may be bound to a `MotionValue` on an SVG element.
+ *
+ * Path props return false: they are owned by the path-drawing pipeline, and
+ * claiming them here would double-write `stroke-dasharray`.
+ *
+ * @param {string} key The prop name to test.
+ * @returns {boolean} True when the prop is attribute-bindable.
+ * @example
+ * isSVGMotionValueAttribute('cx') // true
+ * isSVGMotionValueAttribute('attrScale') // true
+ * isSVGMotionValueAttribute('pathLength') // false
+ */
+export const isSVGMotionValueAttribute = (key: string): boolean => {
+    if (SVG_PATH_PROPERTIES.has(key)) return false
+    if (/^attr[A-Z]/.test(key)) return true
+    return SVG_ATTRIBUTE_PROPERTIES.has(key)
+}
+
+/**
+ * Splits an SVG element's leftover props into MotionValue-bound attributes and
+ * plain static attributes.
+ *
+ * MotionValue keys are returned **verbatim** so `svgEffect` can apply its own
+ * `attr`-prefix conversion and style-vs-attribute routing. Static attr-prefixed
+ * props are renamed eagerly, matching upstream's `buildSVGAttrs`.
+ *
+ * @param {Record<string, unknown>} rest The element's unclaimed props.
+ * @returns {{motionValueAttrs: Record<string, MotionValue>, staticAttrs: Record<string, unknown>}}
+ *   The MotionValue-bound attrs to subscribe, and the static attrs to spread.
+ * @example
+ * const { motionValueAttrs, staticAttrs } = extractSVGMotionValueAttributes({
+ *   cx: motionValue(10),
+ *   attrX: 4
+ * })
+ * // motionValueAttrs -> { cx: MotionValue }   (un-renamed, for svgEffect)
+ * // staticAttrs      -> { x: 4 }              (renamed, for the spread)
+ */
+export const extractSVGMotionValueAttributes = (
+    rest: Record<string, unknown>
+): {
+    motionValueAttrs: Record<string, MotionValue>
+    staticAttrs: Record<string, unknown>
+} => {
+    const motionValueAttrs: Record<string, MotionValue> = {}
+    const staticAttrs: Record<string, unknown> = {}
+
+    for (const [key, value] of Object.entries(rest)) {
+        if (isMotionValue(value) && isSVGMotionValueAttribute(key)) {
+            motionValueAttrs[key] = value
+        } else if (!isMotionValue(value) && /^attr[A-Z]/.test(key)) {
+            staticAttrs[resolveSVGAttrKey(key)] = value
+        } else {
+            staticAttrs[key] = value
+        }
+    }
+
+    return { motionValueAttrs, staticAttrs }
+}
+
+/**
+ * Converts a MotionValue-bound prop name into the DOM attribute name to emit
+ * during SSR.
+ *
+ * The `attr` prefix is stripped **before** the casing gate is applied. `attrX` is
+ * not a member of `camelCaseAttributes`, so gating first would dash-case it into
+ * the inert `attr-x`. Upstream imposes the same ordering: `buildSVGAttrs`
+ * destructures `attrX` into `attrs.x` before `renderSVG`
+ * (`motion-dom/src/render/svg/utils/render.ts:15-19`) applies
+ * `!camelCaseAttributes.has(key) ? camelToDash(key) : key`.
+ *
+ * @param {string} key The incoming prop name.
+ * @returns {string} The DOM attribute name.
+ */
+const toSVGDOMAttrName = (key: string): string => {
+    const resolved = resolveSVGAttrKey(key)
+    return camelCaseAttributes.has(resolved) ? resolved : camelToDash(resolved)
+}
+
+/**
+ * Resolves MotionValue-bound SVG attributes to their current values for server
+ * rendering, keyed by DOM attribute name.
+ *
+ * SSR must emit the MotionValue's current value so the server payload is correct
+ * and hydration doesn't flash. SVG attribute names are case-sensitive, so the
+ * emitted names go through upstream's casing gate: `strokeDashoffset` becomes
+ * `stroke-dashoffset`, while `viewBox` and the filter primitives stay camelCase.
+ *
+ * Style-routed keys (`cx`, `r`, …) SSR correctly as presentation attributes; the
+ * client-set CSS property simply wins once `svgEffect` subscribes.
+ *
+ * @param {Record<string, MotionValue>} motionValueAttrs MotionValue-bound attrs.
+ * @returns {Record<string, string>} DOM attribute names mapped to string values.
+ * @example
+ * computeSSRSVGAttrValues({ attrX: motionValue(3) }) // { x: '3' }
+ * computeSSRSVGAttrValues({ strokeDashoffset: motionValue(4) }) // { 'stroke-dashoffset': '4' }
+ */
+export const computeSSRSVGAttrValues = (
+    motionValueAttrs: Record<string, MotionValue>
+): Record<string, string> => {
+    const attrs: Record<string, string> = {}
+
+    for (const [key, value] of Object.entries(motionValueAttrs)) {
+        const current = value.get()
+        if (current === null || current === undefined) continue
+        attrs[toSVGDOMAttrName(key)] = String(current)
+    }
+
+    return attrs
+}
 
 /**
  * The SVG namespace URI.

--- a/src/lib/utils/svg.ts
+++ b/src/lib/utils/svg.ts
@@ -65,7 +65,12 @@ export const SVG_ATTRIBUTE_PROPERTIES = new Set([
     'stroke-opacity',
     'stroke-width',
     'stroke-dashoffset',
-    'stroke-dasharray'
+    'stroke-dasharray',
+    // Filter-primitive attributes whose names are all-lowercase, so
+    // `camelCaseAttributes` cannot cover them (see isSVGMotionValueAttribute).
+    'dx',
+    'dy',
+    'radius'
 ])
 
 /**
@@ -94,19 +99,33 @@ export const resolveSVGAttrKey = (key: string): string => {
 /**
  * Determines whether a prop may be bound to a `MotionValue` on an SVG element.
  *
- * Path props return false: they are owned by the path-drawing pipeline, and
- * claiming them here would double-write `stroke-dasharray`.
+ * Resolution order matters:
+ *
+ * 1. Path props return false first. They are owned by the path-drawing pipeline,
+ *    and claiming them here would double-write `stroke-dasharray`. This check
+ *    must precede the `camelCaseAttributes` lookup, because `pathLength` is a
+ *    member of that set.
+ * 2. `attr`-prefixed props are always bindable.
+ * 3. motion-dom's exported `camelCaseAttributes` covers every camelCase SVG
+ *    attribute name upstream knows about — `stdDeviation`, `baseFrequency`,
+ *    `numOctaves`, `gradientTransform`, `textLength`, and so on. Deferring to it
+ *    means upstream additions track automatically on version bumps, rather than
+ *    silently falling through to the raw spread as `[object Object]`.
+ * 4. Finally the local allowlist, which carries the lowercase and kebab-case
+ *    names `camelCaseAttributes` cannot express (`cx`, `dx`, `stroke-width`, …).
  *
  * @param {string} key The prop name to test.
  * @returns {boolean} True when the prop is attribute-bindable.
  * @example
  * isSVGMotionValueAttribute('cx') // true
+ * isSVGMotionValueAttribute('stdDeviation') // true — via camelCaseAttributes
  * isSVGMotionValueAttribute('attrScale') // true
- * isSVGMotionValueAttribute('pathLength') // false
+ * isSVGMotionValueAttribute('pathLength') // false — the path pipeline owns it
  */
 export const isSVGMotionValueAttribute = (key: string): boolean => {
     if (SVG_PATH_PROPERTIES.has(key)) return false
     if (/^attr[A-Z]/.test(key)) return true
+    if (camelCaseAttributes.has(key)) return true
     return SVG_ATTRIBUTE_PROPERTIES.has(key)
 }
 

--- a/src/lib/utils/svg.ts
+++ b/src/lib/utils/svg.ts
@@ -289,6 +289,68 @@ export const isSVGTag = (tag: string): boolean => {
 }
 
 /**
+ * Canonical casing for the SVG elements whose tag names are not all-lowercase.
+ *
+ * SVG tag names are **case-sensitive**, unlike HTML. Creating
+ * `fedisplacementmap` in the SVG namespace yields an inert generic `SVGElement`
+ * rather than an `SVGFEDisplacementMapElement`, so the filter primitive is
+ * ignored and its attributes (`scale`, `stdDeviation`, …) do nothing.
+ *
+ * Keys are the lowercase forms our components pass as `tag`; values are the
+ * spec spellings. See the SVG 2 element index.
+ */
+export const SVG_TAG_CASING: Record<string, string> = {
+    animatemotion: 'animateMotion',
+    animatetransform: 'animateTransform',
+    clippath: 'clipPath',
+    feblend: 'feBlend',
+    fecolormatrix: 'feColorMatrix',
+    fecomponenttransfer: 'feComponentTransfer',
+    fecomposite: 'feComposite',
+    feconvolvematrix: 'feConvolveMatrix',
+    fediffuselighting: 'feDiffuseLighting',
+    fedisplacementmap: 'feDisplacementMap',
+    fedistantlight: 'feDistantLight',
+    fedropshadow: 'feDropShadow',
+    feflood: 'feFlood',
+    fefunca: 'feFuncA',
+    fefuncb: 'feFuncB',
+    fefuncg: 'feFuncG',
+    fefuncr: 'feFuncR',
+    fegaussianblur: 'feGaussianBlur',
+    feimage: 'feImage',
+    femerge: 'feMerge',
+    femergenode: 'feMergeNode',
+    femorphology: 'feMorphology',
+    feoffset: 'feOffset',
+    fepointlight: 'fePointLight',
+    fespecularlighting: 'feSpecularLighting',
+    fespotlight: 'feSpotLight',
+    fetile: 'feTile',
+    feturbulence: 'feTurbulence',
+    foreignobject: 'foreignObject',
+    lineargradient: 'linearGradient',
+    radialgradient: 'radialGradient',
+    textpath: 'textPath'
+}
+
+/**
+ * Resolves an SVG tag name to its case-sensitive spec spelling.
+ *
+ * Non-SVG tags and already-correct names are returned unchanged.
+ *
+ * @param {string} tag The tag name to canonicalize.
+ * @returns {string} The spec-cased SVG tag name.
+ * @example
+ * resolveSVGTagName('fedisplacementmap') // 'feDisplacementMap'
+ * resolveSVGTagName('circle') // 'circle'
+ * resolveSVGTagName('div') // 'div'
+ */
+export const resolveSVGTagName = (tag: string): string => {
+    return SVG_TAG_CASING[tag.toLowerCase()] ?? tag
+}
+
+/**
  * Check if an element is an SVG path element.
  */
 /**

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -573,6 +573,14 @@
                         SVG Namespace Test
                     </a>
                 </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/svg/motion-value-attributes') + searchParams}
+                    >
+                        SVG MotionValue Attributes
+                    </a>
+                </li>
             </ul>
         </div>
         <div>

--- a/src/routes/tests/svg/motion-value-attributes/+page.svelte
+++ b/src/routes/tests/svg/motion-value-attributes/+page.svelte
@@ -29,6 +29,13 @@
      */
     const attrScale = motionValue(12)
 
+    /**
+     * Attribute-routed camelCase filter key. `stdDeviation` is claimed via
+     * motion-dom's `camelCaseAttributes`, not our hand-written allowlist — an
+     * unclaimed key would render `stdDeviation="[object Object]"`.
+     */
+    const blurStdDeviation = motionValue(2)
+
     // Buttons (used by e2e) and sliders both drive the same MotionValues.
     const bumpCx = () => cx.set(Math.min(280, cx.get() + 20))
     const bumpStrokeWidth = () => strokeWidth.set(Math.min(20, strokeWidth.get() + 3))
@@ -42,6 +49,7 @@
         attrX.set(10)
         attrY.set(10)
         attrScale.set(12)
+        blurStdDeviation.set(2)
     }
 
     /** Toggle: unmount/remount the whole SVG to exercise subscription teardown. */
@@ -75,6 +83,12 @@
             testid: 'displacement-map',
             label: 'feDisplacementMap (attrScale)',
             prop: 'scale',
+            channel: 'attribute'
+        },
+        {
+            testid: 'blur-filter',
+            label: 'feGaussianBlur',
+            prop: 'stdDeviation',
             channel: 'attribute'
         }
     ]
@@ -236,6 +250,20 @@
                 />
             </label>
 
+            <label class="block text-sm">
+                <span class="mb-1 block">stdDeviation → feGaussianBlur</span>
+                <input
+                    data-testid="slider-blur"
+                    type="range"
+                    min="0"
+                    max="10"
+                    step="1"
+                    value="2"
+                    class="w-full"
+                    oninput={(e) => blurStdDeviation.set(Number(e.currentTarget.value))}
+                />
+            </label>
+
             <div class="grid grid-cols-2 gap-2 pt-2">
                 <button
                     data-testid="bump-cx"
@@ -294,7 +322,7 @@
                         width="300"
                         height="120"
                         viewBox="0 0 300 120"
-                        class="rounded bg-slate-800 {highlight ? 'ring-2 ring-yellow-400' : ''}"
+                        class="rounded bg-slate-800"
                     >
                         <motion.circle data-testid="mv-circle" {cx} cy={45} r={12} fill="#60a5fa" />
                         <motion.circle
@@ -371,11 +399,19 @@
                         <strong class="text-amber-300">deliberately ignores</strong> — watch it track
                         in the table while the box never resizes.
                     </p>
+                    <!--
+                      The highlight toggle must re-render the element under test.
+                      `data-highlight` marks the subtree for the e2e assertion, and the
+                      `class` prop on the motion element is what actually re-evaluates
+                      its attribute spread — a class change on an ancestor alone would
+                      leave `attr-rect`'s props untouched, and the clobber test vacuous.
+                    -->
                     <svg
                         width="300"
                         height="120"
                         viewBox="0 0 300 120"
-                        class="rounded bg-slate-800"
+                        data-highlight={highlight}
+                        class="rounded bg-slate-800 {highlight ? 'ring-2 ring-yellow-400' : ''}"
                     >
                         <motion.rect
                             data-testid="attr-rect"
@@ -385,6 +421,7 @@
                             width={40}
                             height={40}
                             fill="#a78bfa"
+                            class={highlight ? 'opacity-80' : ''}
                         />
                     </svg>
                 </div>
@@ -434,6 +471,44 @@
                             rx="8"
                             fill="#38bdf8"
                             filter="url(#warp)"
+                        />
+                    </svg>
+                </div>
+
+                <div>
+                    <h3 class="mb-1 text-sm font-medium text-slate-300">
+                        Attribute-routed: stdDeviation (feGaussianBlur)
+                    </h3>
+                    <p class="mb-2 max-w-md text-xs text-slate-400">
+                        <code class="rounded bg-slate-800 px-1">stdDeviation</code> is claimed via
+                        motion-dom's
+                        <code class="rounded bg-slate-800 px-1">camelCaseAttributes</code>, not a
+                        hand-written list. Before that, it fell through to the raw spread and
+                        rendered
+                        <code class="rounded bg-slate-800 px-1">[object Object]</code>. Drag the
+                        slider to 0 for a sharp edge.
+                    </p>
+                    <svg
+                        width="300"
+                        height="120"
+                        viewBox="0 0 300 120"
+                        class="rounded bg-slate-800"
+                    >
+                        <filter id="soften" x="-20%" y="-20%" width="140%" height="140%">
+                            <motion.fegaussianblur
+                                data-testid="blur-filter"
+                                in="SourceGraphic"
+                                stdDeviation={blurStdDeviation}
+                            />
+                        </filter>
+                        <rect
+                            x="40"
+                            y="25"
+                            width="220"
+                            height="70"
+                            rx="8"
+                            fill="#4ade80"
+                            filter="url(#soften)"
                         />
                     </svg>
                 </div>

--- a/src/routes/tests/svg/motion-value-attributes/+page.svelte
+++ b/src/routes/tests/svg/motion-value-attributes/+page.svelte
@@ -66,6 +66,12 @@
         { testid: 'attr-rect', label: 'rect (attrX)', prop: 'x', channel: 'attribute' },
         { testid: 'attr-rect', label: 'rect (attrY)', prop: 'y', channel: 'attribute' },
         {
+            testid: 'attr-rect',
+            label: 'rect (attrScale) — inert',
+            prop: 'scale',
+            channel: 'attribute'
+        },
+        {
             testid: 'displacement-map',
             label: 'feDisplacementMap (attrScale)',
             prop: 'scale',
@@ -355,8 +361,16 @@
 
                 <div>
                     <h3 class="mb-1 text-sm font-medium text-slate-300">
-                        Attribute-routed: attrX / attrY (the rect's x / y attributes)
+                        Attribute-routed: attrX / attrY / attrScale
                     </h3>
+                    <p class="mb-2 max-w-md text-xs text-slate-400">
+                        <code class="rounded bg-slate-800 px-1">attrX</code> and
+                        <code class="rounded bg-slate-800 px-1">attrY</code> move the rect.
+                        <code class="rounded bg-slate-800 px-1">attrScale</code> writes a
+                        <code class="rounded bg-slate-800 px-1">scale</code> attribute that the rect
+                        <strong class="text-amber-300">deliberately ignores</strong> — watch it track
+                        in the table while the box never resizes.
+                    </p>
                     <svg
                         width="300"
                         height="120"
@@ -367,6 +381,7 @@
                             data-testid="attr-rect"
                             {attrX}
                             {attrY}
+                            {attrScale}
                             width={40}
                             height={40}
                             fill="#a78bfa"

--- a/src/routes/tests/svg/motion-value-attributes/+page.svelte
+++ b/src/routes/tests/svg/motion-value-attributes/+page.svelte
@@ -1,0 +1,417 @@
+<script lang="ts">
+    import { motion, motionValue } from '$lib'
+
+    /**
+     * Style-routed: `cx` is a CSS property in Chromium, so `svgEffect` writes it to
+     * `element.style`. The same MotionValue also drives `x2` on the chart line,
+     * which is attribute-routed — one value, both channels.
+     */
+    const cx = motionValue(40)
+
+    /** Style-routed, kebab-cased — the spelling a Svelte author actually writes. */
+    const strokeWidth = motionValue(4)
+
+    /** Style-routed. The ring sweeps by shrinking its dash offset. */
+    const RING_CIRCUMFERENCE = 2 * Math.PI * 30
+    const dashOffset = motionValue(RING_CIRCUMFERENCE * 0.35)
+
+    /** Attribute-routed: rendered as the `x` / `y` / `scale` attributes. */
+    const attrX = motionValue(10)
+    const attrY = motionValue(10)
+    const attrScale = motionValue(1)
+
+    // Buttons (used by e2e) and sliders both drive the same MotionValues.
+    const bumpCx = () => cx.set(Math.min(280, cx.get() + 20))
+    const bumpStrokeWidth = () => strokeWidth.set(Math.min(20, strokeWidth.get() + 3))
+    const advanceProgress = () => dashOffset.set(Math.max(0, dashOffset.get() - 40))
+    const bumpAttrX = () => attrX.set(Math.min(240, attrX.get() + 15))
+
+    const reset = () => {
+        cx.set(40)
+        strokeWidth.set(4)
+        dashOffset.set(RING_CIRCUMFERENCE * 0.35)
+        attrX.set(10)
+        attrY.set(10)
+        attrScale.set(1)
+    }
+
+    /** Toggle: unmount/remount the whole SVG to exercise subscription teardown. */
+    let mounted = $state(true)
+
+    /**
+     * Toggle: force an unrelated Svelte re-render (a class change). The attribute
+     * spread must not clobber a value that `svgEffect` owns.
+     */
+    let highlight = $state(false)
+
+    /** Live readout of both DOM channels, sampled every frame. */
+    type Row = { label: string; prop: string; channel: string; attr: string; style: string }
+    let rows = $state<Row[]>([])
+
+    const WATCHED: { testid: string; label: string; prop: string; channel: string }[] = [
+        { testid: 'mv-circle', label: 'circle (bound)', prop: 'cx', channel: 'style' },
+        { testid: 'static-circle', label: 'circle (plain 5)', prop: 'cx', channel: 'style' },
+        { testid: 'kebab-circle', label: 'circle', prop: 'stroke-width', channel: 'style' },
+        { testid: 'progress-ring', label: 'ring', prop: 'stroke-dashoffset', channel: 'style' },
+        { testid: 'chart-line', label: 'line', prop: 'x2', channel: 'attribute' },
+        { testid: 'attr-rect', label: 'rect (attrX)', prop: 'x', channel: 'attribute' },
+        { testid: 'attr-rect', label: 'rect (attrY)', prop: 'y', channel: 'attribute' },
+        { testid: 'attr-rect', label: 'rect (attrScale)', prop: 'scale', channel: 'attribute' }
+    ]
+
+    $effect(() => {
+        let raf = 0
+        const tick = () => {
+            rows = WATCHED.map(({ testid, label, prop, channel }) => {
+                const el = document.querySelector(`[data-testid="${testid}"]`)
+                return {
+                    label,
+                    prop,
+                    channel,
+                    attr: el?.getAttribute(prop) ?? '—',
+                    style: el ? getComputedStyle(el).getPropertyValue(prop) || '—' : '—'
+                }
+            })
+            raf = requestAnimationFrame(tick)
+        }
+        tick()
+        return () => cancelAnimationFrame(raf)
+    })
+
+    const hasObjectObject = $derived(rows.some((r) => r.attr.includes('[object Object]')))
+</script>
+
+<svelte:head>
+    <title>SVG MotionValue attributes</title>
+</svelte:head>
+
+<main class="min-h-screen bg-slate-950 p-8 text-slate-100">
+    <h1 class="mb-2 text-2xl font-semibold">SVG MotionValue attributes</h1>
+
+    <div class="mb-6 max-w-3xl space-y-3 text-sm leading-relaxed text-slate-300">
+        <p>
+            <strong class="text-slate-100">What this page tests.</strong> Binding a
+            <code class="rounded bg-slate-800 px-1">MotionValue</code> straight to an SVG
+            presentation attribute — <code class="rounded bg-slate-800 px-1">cx</code>,
+            <code class="rounded bg-slate-800 px-1">stroke-width</code>,
+            <code class="rounded bg-slate-800 px-1">attrX</code> — instead of animating it. Before
+            this feature the value was spread raw onto the element and rendered as the literal
+            string <code class="rounded bg-slate-800 px-1">[object Object]</code>.
+        </p>
+        <p>
+            <strong class="text-slate-100">The subtlety.</strong>
+            <code class="rounded bg-slate-800 px-1">svgEffect</code> writes to
+            <em>two different DOM channels</em>. Keys that are CSS properties in the browser (<code
+                class="rounded bg-slate-800 px-1">cx</code
+            >,
+            <code class="rounded bg-slate-800 px-1">r</code>,
+            <code class="rounded bg-slate-800 px-1">stroke-*</code>) go to
+            <code class="rounded bg-slate-800 px-1">element.style</code> — their
+            <em>attribute</em> never changes. Everything else (<code
+                class="rounded bg-slate-800 px-1">x2</code
+            >,
+            <code class="rounded bg-slate-800 px-1">attrX</code>) goes to
+            <code class="rounded bg-slate-800 px-1">setAttribute</code>. The table shows both, so
+            you can see which channel each key actually moves.
+        </p>
+    </div>
+
+    <!-- Verdict banner -->
+    <div
+        data-testid="verdict"
+        class="mb-6 inline-block rounded px-3 py-2 text-sm font-medium {hasObjectObject
+            ? 'bg-red-900 text-red-100'
+            : 'bg-emerald-900 text-emerald-100'}"
+    >
+        {hasObjectObject
+            ? '✗ FAIL — [object Object] found in the DOM'
+            : '✓ PASS — no [object Object] in any watched attribute'}
+    </div>
+
+    <div class="flex flex-wrap gap-8">
+        <!-- Controls -->
+        <section class="w-80 shrink-0 space-y-4 rounded-lg bg-slate-900 p-4">
+            <h2 class="text-lg font-medium">Controls</h2>
+
+            <label class="block text-sm">
+                <span class="mb-1 flex justify-between">
+                    <span>cx (and line x2)</span>
+                    <span class="font-mono text-slate-400">{rows[0]?.style ?? ''}</span>
+                </span>
+                <input
+                    data-testid="slider-cx"
+                    type="range"
+                    min="10"
+                    max="280"
+                    value="40"
+                    class="w-full"
+                    oninput={(e) => cx.set(Number(e.currentTarget.value))}
+                />
+            </label>
+
+            <label class="block text-sm">
+                <span class="mb-1 block">stroke-width (kebab-case prop)</span>
+                <input
+                    data-testid="slider-stroke-width"
+                    type="range"
+                    min="1"
+                    max="20"
+                    value="4"
+                    class="w-full"
+                    oninput={(e) => strokeWidth.set(Number(e.currentTarget.value))}
+                />
+            </label>
+
+            <label class="block text-sm">
+                <span class="mb-1 block">progress (stroke-dashoffset)</span>
+                <input
+                    data-testid="slider-progress"
+                    type="range"
+                    min="0"
+                    max={RING_CIRCUMFERENCE}
+                    value={RING_CIRCUMFERENCE * 0.35}
+                    step="0.1"
+                    class="w-full"
+                    oninput={(e) => dashOffset.set(Number(e.currentTarget.value))}
+                />
+            </label>
+
+            <label class="block text-sm">
+                <span class="mb-1 block">attrX → x attribute</span>
+                <input
+                    data-testid="slider-attr-x"
+                    type="range"
+                    min="0"
+                    max="240"
+                    value="10"
+                    class="w-full"
+                    oninput={(e) => attrX.set(Number(e.currentTarget.value))}
+                />
+            </label>
+
+            <label class="block text-sm">
+                <span class="mb-1 block">attrY → y attribute</span>
+                <input
+                    data-testid="slider-attr-y"
+                    type="range"
+                    min="0"
+                    max="70"
+                    value="10"
+                    class="w-full"
+                    oninput={(e) => attrY.set(Number(e.currentTarget.value))}
+                />
+            </label>
+
+            <label class="block text-sm">
+                <span class="mb-1 block">attrScale → scale attribute</span>
+                <input
+                    data-testid="slider-attr-scale"
+                    type="range"
+                    min="0.5"
+                    max="3"
+                    step="0.1"
+                    value="1"
+                    class="w-full"
+                    oninput={(e) => attrScale.set(Number(e.currentTarget.value))}
+                />
+            </label>
+
+            <div class="grid grid-cols-2 gap-2 pt-2">
+                <button
+                    data-testid="bump-cx"
+                    class="rounded bg-blue-600 px-2 py-1 text-sm hover:bg-blue-500"
+                    onclick={bumpCx}>Bump cx</button
+                >
+                <button
+                    data-testid="bump-stroke-width"
+                    class="rounded bg-pink-600 px-2 py-1 text-sm hover:bg-pink-500"
+                    onclick={bumpStrokeWidth}>Bump stroke-width</button
+                >
+                <button
+                    data-testid="advance-progress"
+                    class="rounded bg-amber-600 px-2 py-1 text-sm hover:bg-amber-500"
+                    onclick={advanceProgress}>Advance progress</button
+                >
+                <button
+                    data-testid="bump-attr-x"
+                    class="rounded bg-violet-600 px-2 py-1 text-sm hover:bg-violet-500"
+                    onclick={bumpAttrX}>Bump attrX</button
+                >
+                <button
+                    data-testid="reset"
+                    class="col-span-2 rounded bg-slate-700 px-2 py-1 text-sm hover:bg-slate-600"
+                    onclick={reset}>Reset all</button
+                >
+            </div>
+
+            <div class="space-y-2 border-t border-slate-700 pt-3 text-sm">
+                <label class="flex items-center gap-2">
+                    <input data-testid="toggle-mounted" type="checkbox" bind:checked={mounted} />
+                    <span>Mounted <span class="text-slate-400">(tests teardown)</span></span>
+                </label>
+                <label class="flex items-center gap-2">
+                    <input
+                        data-testid="toggle-highlight"
+                        type="checkbox"
+                        bind:checked={highlight}
+                    />
+                    <span>
+                        Force re-render
+                        <span class="text-slate-400">(class change must not clobber attrs)</span>
+                    </span>
+                </label>
+            </div>
+        </section>
+
+        <!-- Live figures -->
+        <section class="space-y-6">
+            {#if mounted}
+                <div>
+                    <h3 class="mb-1 text-sm font-medium text-slate-300">
+                        Style-routed: cx, stroke-width &nbsp;·&nbsp; Attribute-routed: x2
+                    </h3>
+                    <svg
+                        width="300"
+                        height="120"
+                        viewBox="0 0 300 120"
+                        class="rounded bg-slate-800 {highlight ? 'ring-2 ring-yellow-400' : ''}"
+                    >
+                        <motion.circle data-testid="mv-circle" {cx} cy={45} r={12} fill="#60a5fa" />
+                        <motion.circle
+                            data-testid="kebab-circle"
+                            cx={250}
+                            cy={45}
+                            r={20}
+                            fill="none"
+                            stroke="#f472b6"
+                            stroke-width={strokeWidth}
+                        />
+                        <motion.line
+                            data-testid="chart-line"
+                            x1={10}
+                            y1={95}
+                            x2={cx}
+                            y2={95}
+                            stroke="#34d399"
+                            stroke-width="3"
+                        />
+                        <motion.circle
+                            data-testid="static-circle"
+                            cx={5}
+                            cy={112}
+                            r={3}
+                            fill="#94a3b8"
+                        />
+                    </svg>
+                </div>
+
+                <div>
+                    <h3 class="mb-1 text-sm font-medium text-slate-300">
+                        Progress ring: stroke-dashoffset (style-routed)
+                    </h3>
+                    <svg
+                        width="140"
+                        height="140"
+                        viewBox="0 0 120 120"
+                        class="rounded bg-slate-800"
+                    >
+                        <circle
+                            cx="60"
+                            cy="60"
+                            r="30"
+                            fill="none"
+                            stroke="#334155"
+                            stroke-width="8"
+                        />
+                        <motion.circle
+                            data-testid="progress-ring"
+                            cx={60}
+                            cy={60}
+                            r={30}
+                            fill="none"
+                            stroke="#fbbf24"
+                            stroke-width="8"
+                            stroke-linecap="round"
+                            stroke-dasharray={RING_CIRCUMFERENCE}
+                            stroke-dashoffset={dashOffset}
+                            transform="rotate(-90 60 60)"
+                        />
+                    </svg>
+                </div>
+
+                <div>
+                    <h3 class="mb-1 text-sm font-medium text-slate-300">
+                        Attribute-routed: attrX / attrY / attrScale
+                    </h3>
+                    <svg
+                        width="300"
+                        height="120"
+                        viewBox="0 0 300 120"
+                        class="rounded bg-slate-800"
+                    >
+                        <motion.rect
+                            data-testid="attr-rect"
+                            {attrX}
+                            {attrY}
+                            {attrScale}
+                            width={40}
+                            height={40}
+                            fill="#a78bfa"
+                        />
+                    </svg>
+                </div>
+            {:else}
+                <p class="rounded bg-slate-900 p-8 text-sm text-slate-400">
+                    Unmounted. Re-check the box to remount — values should reattach without
+                    <code>[object Object]</code> and without a flash.
+                </p>
+            {/if}
+        </section>
+
+        <!-- Metrics -->
+        <section class="min-w-[26rem] flex-1">
+            <h2 class="mb-2 text-lg font-medium">Live DOM channels</h2>
+            <p class="mb-3 text-xs text-slate-400">
+                Sampled every animation frame. A style-routed key moves in the
+                <strong>computed style</strong> column while its attribute stays frozen at the server-rendered
+                seed — that is correct, not a bug.
+            </p>
+            <table class="w-full border-collapse text-left font-mono text-xs">
+                <thead>
+                    <tr class="border-b border-slate-700 text-slate-400">
+                        <th class="py-2 pr-3 font-medium">element</th>
+                        <th class="py-2 pr-3 font-medium">prop</th>
+                        <th class="py-2 pr-3 font-medium">channel</th>
+                        <th class="py-2 pr-3 font-medium">getAttribute()</th>
+                        <th class="py-2 font-medium">computed style</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {#each rows as row (row.label + row.prop)}
+                        <tr class="border-b border-slate-800/60">
+                            <td class="py-1.5 pr-3 text-slate-300">{row.label}</td>
+                            <td class="py-1.5 pr-3 text-slate-100">{row.prop}</td>
+                            <td class="py-1.5 pr-3">
+                                <span
+                                    class={row.channel === 'style'
+                                        ? 'text-sky-400'
+                                        : 'text-violet-400'}
+                                >
+                                    {row.channel}
+                                </span>
+                            </td>
+                            <td
+                                class="py-1.5 pr-3 {row.attr.includes('[object Object]')
+                                    ? 'bg-red-900 text-red-100'
+                                    : 'text-slate-300'}"
+                            >
+                                {row.attr}
+                            </td>
+                            <td class="py-1.5 text-emerald-300">{row.style}</td>
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        </section>
+    </div>
+</main>

--- a/src/routes/tests/svg/motion-value-attributes/+page.svelte
+++ b/src/routes/tests/svg/motion-value-attributes/+page.svelte
@@ -15,10 +15,19 @@
     const RING_CIRCUMFERENCE = 2 * Math.PI * 30
     const dashOffset = motionValue(RING_CIRCUMFERENCE * 0.35)
 
-    /** Attribute-routed: rendered as the `x` / `y` / `scale` attributes. */
+    /** Attribute-routed: rendered as the `x` / `y` attributes on the rect. */
     const attrX = motionValue(10)
     const attrY = motionValue(10)
-    const attrScale = motionValue(1)
+
+    /**
+     * Attribute-routed. `scale` is not a presentation attribute on shape elements —
+     * writing it to a rect is inert, which is upstream's behavior too. It is a real
+     * attribute on `<feDisplacementMap>`, where it drives the warp below.
+     *
+     * `attrScale` exists because a plain `scale` prop would collide with the CSS
+     * transform property and be style-routed.
+     */
+    const attrScale = motionValue(12)
 
     // Buttons (used by e2e) and sliders both drive the same MotionValues.
     const bumpCx = () => cx.set(Math.min(280, cx.get() + 20))
@@ -32,7 +41,7 @@
         dashOffset.set(RING_CIRCUMFERENCE * 0.35)
         attrX.set(10)
         attrY.set(10)
-        attrScale.set(1)
+        attrScale.set(12)
     }
 
     /** Toggle: unmount/remount the whole SVG to exercise subscription teardown. */
@@ -56,7 +65,12 @@
         { testid: 'chart-line', label: 'line', prop: 'x2', channel: 'attribute' },
         { testid: 'attr-rect', label: 'rect (attrX)', prop: 'x', channel: 'attribute' },
         { testid: 'attr-rect', label: 'rect (attrY)', prop: 'y', channel: 'attribute' },
-        { testid: 'attr-rect', label: 'rect (attrScale)', prop: 'scale', channel: 'attribute' }
+        {
+            testid: 'displacement-map',
+            label: 'feDisplacementMap (attrScale)',
+            prop: 'scale',
+            channel: 'attribute'
+        }
     ]
 
     $effect(() => {
@@ -203,14 +217,14 @@
             </label>
 
             <label class="block text-sm">
-                <span class="mb-1 block">attrScale → scale attribute</span>
+                <span class="mb-1 block">attrScale → feDisplacementMap warp</span>
                 <input
                     data-testid="slider-attr-scale"
                     type="range"
-                    min="0.5"
-                    max="3"
-                    step="0.1"
-                    value="1"
+                    min="0"
+                    max="40"
+                    step="1"
+                    value="12"
                     class="w-full"
                     oninput={(e) => attrScale.set(Number(e.currentTarget.value))}
                 />
@@ -341,7 +355,7 @@
 
                 <div>
                     <h3 class="mb-1 text-sm font-medium text-slate-300">
-                        Attribute-routed: attrX / attrY / attrScale
+                        Attribute-routed: attrX / attrY (the rect's x / y attributes)
                     </h3>
                     <svg
                         width="300"
@@ -353,10 +367,58 @@
                             data-testid="attr-rect"
                             {attrX}
                             {attrY}
-                            {attrScale}
                             width={40}
                             height={40}
                             fill="#a78bfa"
+                        />
+                    </svg>
+                </div>
+
+                <div>
+                    <h3 class="mb-1 text-sm font-medium text-slate-300">
+                        Attribute-routed: attrScale (feDisplacementMap's scale)
+                    </h3>
+                    <p class="mb-2 max-w-md text-xs text-slate-400">
+                        <code class="rounded bg-slate-800 px-1">scale</code> is inert on a
+                        <code class="rounded bg-slate-800 px-1">&lt;rect&gt;</code> — it is not a
+                        presentation attribute there. On
+                        <code class="rounded bg-slate-800 px-1">&lt;feDisplacementMap&gt;</code> it
+                        is real, and drives this warp. A plain
+                        <code class="rounded bg-slate-800 px-1">scale</code> prop would be routed to
+                        the CSS transform instead, so
+                        <code class="rounded bg-slate-800 px-1">attrScale</code> is the only way to reach
+                        it. Drag the slider to 0 to flatten the warp.
+                    </p>
+                    <svg
+                        width="300"
+                        height="120"
+                        viewBox="0 0 300 120"
+                        class="rounded bg-slate-800"
+                    >
+                        <filter id="warp" x="-20%" y="-20%" width="140%" height="140%">
+                            <feTurbulence
+                                type="turbulence"
+                                baseFrequency="0.04"
+                                numOctaves="2"
+                                result="noise"
+                            />
+                            <motion.fedisplacementmap
+                                data-testid="displacement-map"
+                                in="SourceGraphic"
+                                in2="noise"
+                                {attrScale}
+                                xChannelSelector="R"
+                                yChannelSelector="G"
+                            />
+                        </filter>
+                        <rect
+                            x="40"
+                            y="25"
+                            width="220"
+                            height="70"
+                            rx="8"
+                            fill="#38bdf8"
+                            filter="url(#warp)"
                         />
                     </svg>
                 </div>


### PR DESCRIPTION
## Summary

A `MotionValue` bound to any non-path SVG attribute was spread raw onto the element and stringified as `[object Object]`; `attrX`/`attrY`/`attrScale` did not exist at all. This binds MotionValues to SVG presentation attributes through motion-dom's `svgEffect`, adds the `attr*` family, and fixes SSR so the resolved value is in the server payload rather than flashing on hydration.

Along the way it fixes a latent bug: SVG tag names are **case-sensitive**, but our generated components hardcode a lowercase tag (`tag="fedisplacementmap"`). `createElementNS(NS, 'fedisplacementmap')` returns an inert generic `SVGElement`, so every filter primitive — `feDisplacementMap`, `feTurbulence`, `feGaussianBlur` — was silently ignored when created client-side.

Two details worth a reviewer's attention:

- **Motion writes a bound key to one of two channels**, chosen at runtime by `key in element.style`. `cx`, `cy`, `r`, `x`, `y`, `width`, `height`, `d` and the `stroke-*` family are CSS properties in Chromium, so they go to `element.style` and the DOM **attribute never changes**. Only `points`, `viewBox`, `x1..y2` and `attrX/attrY/attrScale` reach `setAttribute`. The docs page teaches this explicitly, including the devtools trap.
- **The attribute allowlist carries kebab-case DOM spellings**, not just upstream's React-facing camelCase. Svelte templates take the DOM spelling, so `<motion.circle stroke-width={mv}>` is the common form; a camelCase-only list would have let it render `[object Object]`.

SSR casing mirrors upstream's own mechanism verbatim — `camelCaseAttributes` and `camelToDash` are **imported from `motion-dom`**, not vendored, so upstream additions track on version bumps. The gate runs *after* `attr`-prefix resolution, so `attrX` emits `x` and never `attr-x`.

## Changes

- ✨ Bind MotionValues to SVG presentation attributes via `svgEffect`; strip them from the raw spread so they can never stringify
- ✨ Add `attrX` / `attrY` / `attrScale`, rendered as the `x` / `y` / `scale` **attributes** (distinct from the CSS transform)
- ✨ SSR emits resolved values under their DOM attribute names (`strokeDashoffset` → `stroke-dashoffset`, `viewBox` preserved), so hydration doesn't flash
- 🐛 Render camelCase SVG tags with their spec spelling — `feDisplacementMap`, `clipPath`, `linearGradient`, `foreignObject`, `animateTransform` and 27 more
- 🧪 Unit coverage for classification, `resolveSVGAttrKey`, extraction, and the SSR casing gate; e2e asserts the *bound channel* per key, and the tag-casing test asserts after a client-side remount (verified to fail with the fix reverted)
- 📚 New `docs/svg-animation` page + example, nav entry under Animation

## Commits

- [`0bdaa19`](https://github.com/humanspeak/svelte-motion/commit/0bdaa1937f20548b44be2e6c245af344cd194687) docs(plans): guard log for 002 red-test checkpoint
- [`af90f5a`](https://github.com/humanspeak/svelte-motion/commit/af90f5ab91f89faf75f4bec9c69ab7d583243dbe) test(svg): add red tests for MotionValue-driven SVG attributes
- [`74099d7`](https://github.com/humanspeak/svelte-motion/commit/74099d74481d89f50b8fc29eca4361dd4525ef66) docs(plans): amend 002 for svgEffect's two DOM channels
- [`0fb622b`](https://github.com/humanspeak/svelte-motion/commit/0fb622b6f0f22b2b889268e88c84ea4375a40849) docs(plans): preserve the SVG channel probe behind 002's amendment
- [`5c307fe`](https://github.com/humanspeak/svelte-motion/commit/5c307fe34ae25c307ba2741a6c12fc07e6bba9ae) docs(plans): adopt upstream casing ruling v2 for 002 SSR attributes
- [`b932936`](https://github.com/humanspeak/svelte-motion/commit/b9329362a1a2606135cce09157de24d7ae98b5a1) test(svg): assert the bound channel, add casing and kebab coverage
- [`a178841`](https://github.com/humanspeak/svelte-motion/commit/a178841aabc19b0ef1d1171434f97aa0484817b5) docs(plans): guard log for 002 casing-ruling checkpoint
- [`3f44dd9`](https://github.com/humanspeak/svelte-motion/commit/3f44dd95a831c47e082f5a222a9a1d6e981da573) test(svg): pin SSR casing-gate ordering and upstream allowlist sourcing
- [`bdb9a13`](https://github.com/humanspeak/svelte-motion/commit/bdb9a13a8444ad03929ae38ecac86e6b9781f85a) feat(svg): bind MotionValues to SVG presentation attributes
- [`9557778`](https://github.com/humanspeak/svelte-motion/commit/9557778f457f6931c57f29b9c81b993fb4b8ca2b) fix(svg): render camelCase SVG tags with their spec spelling
- [`03db3e3`](https://github.com/humanspeak/svelte-motion/commit/03db3e36c5322ff33aeee08af19d0deac77df5f2) docs(plans): amend 002 for tag-casing scope addition; log checkpoint
- [`7765a24`](https://github.com/humanspeak/svelte-motion/commit/7765a24a75bc4d648533d42788c25071b572adc5) test(svg): make tag-casing e2e non-vacuous; assert attrScale is inert on shapes
- [`8f51399`](https://github.com/humanspeak/svelte-motion/commit/8f51399369b785ed68b74507a3bdb5ce62ff78da) docs(svg): add SVG Animation docs page, example, and nav entry
- [`54b7620`](https://github.com/humanspeak/svelte-motion/commit/54b7620343e763ea8d74c4db6af26881ced2aa9e) docs(svg-animation): fix demo typography under prose-v2 cascade

Closes #435
