### PR TITLE
fix(docs): render SEO components after children so SSR sees seo state

### DIFF
--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -1,35 +1,12 @@
 <script lang="ts">
     import '../app.css'
-    import { ModeWatcher } from 'mode-watcher'
-    import { MotionConfig } from '@humanspeak/svelte-motion'
-    import {
-        BreadcrumbContextProvider,
-        BreadcrumbJsonLd,
-        SeoContextProvider,
-        SeoH1,
-        SeoHead,
-        type SeoContext
-    } from '@humanspeak/docs-kit'
+    import { RootLayout } from '@humanspeak/docs-kit'
     import { docsConfig } from '$lib/docs-config'
     import favicon from '$lib/assets/logo.svg'
-    const { children } = $props()
 
-    const seo = $state<SeoContext>({})
+    const { children } = $props()
 </script>
 
-<ModeWatcher />
-<SeoContextProvider {seo}>
-    <SeoHead {seo} config={docsConfig} {favicon} />
-    <BreadcrumbContextProvider>
-        <BreadcrumbJsonLd config={docsConfig} />
-        <MotionConfig transition={{ duration: 0.5 }}>
-            <!-- Renders a single per-page <h1> from the SEO context. Pages
-                 whose visible chrome already carries an <h1> leave seo.h1
-                 unset (nothing renders); pages built only from <ExampleV2>
-                 sections set seo.h1 so screen readers and crawlers still get
-                 a top-level heading. -->
-            <SeoH1 {seo} />
-            {@render children?.()}
-        </MotionConfig>
-    </BreadcrumbContextProvider>
-</SeoContextProvider>
+<RootLayout config={docsConfig} {favicon}>
+    {@render children?.()}
+</RootLayout>

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -26,7 +26,7 @@
     if (seo) {
         seo.title = 'Svelte Motion · Framer Motion-compatible animation library for Svelte 5'
         seo.description =
-            'Svelte Motion is a Framer Motion-compatible animation library for Svelte 5. Declarative motion.<tag> components, AnimatePresence exit animations, gestures (hover/tap/drag/focus/in-view), variants, FLIP layout, shared-layout, spring physics, and scroll-linked motion values.'
+            'Framer Motion-compatible animation library for Svelte 5 — motion components, AnimatePresence, gestures, variants, layout, springs, and scroll.'
         seo.ogTitle = 'Svelte Motion'
         seo.ogTagline =
             'Framer Motion for Svelte 5 — declarative motion components, gestures, variants, layout, spring, and scroll-linked values.'
@@ -372,11 +372,7 @@
 </script>
 
 <svelte:head>
-    <title>Svelte Motion · Framer Motion-compatible animation library for Svelte 5</title>
-    <meta
-        name="description"
-        content="Svelte Motion is a Framer Motion-compatible animation library for Svelte 5. Declarative motion.<tag> components, AnimatePresence exit animations, gestures, variants, FLIP layout, shared-layout, spring physics, and scroll-linked motion values."
-    />
+    <!-- Title and meta description are emitted by SeoHead (see seo.title / seo.description above). -->
     <!-- eslint-disable-next-line svelte/no-at-html-tags -- static JSON-LD, no user input -->
     {@html softwareJsonLd}
 </svelte:head>

--- a/docs/src/routes/docs/animate-presence-custom/+page.svx
+++ b/docs/src/routes/docs/animate-presence-custom/+page.svx
@@ -11,7 +11,7 @@ description: 'Pass dynamic data from AnimatePresence into exiting variants.'
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'AnimatePresence custom | Docs | Svelte Motion'
-      seo.description = 'Forward dynamic data from AnimatePresence into exiting variants, matching Motion custom presence semantics.'
+      seo.description = 'Forward dynamic data from AnimatePresence into exiting variants in Svelte, matching Motion custom presence semantics for direction-aware exit animations.'
       seo.ogTitle = 'AnimatePresence custom'
       seo.ogTagline = 'Directional exits from parent presence data'
       seo.ogFeatures = ['AnimatePresence', 'custom', 'Dynamic Variants', 'Directional Exit']

--- a/docs/src/routes/docs/gestures/+page.svx
+++ b/docs/src/routes/docs/gestures/+page.svx
@@ -9,7 +9,7 @@ description: Pointer-driven animations on motion components via whileHover, whil
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'Gestures | Docs | Svelte Motion'
-      seo.description = 'whileHover, whileTap, whileFocus, and whileInView props on motion components — pointer-driven animations with gesture callbacks, true-hover gating, and IntersectionObserver-backed in-view detection.'
+      seo.description = 'whileHover, whileTap, whileFocus, and whileInView props for pointer-driven animations on Svelte motion components, with gesture callbacks and hover gating.'
       seo.ogTitle = 'Gestures'
       seo.ogTagline = 'Pointer-driven animations as motion-component props'
       seo.ogFeatures = ['Hover', 'Tap', 'Focus', 'In-view']

--- a/docs/src/routes/docs/layout-animations/+page.svx
+++ b/docs/src/routes/docs/layout-animations/+page.svx
@@ -11,7 +11,7 @@ description: Animate elements between positions with layout and layoutId for smo
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'Layout Animations | Docs | Svelte Motion'
-        seo.description = 'Animate elements between positions with layout and layoutId for smooth shared layout transitions in Svelte Motion.'
+        seo.description = 'Animate elements between positions with the layout and layoutId props for smooth shared-element layout transitions in Svelte Motion, powered by FLIP.'
         seo.ogTitle = 'Layout Animations'
         seo.ogTagline = 'Smooth transitions when elements change size or position'
         seo.ogFeatures = ['FLIP Animation', 'Shared Layout', 'layoutId', 'Position Tracking']

--- a/docs/src/routes/docs/layout-dependency/+page.svx
+++ b/docs/src/routes/docs/layout-dependency/+page.svx
@@ -11,7 +11,7 @@ description: 'Gate layout measurement so FLIP only recomputes when a dependency 
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'layoutDependency | Docs | Svelte Motion'
-      seo.description = 'Gate layout (FLIP) measurement so a frequently-rerendering element only re-measures when a dependency changes.'
+      seo.description = 'Gate layout (FLIP) measurement with layoutDependency so a frequently-rerendering element only re-measures when a specific dependency value changes in Svelte.'
       seo.ogTitle = 'layoutDependency'
       seo.ogTagline = 'Re-measure only when it matters'
       seo.ogFeatures = ['Layout Animations', 'FLIP', 'Performance', 'Motion Parity']

--- a/docs/src/routes/docs/lazy-motion/+page.svx
+++ b/docs/src/routes/docs/lazy-motion/+page.svx
@@ -9,7 +9,7 @@ description: Load only the motion feature bundle your page needs
     const seo = getSeoContext()
     if (seo) {
         seo.title = 'LazyMotion | Docs | Svelte Motion'
-        seo.description = 'Use LazyMotion with the m namespace and domMin, domAnimation, or domMax feature bundles.'
+        seo.description = 'Use LazyMotion with the m namespace to load only the motion feature bundle your page needs — pick domMin, domAnimation, or domMax to shrink your bundle.'
         seo.ogTitle = 'LazyMotion'
         seo.ogTagline = 'Load motion features on demand'
         seo.ogFeatures = ['m namespace', 'domMin', 'domAnimation', 'domMax']

--- a/docs/src/routes/docs/motion-value-children/+page.svx
+++ b/docs/src/routes/docs/motion-value-children/+page.svx
@@ -11,7 +11,7 @@ description: 'Render MotionValue<number | string> values as live text children.'
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'MotionValue children | Docs | Svelte Motion'
-      seo.description = 'Render MotionValue<number | string> values as live text children on motion elements.'
+      seo.description = 'Render a MotionValue<number | string> as live text children on a motion element, updating the DOM node directly without a Svelte re-render.'
       seo.ogTitle = 'MotionValue children'
       seo.ogTagline = 'Live text powered directly by MotionValue'
       seo.ogFeatures = ['MotionValue', 'Live Text', 'useTransform', 'Readouts']

--- a/docs/src/routes/docs/motion-values/+page.svx
+++ b/docs/src/routes/docs/motion-values/+page.svx
@@ -9,7 +9,7 @@ description: "An overview of motion values — reactive primitives that drive an
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'Motion values | Docs | Svelte Motion'
-      seo.description = 'An overview of motion values — reactive primitives that drive animations outside the render cycle. Reactive .current reads, velocity tracking, and composable chains.'
+      seo.description = 'Motion values are reactive primitives that drive Svelte animations outside the render cycle — with .current reads, velocity tracking, and composable chains.'
       seo.ogTitle = 'Motion Values'
       seo.ogTagline = 'Reactive values that drive animations outside the render cycle'
       seo.ogFeatures = ['Reactive Reads', 'Velocity Tracking', 'Composable', 'Render-Free']

--- a/docs/src/routes/docs/object-style-motion-values/+page.svx
+++ b/docs/src/routes/docs/object-style-motion-values/+page.svx
@@ -11,7 +11,7 @@ description: 'Pass MotionValues directly to object-form style props.'
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'Object style MotionValues | Docs | Svelte Motion'
-      seo.description = 'Pass MotionValues directly to object-form style props and let motion-dom update inline styles.'
+      seo.description = 'Pass MotionValues directly to object-form style props in Svelte and let motion-dom update inline styles imperatively, outside the render cycle.'
       seo.ogTitle = 'Object style MotionValues'
       seo.ogTagline = 'MotionValue interpolation directly inside style objects'
       seo.ogFeatures = ['MotionValue', 'Style Objects', 'Transforms', 'motion-dom']

--- a/docs/src/routes/docs/optimized-appear/+page.svx
+++ b/docs/src/routes/docs/optimized-appear/+page.svx
@@ -10,7 +10,7 @@ description: Start SSR appear animations before hydration
     if (seo) {
         seo.title = 'Optimized appear | Docs | Svelte Motion'
         seo.description =
-            'Start server-rendered entrance animations before Svelte hydrates the motion runtime.'
+            'Start server-rendered entrance animations before Svelte hydrates the motion runtime, handing off seamlessly to avoid a flash of unanimated content.'
         seo.ogTitle = 'Optimized appear'
         seo.ogTagline = 'SSR entrance animations without the flash'
         seo.ogFeatures = ['SSR', 'Hydration', 'WAAPI', 'Appear handoff']

--- a/docs/src/routes/docs/pan/+page.svx
+++ b/docs/src/routes/docs/pan/+page.svx
@@ -11,7 +11,7 @@ description: Pan gesture primitive — pointer offset/velocity reporting without
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'Pan | Docs | Svelte Motion'
-      seo.description = 'Pan is the gesture primitive that powers swipe-to-dismiss drawers, swipe-to-delete rows, and custom carousels. Lower-level than drag — pure offset and velocity reporting.'
+      seo.description = 'The pan gesture primitive reports pointer offset and velocity — build swipe-to-dismiss drawers, swipe-to-delete rows, and custom carousels in Svelte.'
       seo.ogTitle = 'Pan'
       seo.ogTagline = 'Pointer offset + velocity, no constraints'
       seo.ogFeatures = ['Pan', 'Gestures', 'Swipe', 'Velocity']

--- a/docs/src/routes/docs/scoped-motion-classes/+page.svx
+++ b/docs/src/routes/docs/scoped-motion-classes/+page.svx
@@ -11,7 +11,7 @@ description: Use @humanspeak/svelte-scoped-props when component-scoped CSS class
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'Scoped Motion Classes | Docs | Svelte Motion'
-      seo.description = 'Use @humanspeak/svelte-scoped-props when Svelte prunes scoped CSS selectors that are only passed to motion components.'
+      seo.description = 'Use @humanspeak/svelte-scoped-props when Svelte prunes component-scoped CSS selectors that are only ever passed as classes to your motion components.'
       seo.ogTitle = 'Scoped Motion Classes'
       seo.ogTagline = 'Keep parent-scoped CSS on motion components'
       seo.ogFeatures = ['scoped:class', 'motion.*', 'Svelte CSS', 'Companion Preprocessor']

--- a/docs/src/routes/docs/transform-template/+page.svx
+++ b/docs/src/routes/docs/transform-template/+page.svx
@@ -11,7 +11,7 @@ description: 'Customize the generated CSS transform string for motion components
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'transformTemplate | Docs | Svelte Motion'
-      seo.description = 'Customize generated Motion transform strings while keeping transform shortcuts and MotionValues.'
+      seo.description = 'Customize the generated CSS transform string with transformTemplate while keeping Motion transform shortcuts and MotionValues intact in Svelte.'
       seo.ogTitle = 'transformTemplate'
       seo.ogTagline = 'Reshape generated transform strings'
       seo.ogFeatures = ['Transform Shortcuts', 'MotionValue', 'CSS Transform', 'Motion Parity']

--- a/docs/src/routes/docs/use-in-view/+page.svx
+++ b/docs/src/routes/docs/use-in-view/+page.svx
@@ -12,7 +12,7 @@ description: 'Track whether an element is in the viewport via a $state-backed { 
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'useInView | Docs | Svelte Motion'
-      seo.description = 'Track whether an element is in the viewport with a $state-backed { current } snapshot. useInView mirrors framer-motion and pairs naturally with Svelte 5 bind:this.'
+      seo.description = 'Track whether an element is in the viewport with a $state-backed { current } snapshot. useInView pairs naturally with Svelte 5 bind:this.'
       seo.ogTitle = 'useInView'
       seo.ogTagline = 'Detect viewport entry via a reactive snapshot'
       seo.ogFeatures = ['Svelte 5 Runes', 'IntersectionObserver', 'Once Latch', 'SSR Safe']

--- a/docs/src/routes/docs/use-motion-template/+page.svx
+++ b/docs/src/routes/docs/use-motion-template/+page.svx
@@ -9,7 +9,7 @@ description: "Compose a MotionValue<string> from multiple motion values using a 
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'useMotionTemplate | Docs | Svelte Motion'
-      seo.description = 'Compose a MotionValue<string> from multiple motion values using a tagged template literal. Build dynamic filter, transform, and background values reactively in Svelte 5.'
+      seo.description = 'Compose a MotionValue<string> from multiple motion values with a tagged template literal — build dynamic filter, transform, and background values in Svelte.'
       seo.ogTitle = 'useMotionTemplate'
       seo.ogTagline = 'Compose motion values into CSS template strings'
       seo.ogFeatures = ['Template Literals', 'CSS Composition', 'MotionValue', 'Reactive Strings']

--- a/docs/src/routes/docs/use-motion-value-event/+page.svx
+++ b/docs/src/routes/docs/use-motion-value-event/+page.svx
@@ -9,7 +9,7 @@ description: "Subscribe to motion value store changes with automatic cleanup."
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'useMotionValueEvent | Docs | Svelte Motion'
-      seo.description = 'Subscribe to motion value store changes with automatic cleanup in Svelte Motion.'
+      seo.description = 'Subscribe to motion value changes like change, animationStart, and animationComplete with automatic cleanup on unmount in Svelte Motion.'
       seo.ogTitle = 'useMotionValueEvent'
       seo.ogTagline = 'Listen for motion value change events'
       seo.ogFeatures = ['Event Subscription', 'Auto Cleanup', 'Change Detection', 'Store Events']

--- a/docs/src/routes/docs/use-presence-data/+page.svx
+++ b/docs/src/routes/docs/use-presence-data/+page.svx
@@ -11,7 +11,7 @@ description: 'Read AnimatePresence custom data from an exiting child.'
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'usePresenceData | Docs | Svelte Motion'
-      seo.description = 'Read custom data passed to AnimatePresence from entering and exiting children.'
+      seo.description = 'Read the custom data passed to AnimatePresence from inside entering and exiting children, enabling direction-aware exit animations in Svelte.'
       seo.ogTitle = 'usePresenceData'
       seo.ogTagline = 'Presence custom data inside exiting children'
       seo.ogFeatures = ['AnimatePresence', 'custom', 'usePresenceData', 'Directional Exit']

--- a/docs/src/routes/docs/use-reduced-motion/+page.svx
+++ b/docs/src/routes/docs/use-reduced-motion/+page.svx
@@ -12,7 +12,7 @@ description: "Reactive Svelte 5 hook for the user's prefers-reduced-motion acces
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'useReducedMotion | Docs | Svelte Motion'
-      seo.description = "Detect the user's prefers-reduced-motion setting in Svelte. useReducedMotion returns a $state-backed { current } object that updates live when the OS preference changes."
+      seo.description = 'Detect prefers-reduced-motion in Svelte. useReducedMotion returns a $state-backed { current } object that updates live when the OS setting changes.'
       seo.ogTitle = 'useReducedMotion'
       seo.ogTagline = "Honor the user's reduced-motion preference"
       seo.ogFeatures = ['Accessibility', 'Svelte 5 Runes', 'Live Media-Query Updates', 'SSR Safe']

--- a/docs/src/routes/docs/use-scroll/+page.svx
+++ b/docs/src/routes/docs/use-scroll/+page.svx
@@ -11,7 +11,7 @@ description: "Create scroll-linked animations like progress indicators and paral
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'useScroll | Docs | Svelte Motion'
-      seo.description = 'Create scroll-linked animations like progress indicators and parallax effects with Svelte Motion useScroll.'
+      seo.description = 'Create scroll-linked animations like progress indicators and parallax effects with useScroll, tracking viewport or element scroll offsets in Svelte.'
       seo.ogTitle = 'useScroll'
       seo.ogTagline = 'Track scroll progress of the page or a container'
       seo.ogFeatures = ['Scroll Progress', 'Parallax Effects', 'Container Scroll', 'Scroll Velocity']

--- a/docs/src/routes/docs/use-spring/+page.svx
+++ b/docs/src/routes/docs/use-spring/+page.svx
@@ -9,7 +9,7 @@ description: "Create a spring-animated motion value with physics-based motion."
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'useSpring | Docs | Svelte Motion'
-      seo.description = 'Create a spring-animated motion value with physics-based motion. Animate values with configurable stiffness, damping, mass, duration, and bounce using Svelte Motion.'
+      seo.description = 'Create a spring-animated motion value in Svelte with physics-based motion — configurable stiffness, damping, mass, duration, and bounce.'
       seo.ogTitle = 'useSpring'
       seo.ogTagline = 'Spring-based motion values with natural physics'
       seo.ogFeatures = ['Spring Physics', 'Motion Values', 'Stiffness Control', 'Damping']

--- a/docs/src/routes/docs/vanilla-values/+page.svx
+++ b/docs/src/routes/docs/vanilla-values/+page.svx
@@ -11,7 +11,7 @@ description: Component-free motion values — motionValue, springValue, transfor
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'Vanilla motion values | Docs | Svelte Motion'
-      seo.description = 'Component-free motion values for Svelte — motionValue, springValue, transformValue, mapValue, element effects, and the toMotionValue bridge that turns runes into motion values.'
+      seo.description = 'Component-free motion values for Svelte — motionValue, springValue, transformValue, mapValue, element effects, and the toMotionValue rune bridge.'
       seo.ogTitle = 'Vanilla Motion Values'
       seo.ogTagline = 'Motion values anywhere — module scope, stores, event handlers'
       seo.ogFeatures = ['No Components Needed', 'Rune Bridge', 'Element Effects', 'Manual Lifecycle']

--- a/docs/src/routes/docs/view/+page.svx
+++ b/docs/src/routes/docs/view/+page.svx
@@ -11,7 +11,7 @@ description: Animate between two DOM states with the browser View Transitions AP
   const seo = getSeoContext()
   if (seo) {
       seo.title = 'View Transitions | Docs | Svelte Motion'
-      seo.description = 'Animate between two DOM states with animateView and the browser View Transitions API — crossfades, shared-element morphs, and enter/exit animations with spring timing.'
+      seo.description = 'Animate between two DOM states with animateView and the browser View Transitions API — crossfades, shared-element morphs, and enter/exit animations in Svelte.'
       seo.ogTitle = 'View Transitions'
       seo.ogTagline = 'Shared-element morphs and page transitions with animateView'
       seo.ogFeatures = ['Shared Element Morphs', 'Spring Timing', 'Enter/Exit Layers', 'Native Browser API']


### PR DESCRIPTION
## Summary

Fixes the SSR/SEO bug behind the three top Ahrefs findings (project 8934908, crawl 2026-07-10): the hand-rolled root layout rendered `SeoH1`/`SeoHead` **before** `{@render children?.()}`, and since Svelte SSR is a single sequential pass, they serialized while `seo` was still `{}`. Crawlers saw no `<h1>`, fallback titles, and fallback descriptions on every example page — while the hydrated client looked perfect. The layout is replaced with docs-kit's `RootLayout` (correct ordering, and structurally prevents the drift from recurring), matching markdown.svelte.page which scores 100.

## Changes

- 🐛 **Root cause** — `docs/src/routes/+layout.svelte` swapped to docs-kit `RootLayout`. All the old layout's providers (MotionConfig, SeoContext, Breadcrumb, ModeWatcher) are subsumed; `app.css` import retained; `stars` prop deliberately not passed so the homepage's hand-rolled `SoftwareApplication` JSON-LD stays the only one.
- 🔧 **Meta descriptions** — 21 docs pages normalized into the 120–158 char window (all 44 now comply); homepage description tightened from ~260 to 142 chars.
- 🐛 **Homepage duplicate head** — removed hand-rolled `<title>` + `<meta name="description">` from `svelte:head` (SeoHead already emits both from `seo.*`); now exactly one of each.

## Verification (production build, not dev)

- **60/60** `/examples/*` slugs SSR exactly one `<h1>` (was 0/60)
- `use-cycle` and `variants-dynamic` SSR their hand-tuned titles/descriptions instead of the `+page.ts` and `config.description` fallbacks
- The 7 bare-titled `/docs/*` pages SSR `<Page> | Docs | Svelte Motion` titles; docs pages keep exactly one `<h1>` (no duplicates)
- Homepage: 1 title, 1 meta description, 1 SoftwareApplication block
- `pnpm --filter docs check` — 0 errors

After deploy: re-crawl Ahrefs project 8934908; the h1/description/title issue counts should drop to zero.

## Commits

- [`b05a66f`](https://github.com/humanspeak/svelte-motion/commit/b05a66f217e90a77e3e8eff0da543ae34f1457c4) fix(docs): render SEO components after children so SSR sees seo state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
