### PR TITLE
fix(drag): compose full transform during drag via buildTransform

### DIFF
--- a/.agents/.plans/upstream-parity-top3/003-drag-transform-composition.guard-report.md
+++ b/.agents/.plans/upstream-parity-top3/003-drag-transform-composition.guard-report.md
@@ -1,0 +1,75 @@
+# Guard report — 003 drag-transform-composition
+
+**Recommendation: PASS** — every done criterion reproduced green, the three
+characterization tests confirmed red without the fix, and the diff delivers the
+plan's intent through motion-dom's own `buildTransform`, exactly as prescribed.
+**Reviewed at** `c3525d0` · 2026-07-10 11:44 · **Plan planned at** `634983b`
+**Integrated** — PR **not** opened: the plan's Git workflow section forbids it
+("Do NOT push or open a PR; maintainer signs off on live demos first"), and
+standing maintainer feedback requires a live-demo sign-off before any PR. The
+verified snapshot `c3525d0` sits on `fix/drag-transform-composition`, ready to
+publish on the operator's word. Demo page for sign-off:
+`/tests/drag/while-drag-transforms`.
+
+## Done criteria
+
+| Criterion                                                        | Result | Evidence                                                                                                                  |
+| ---------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm check` exits 0                                             | met    | Reproduced: `COMPLETED 1018 FILES 0 ERRORS 32 WARNINGS` (warnings pre-existing, in unrelated routes)                      |
+| `pnpm test` exits 0 with new unit cases                          | met    | Reproduced: 66 files / 759 tests passed; new cases at `drag.spec.ts:30-68`, `hover.spec.ts:219-252`                       |
+| Playwright `e2e/drag e2e/reorder` exits 0 incl. 3 new char tests | met    | Reproduced: 76 passed / 1 skipped (2.9m), exit 0; `siblings-flip` (#379 gate) green                                       |
+| Char tests genuinely characterize (Step 1 verify)                | met    | Red-verified: with `e0a88c7` source restored, exactly the 3 tests FAIL (rotation→0, y-drift, m23 lost); 1 nav test passes |
+| `grep "only updates \`origin\`" drag.ts` returns no match        | met    | Reproduced: grep exit 1; deferral comment replaced by cross-axis rationale at `drag.ts:777-783`                           |
+| `git status` clean outside in-scope list                         | met    | Tree fully clean at `c3525d0`; `git diff HEAD` empty after review                                                         |
+| Batch README status row updated                                  | met    | README row 003 → DONE with gate results (`README.md:20,49-55`)                                                            |
+
+## Spirit
+
+The plan's north star was to stop the drag composer from clobbering every
+transform channel it didn't own, and the diff delivers precisely that: a single
+writer (`transformComposer.ts:22-35`) built on motion-dom's `buildTransform` —
+the plan's preferred option over reimplementation — now composes drag
+translation, whileDrag channels (each animated as its own MotionValue,
+subscribed so the composer never reads the DOM, matching Step 2's preference),
+cross-axis projection compensation (`drag.ts:781-786`, painting what
+`adjustOrigin` previously only bookkept), authored style channels, and a live
+`transformTemplate` (threaded through `_MotionContainer.svelte:1628`, replacing
+the static-output-only path the plan called out). The hover partial rebuild —
+the same disease in `hover.ts` — was routed through the identical writer rather
+than left as a second implementation. Both preserved behaviors the plan fenced
+off are demonstrably intact: the #379 sync/microtask/rAF write survives
+(`drag.ts:634-642`, siblings-flip e2e green) and the #421 dual-write plus
+empty-write guard survives (`drag.ts:592-593,616-624`, unit test
+`drag.spec.ts:47-68`). No gap between letter and intent found.
+
+## Scope & conduct
+
+- In-scope only? Yes, with two intent-faithful deviations: (1) the hover fix
+  landed in `hover.ts`/`hover.spec.ts` — the plan misnamed the file as
+  `interaction.ts`, which contains no transform rebuild (plan defect, moot
+  post-execution); (2) the shared writer is a new module
+  `src/lib/utils/transformComposer.ts` rather than living inside `drag.ts` —
+  required for hover reuse (Step 4) and aligned with the maintenance note to
+  keep the writer's API small for Plan 004. `projection.ts` /
+  `motionDomProjection.ts` untouched — the Plan 004 boundary held.
+- STOP conditions respected? Yes. Char tests failed as predicted (red-verified
+  by guard); `buildTransform` imported from motion-dom (no duplication clause
+  triggered); no projection-path modification; siblings-flip never regressed.
+- Plan amendments during execution: none. Plan file untouched by the executor
+  (no tampering).
+
+## Residual risk / follow-ups
+
+- `transformComposer.ts` coverage is 66% statements — `splitGestureTransformValues`
+  (lines 59-66) is exercised only indirectly via drag/hover paths; a dedicated
+  spec file would be cheap insurance given Plan 004 will build on this seam.
+- `addPixelOffset` (`drag.ts:420-431`) falls back to `calc()` for non-px
+  authored x/y (e.g. `x: '10%'`); correct CSS, but untested — worth a case if
+  percentage translations show up in issues.
+- Restore-path generation guard (`drag.ts:817-830`) is new logic for rapid
+  drag→release→drag cycles; the while-drag-restore e2e covers the common case,
+  not the race.
+- Plan 004 dependency is now unblocked: the writer's values-map is the seam it
+  expects (`crossAxisOffset` + `gestureTransformValues` feeding `setXYImmediate`).
+- Maintainer live-demo sign-off is the remaining gate before PR/publication,
+  per the plan's Git workflow.

--- a/.agents/.plans/upstream-parity-top3/003-drag-transform-composition.guard-report.md
+++ b/.agents/.plans/upstream-parity-top3/003-drag-transform-composition.guard-report.md
@@ -4,12 +4,12 @@
 characterization tests confirmed red without the fix, and the diff delivers the
 plan's intent through motion-dom's own `buildTransform`, exactly as prescribed.
 **Reviewed at** `c3525d0` · 2026-07-10 11:44 · **Plan planned at** `634983b`
-**Integrated** — PR **not** opened: the plan's Git workflow section forbids it
-("Do NOT push or open a PR; maintainer signs off on live demos first"), and
-standing maintainer feedback requires a live-demo sign-off before any PR. The
-verified snapshot `c3525d0` sits on `fix/drag-transform-composition`, ready to
-publish on the operator's word. Demo page for sign-off:
-`/tests/drag/while-drag-transforms`.
+**Integrated** — PR <https://github.com/humanspeak/svelte-motion/pull/446>
+opened via the `pr` skill for the reviewed snapshot `c3525d0`. Publication was
+initially withheld per the plan's Git workflow ("Do NOT push or open a PR;
+maintainer signs off on live demos first"); the maintainer drove the live demo
+at `/tests/drag/while-drag-transforms` and signed off on 2026-07-10, after
+which the PR was opened.
 
 ## Done criteria
 

--- a/.agents/.plans/upstream-parity-top3/003-drag-transform-composition.guard-report.md
+++ b/.agents/.plans/upstream-parity-top3/003-drag-transform-composition.guard-report.md
@@ -71,5 +71,5 @@ empty-write guard survives (`drag.ts:592-593,616-624`, unit test
   not the race.
 - Plan 004 dependency is now unblocked: the writer's values-map is the seam it
   expects (`crossAxisOffset` + `gestureTransformValues` feeding `setXYImmediate`).
-- Maintainer live-demo sign-off is the remaining gate before PR/publication,
-  per the plan's Git workflow.
+- Maintainer live-demo sign-off and the PR/publication gate are resolved:
+  PR #446 is open and recorded in the plan 003 close-out.

--- a/.agents/.plans/upstream-parity-top3/003-drag-transform-composition.guard.md
+++ b/.agents/.plans/upstream-parity-top3/003-drag-transform-composition.guard.md
@@ -1,0 +1,53 @@
+# Guard log — 003 drag-transform-composition
+
+## Checkpoint 1 — 2026-07-10 11:41 — ON TRACK
+
+c3525d0 · post-completion checkpoint at operator request; executor had marked
+the plan DONE in the batch README. Snapshot-committed the working tree
+(drag.ts writer, transformComposer.ts, hover composer, container plumbing,
+unit tests, README row) via the commit skill; pre-commit fmt/lint/svelte-check
+passed.
+
+- Drift check: in-scope files changed between `634983b` (planned-at) and the
+  fork point `89f8d70` (263/29/8 lines), but the plan's "Current state"
+  excerpts still matched at the fork — the executor's diff removes exactly the
+  excerpted `managedScale`/translate string-splicing (`drag.ts` old ~550-589).
+  No STOP warranted.
+- Done criteria reproduced: `pnpm check` → 0 errors; `pnpm test` → 759/759;
+  `grep -n "only updates \`origin\`" src/lib/utils/drag.ts` → no match;
+  drag/reorder e2e launched (result recorded in Checkpoint 2).
+- Assertions read, not gamed: e2e decomposes `getComputedStyle().transform`
+  via DOMMatrix across 8 live frames (`while-drag-transforms.spec.ts:43-54,
+71-78,90-105`); unit tests cover upstream channel order, live
+  transformTemplate values, and the #421 bound-MotionValue empty-write guard
+  (`drag.spec.ts:30-68`); the plan's required hover rotateX-survival case is
+  present (`hover.spec.ts:219-230`). Demo page drives rotation only via
+  `whileDrag` — nothing rigged.
+- Plan defect (minor, moot): plan names `src/lib/utils/interaction.ts` for the
+  hover partial-rebuild; the pattern actually lived in `hover.ts`
+  (`writeComposedScale`, removed by this diff). `interaction.ts` has no
+  transform rebuild (grep empty). Executor followed the plan's intent in the
+  right file. No amendment needed post-execution.
+- Justified deviation: shared writer landed in new
+  `src/lib/utils/transformComposer.ts` instead of inside `drag.ts` — Step 4
+  ("route hover through the same writer") requires a shared module, and it
+  serves Plan 004's note to keep the writer's API small and documented.
+- Action: proceeded to final close-out at operator request.
+
+## Checkpoint 2 — 2026-07-10 11:44 — ON TRACK (final)
+
+c3525d0 · final close-out. Tree already clean (same snapshot as Checkpoint 1).
+
+- e2e gate reproduced: `pnpm exec playwright test e2e/drag e2e/reorder` →
+  76 passed / 1 skipped, exit 0, including the `siblings-flip` drift-sampling
+  specs that encode the #379 no-lag pin.
+- Red verification: restored `drag.ts`/`hover.ts`/`_MotionContainer.svelte`
+  from `e0a88c7` (tests present, fix absent) and re-ran the new spec — exactly
+  the 3 characterization tests FAIL for the plan's documented reasons
+  (rotation drops, y drifts, rotateX/m23 lost); only the nav-link test passes.
+  Files restored byte-identical afterward (`git diff HEAD` empty).
+- PR withheld despite PASS: the plan's Git workflow section is explicit —
+  "Do NOT push or open a PR; maintainer signs off on live demos first."
+  Recorded in the close-out report; publication is the operator's next move.
+- Action: close-out report written (`003-drag-transform-composition.guard-report.md`),
+  verdict PASS; reported to operator.

--- a/.agents/.plans/upstream-parity-top3/003-drag-transform-composition.guard.md
+++ b/.agents/.plans/upstream-parity-top3/003-drag-transform-composition.guard.md
@@ -51,3 +51,14 @@ c3525d0 · final close-out. Tree already clean (same snapshot as Checkpoint 1).
   Recorded in the close-out report; publication is the operator's next move.
 - Action: close-out report written (`003-drag-transform-composition.guard-report.md`),
   verdict PASS; reported to operator.
+
+## Checkpoint 3 — 2026-07-10 11:55 — ON TRACK (integration)
+
+c3525d0 · maintainer drove the live demo and signed off; publication gate
+cleared.
+
+- Branch pushed (`git push -u origin fix/drag-transform-composition`) and PR
+  opened via the `pr` skill: <https://github.com/humanspeak/svelte-motion/pull/446>
+  (base `main`, labels `bug`/`javascript`, `Closes #436`, refs #403/#396).
+- Report's Integrated line updated with the PR URL.
+- Action: handed back to operator — merging is the operator's call.

--- a/.agents/.plans/upstream-parity-top3/README.md
+++ b/.agents/.plans/upstream-parity-top3/README.md
@@ -17,7 +17,7 @@ the A2 projection issues) — see "Superseded issues" below.
 | ---- | -------------------------------------------------------------------- | ---------- | ------ | ---------- | -------------------------------------------------------------------------- | ------ |
 | 001  | Re-type `animate` for AugmentedMotionValue (kill all 10 casts)       | P1 — FIRST | S–M    | —          | Small — delete casts from docs examples; check prose                       | DONE   |
 | 002  | SVG MotionValue attribute binding + attrX/attrY/attrScale            | P1         | M      | —          | **YES — new docs page** (`docs/svg-animation`)                             | DONE   |
-| 003  | Full transform composition during drag (buildTransform semantics)    | P1         | M      | —          | No public docs; in-code decision comments must be updated                  | TODO   |
+| 003  | Full transform composition during drag (buildTransform semantics)    | P1         | M      | —          | No public docs; in-code decision comments must be updated                  | DONE   |
 | 004  | Motion-dom projection authoritative (page-space, retire legacy FLIP) | P1         | L      | 003        | **YES — update** `docs/layout-animations`; shared-layout page as follow-up | TODO   |
 | 005  | Apple Intelligence wavy glow border — flagship example (smooth)      | P2 — LAST  | M      | 002        | **YES — new example page** (`examples/ai-glow-border`) + nav + sitemap     | DONE   |
 
@@ -45,6 +45,13 @@ REJECTED (with one-line rationale)
   / 2 skipped (both skips pre-existing), docs check 0 errors, `trunk check`
   clean. Guard Finding 8 addressed — the tag-casing e2e now asserts after the
   `{#if mounted}` remount and was confirmed to FAIL with the fix reverted.
+
+- 003: **DONE** 2026-07-10. Drag translation, cross-axis projection
+  compensation, active 2D/3D gesture transforms, authored style channels, and
+  transformTemplate now render through one motion-dom `buildTransform` writer.
+  The same writer replaced hover's partial scale composer; hover enter/leave
+  retains settled drag channels. Final gates: `pnpm check` 0 errors, unit
+  759/759, drag/reorder e2e 76 passed / 1 skipped, trunk clean.
 
 - 005: **DONE** 2026-07-10, executed with heavy maintainer-driven design
   iteration that deliberately superseded the plan's letter (maintainer:

--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -20,5 +20,25 @@ jobs:
               with:
                   persist-credentials: false
 
+            - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
+
+            - name: Use Node.js - 24
+              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              with:
+                  node-version: 24
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile --config.engine-strict=false
+
+            # `$lib/*` is mapped to `src/lib/*` only inside the generated
+            # `.svelte-kit/tsconfig.json`, which the root `tsconfig.json` extends and
+            # `.gitignore` excludes. Without this step it never exists on the runner, so
+            # typed lint resolves every `$lib/…` import to an error type and the
+            # `no-unsafe-*` family fires across the repo.
+            - name: Generate SvelteKit tsconfigs for type-aware lint
+              run: |
+                  pnpm exec svelte-kit sync
+                  pnpm --filter docs exec svelte-kit sync
+
             - name: Trunk Code Quality
               uses: trunk-io/trunk-action@v1 # zizmor: ignore[unpinned-uses]

--- a/docs/src/lib/examples/drag-transforms/demos/Angled.svelte
+++ b/docs/src/lib/examples/drag-transforms/demos/Angled.svelte
@@ -1,0 +1,294 @@
+<script lang="ts">
+    import { motion } from '@humanspeak/svelte-motion'
+
+    let bounds: HTMLElement | null = null
+</script>
+
+<!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
+<div class="dk-demo-shell">
+    <section class="transform-lab" aria-label="Angled drag example">
+        <div class="lab-header">
+            <span>drag lab</span>
+            <strong>angled composition</strong>
+        </div>
+
+        <div class="stage-wrap">
+            <div class="axis-label axis-label-top">rotate −8°</div>
+            <div class="axis-label axis-label-bottom">skewX −5°</div>
+
+            <div bind:this={bounds} class="transform-stage">
+                <motion.div
+                    drag
+                    dragConstraints={bounds}
+                    dragElastic={0.28}
+                    whileHover={{ scale: 1.03 }}
+                    whileDrag={{ rotate: 4, scale: 1.08, cursor: 'grabbing' }}
+                    transition={{ type: 'spring', stiffness: 420, damping: 32 }}
+                    aria-label="Draggable angled card"
+                    style={{
+                        rotate: -8,
+                        skewX: -5,
+                        width: 'clamp(96px, 15vw, 132px)',
+                        aspectRatio: '1',
+                        borderRadius: '8px',
+                        cursor: 'grab',
+                        touchAction: 'none',
+                        background: 'var(--drag-card-bg)',
+                        border: 'var(--drag-card-border)',
+                        boxShadow: 'var(--drag-card-shadow)'
+                    }}
+                >
+                    <span class="tile-mark">SM</span>
+                    <span class="tile-grip" aria-hidden="true">
+                        <i></i><i></i><i></i><i></i>
+                    </span>
+                    <span class="tile-label">angled</span>
+                </motion.div>
+            </div>
+        </div>
+
+        <div class="lab-footer">
+            <span>authored rotate</span>
+            <span>authored skew</span>
+            <span>whileDrag rotate</span>
+        </div>
+    </section>
+</div>
+
+<style>
+    .dk-demo-shell {
+        min-height: 560px;
+        display: grid;
+        place-items: center;
+        padding: clamp(1rem, 4vw, 2.5rem);
+    }
+
+    .transform-lab {
+        --lab-text: #f8fafc;
+        --lab-bg:
+            linear-gradient(135deg, rgb(2 6 23 / 0.94), rgb(15 23 42 / 0.9)),
+            radial-gradient(
+                circle at 18% 18%,
+                color-mix(in oklab, var(--color-brand-400, #34d399) 28%, transparent),
+                transparent 22rem
+            );
+        --lab-border: color-mix(in oklab, var(--color-brand-300, #6ee7b7) 34%, #334155);
+        --lab-shadow: 0 24px 80px rgb(0 0 0 / 0.28);
+        --lab-muted: rgb(226 232 240 / 0.68);
+        --lab-accent: var(--color-brand-300, #6ee7b7);
+        --lab-chip-bg: rgb(15 23 42 / 0.62);
+        --lab-chip-border: rgb(148 163 184 / 0.28);
+        --stage-border: rgb(148 163 184 / 0.2);
+        --stage-grid: rgb(148 163 184 / 0.06);
+        --constraint-border: rgb(226 232 240 / 0.32);
+        --constraint-bg:
+            linear-gradient(135deg, rgb(15 23 42 / 0.72), rgb(30 41 59 / 0.46)),
+            radial-gradient(
+                circle at center,
+                color-mix(in oklab, var(--color-brand-400, #34d399) 16%, transparent),
+                transparent 70%
+            );
+        --axis-label: rgb(226 232 240 / 0.42);
+        --drag-card-text: #042f2e;
+        --drag-card-frame: rgb(4 47 46 / 0.18);
+        --drag-card-corner: rgb(4 47 46 / 0.14);
+        --drag-card-bg:
+            linear-gradient(135deg, rgb(255 255 255 / 0.16), transparent 38%),
+            linear-gradient(135deg, var(--color-brand-300, #6ee7b7), #22d3ee 54%, #38bdf8);
+        --drag-card-border: 1px solid
+            color-mix(in oklab, var(--color-brand-100, #d1fae5) 76%, #ffffff 12%);
+        --drag-card-shadow:
+            0 18px 42px color-mix(in oklab, var(--color-brand-500, #10b981) 28%, transparent),
+            0 1px 0 rgb(255 255 255 / 0.18), inset 0 1px 0 rgb(255 255 255 / 0.52),
+            inset 0 -18px 28px rgb(2 6 23 / 0.12);
+        width: min(100%, 760px);
+        display: grid;
+        gap: 1rem;
+        padding: clamp(1rem, 3vw, 1.4rem);
+        color: var(--lab-text);
+        background: var(--lab-bg);
+        border: 1px solid var(--lab-border);
+        border-radius: 8px;
+        box-shadow: var(--lab-shadow);
+    }
+
+    :global(html:not(.dark)) .transform-lab {
+        --lab-text: #0f172a;
+        --lab-bg:
+            linear-gradient(135deg, rgb(248 250 252 / 0.96), rgb(236 253 245 / 0.84)),
+            radial-gradient(
+                circle at 16% 16%,
+                color-mix(in oklab, var(--color-brand-300, #6ee7b7) 36%, transparent),
+                transparent 22rem
+            );
+        --lab-border: color-mix(in oklab, var(--color-brand-500, #10b981) 24%, #cbd5e1);
+        --lab-shadow: 0 24px 70px rgb(15 23 42 / 0.12);
+        --lab-muted: rgb(15 23 42 / 0.64);
+        --lab-accent: var(--color-brand-700, #047857);
+        --lab-chip-bg: rgb(255 255 255 / 0.74);
+        --lab-chip-border: rgb(15 23 42 / 0.14);
+        --stage-border: rgb(15 23 42 / 0.14);
+        --stage-grid: rgb(15 23 42 / 0.07);
+        --constraint-border: rgb(15 23 42 / 0.22);
+        --constraint-bg:
+            linear-gradient(135deg, rgb(255 255 255 / 0.86), rgb(240 253 250 / 0.7)),
+            radial-gradient(
+                circle at center,
+                color-mix(in oklab, var(--color-brand-300, #6ee7b7) 22%, transparent),
+                transparent 72%
+            );
+        --axis-label: rgb(15 23 42 / 0.42);
+        --drag-card-text: #ecfeff;
+        --drag-card-frame: rgb(236 253 245 / 0.28);
+        --drag-card-corner: rgb(236 253 245 / 0.22);
+        --drag-card-bg:
+            linear-gradient(135deg, rgb(255 255 255 / 0.18), transparent 38%),
+            linear-gradient(135deg, #0f766e, var(--color-brand-600, #059669) 52%, #0284c7);
+        --drag-card-border: 1px solid rgb(15 118 110 / 0.42);
+        --drag-card-shadow:
+            0 18px 42px rgb(15 118 110 / 0.22), 0 1px 0 rgb(255 255 255 / 0.42),
+            inset 0 1px 0 rgb(255 255 255 / 0.24), inset 0 -18px 28px rgb(2 6 23 / 0.22);
+    }
+
+    .lab-header,
+    .lab-footer {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        text-transform: uppercase;
+        font-size: 0.72rem;
+        color: var(--lab-muted);
+    }
+
+    .lab-header strong {
+        color: var(--lab-accent);
+        font-weight: 700;
+    }
+
+    .lab-footer {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+    }
+
+    .lab-footer span {
+        min-height: 1.5rem;
+        display: inline-flex;
+        align-items: center;
+        border: 1px solid var(--lab-chip-border);
+        border-radius: 4px;
+        padding: 0.18rem 0.45rem;
+        background: var(--lab-chip-bg);
+    }
+
+    .stage-wrap {
+        position: relative;
+        display: grid;
+        place-items: center;
+        min-height: clamp(320px, 58vw, 480px);
+        border: 1px dashed var(--stage-border);
+        background-image:
+            linear-gradient(var(--stage-grid) 1px, transparent 1px),
+            linear-gradient(90deg, var(--stage-grid) 1px, transparent 1px);
+        background-size: 28px 28px;
+    }
+
+    .transform-stage {
+        width: min(62vw, 380px);
+        aspect-ratio: 1;
+        display: grid;
+        place-items: center;
+        border: 1px solid var(--constraint-border);
+        border-radius: 8px;
+        background: var(--constraint-bg);
+    }
+
+    .axis-label {
+        position: absolute;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        text-transform: uppercase;
+        font-size: 0.68rem;
+        color: var(--axis-label);
+        pointer-events: none;
+    }
+
+    .axis-label-top {
+        top: 0.65rem;
+    }
+
+    .axis-label-bottom {
+        bottom: 0.65rem;
+    }
+
+    :global(.transform-stage [aria-label='Draggable angled card']) {
+        position: relative;
+        display: grid;
+        grid-template-rows: auto 1fr auto;
+        align-items: center;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        text-transform: uppercase;
+        font-size: 0.72rem;
+        font-weight: 800;
+        color: var(--drag-card-text);
+        letter-spacing: 0.08em;
+        user-select: none;
+        overflow: hidden;
+    }
+
+    :global(.transform-stage [aria-label='Draggable angled card']::before) {
+        content: '';
+        position: absolute;
+        inset: 9px;
+        border: 1px solid var(--drag-card-frame);
+        border-radius: 5px;
+        pointer-events: none;
+    }
+
+    .tile-mark,
+    .tile-label {
+        position: relative;
+        z-index: 1;
+        padding-inline: 0.75rem;
+    }
+
+    .tile-mark {
+        align-self: start;
+        padding-top: 0.7rem;
+        font-size: 0.66rem;
+        opacity: 0.74;
+    }
+
+    .tile-label {
+        align-self: end;
+        padding-bottom: 0.72rem;
+        justify-self: end;
+    }
+
+    .tile-grip {
+        position: relative;
+        z-index: 1;
+        justify-self: center;
+        display: grid;
+        grid-template-columns: repeat(2, 5px);
+        gap: 6px;
+        opacity: 0.52;
+    }
+
+    .tile-grip i {
+        width: 5px;
+        aspect-ratio: 1;
+        border-radius: 999px;
+        background: currentColor;
+    }
+
+    @media (max-width: 640px) {
+        .stage-wrap {
+            min-height: 360px;
+        }
+
+        .transform-stage {
+            width: min(72vw, 320px);
+        }
+    }
+</style>

--- a/docs/src/lib/examples/drag-transforms/demos/Perspective.svelte
+++ b/docs/src/lib/examples/drag-transforms/demos/Perspective.svelte
@@ -1,0 +1,296 @@
+<script lang="ts">
+    import { motion } from '@humanspeak/svelte-motion'
+
+    let bounds: HTMLElement | null = null
+</script>
+
+<!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
+<div class="dk-demo-shell">
+    <section class="perspective-lab" aria-label="Perspective drag example">
+        <div class="lab-header">
+            <span>drag lab</span>
+            <strong>3d composition</strong>
+        </div>
+
+        <div class="stage-wrap">
+            <div class="axis-label axis-label-top">transformPerspective 900</div>
+            <div class="axis-label axis-label-bottom">rotateX −14° · rotateY 22°</div>
+
+            <div bind:this={bounds} class="perspective-stage">
+                <motion.div
+                    drag
+                    dragConstraints={bounds}
+                    dragElastic={0.28}
+                    whileHover={{ scale: 1.03 }}
+                    whileDrag={{
+                        rotateX: -14,
+                        rotateY: 22,
+                        scale: 1.08,
+                        cursor: 'grabbing'
+                    }}
+                    transition={{ type: 'spring', stiffness: 320, damping: 28 }}
+                    aria-label="Draggable perspective card"
+                    style={{
+                        transformPerspective: 900,
+                        width: 'clamp(104px, 17vw, 148px)',
+                        aspectRatio: '1',
+                        borderRadius: '8px',
+                        cursor: 'grab',
+                        touchAction: 'none',
+                        background: 'var(--drag-card-bg)',
+                        border: 'var(--drag-card-border)',
+                        boxShadow: 'var(--drag-card-shadow)'
+                    }}
+                >
+                    <span class="tile-mark">SM</span>
+                    <span class="tile-grip" aria-hidden="true">
+                        <i></i><i></i><i></i><i></i>
+                    </span>
+                    <span class="tile-label">tilt</span>
+                </motion.div>
+            </div>
+        </div>
+
+        <div class="lab-footer">
+            <span>transformPerspective</span>
+            <span>whileDrag rotateX</span>
+            <span>whileDrag rotateY</span>
+        </div>
+    </section>
+</div>
+
+<style>
+    .dk-demo-shell {
+        min-height: 560px;
+        display: grid;
+        place-items: center;
+        padding: clamp(1rem, 4vw, 2.5rem);
+    }
+
+    .perspective-lab {
+        --lab-text: #f8fafc;
+        --lab-bg:
+            linear-gradient(135deg, rgb(2 6 23 / 0.94), rgb(15 23 42 / 0.9)),
+            radial-gradient(
+                circle at 18% 18%,
+                color-mix(in oklab, var(--color-brand-400, #34d399) 28%, transparent),
+                transparent 22rem
+            );
+        --lab-border: color-mix(in oklab, var(--color-brand-300, #6ee7b7) 34%, #334155);
+        --lab-shadow: 0 24px 80px rgb(0 0 0 / 0.28);
+        --lab-muted: rgb(226 232 240 / 0.68);
+        --lab-accent: var(--color-brand-300, #6ee7b7);
+        --lab-chip-bg: rgb(15 23 42 / 0.62);
+        --lab-chip-border: rgb(148 163 184 / 0.28);
+        --stage-border: rgb(148 163 184 / 0.2);
+        --stage-grid: rgb(148 163 184 / 0.06);
+        --constraint-border: rgb(226 232 240 / 0.32);
+        --constraint-bg:
+            linear-gradient(135deg, rgb(15 23 42 / 0.72), rgb(30 41 59 / 0.46)),
+            radial-gradient(
+                circle at center,
+                color-mix(in oklab, var(--color-brand-400, #34d399) 16%, transparent),
+                transparent 70%
+            );
+        --axis-label: rgb(226 232 240 / 0.42);
+        --drag-card-text: #042f2e;
+        --drag-card-frame: rgb(4 47 46 / 0.18);
+        --drag-card-bg:
+            linear-gradient(135deg, rgb(255 255 255 / 0.16), transparent 38%),
+            linear-gradient(135deg, var(--color-brand-300, #6ee7b7), #22d3ee 54%, #38bdf8);
+        --drag-card-border: 1px solid
+            color-mix(in oklab, var(--color-brand-100, #d1fae5) 76%, #ffffff 12%);
+        --drag-card-shadow:
+            0 18px 42px color-mix(in oklab, var(--color-brand-500, #10b981) 28%, transparent),
+            0 1px 0 rgb(255 255 255 / 0.18), inset 0 1px 0 rgb(255 255 255 / 0.52),
+            inset 0 -18px 28px rgb(2 6 23 / 0.12);
+        width: min(100%, 760px);
+        display: grid;
+        gap: 1rem;
+        padding: clamp(1rem, 3vw, 1.4rem);
+        color: var(--lab-text);
+        background: var(--lab-bg);
+        border: 1px solid var(--lab-border);
+        border-radius: 8px;
+        box-shadow: var(--lab-shadow);
+    }
+
+    :global(html:not(.dark)) .perspective-lab {
+        --lab-text: #0f172a;
+        --lab-bg:
+            linear-gradient(135deg, rgb(248 250 252 / 0.96), rgb(236 253 245 / 0.84)),
+            radial-gradient(
+                circle at 16% 16%,
+                color-mix(in oklab, var(--color-brand-300, #6ee7b7) 36%, transparent),
+                transparent 22rem
+            );
+        --lab-border: color-mix(in oklab, var(--color-brand-500, #10b981) 24%, #cbd5e1);
+        --lab-shadow: 0 24px 70px rgb(15 23 42 / 0.12);
+        --lab-muted: rgb(15 23 42 / 0.64);
+        --lab-accent: var(--color-brand-700, #047857);
+        --lab-chip-bg: rgb(255 255 255 / 0.74);
+        --lab-chip-border: rgb(15 23 42 / 0.14);
+        --stage-border: rgb(15 23 42 / 0.14);
+        --stage-grid: rgb(15 23 42 / 0.07);
+        --constraint-border: rgb(15 23 42 / 0.22);
+        --constraint-bg:
+            linear-gradient(135deg, rgb(255 255 255 / 0.86), rgb(240 253 250 / 0.7)),
+            radial-gradient(
+                circle at center,
+                color-mix(in oklab, var(--color-brand-300, #6ee7b7) 22%, transparent),
+                transparent 72%
+            );
+        --axis-label: rgb(15 23 42 / 0.42);
+        --drag-card-text: #ecfeff;
+        --drag-card-frame: rgb(236 253 245 / 0.28);
+        --drag-card-bg:
+            linear-gradient(135deg, rgb(255 255 255 / 0.18), transparent 38%),
+            linear-gradient(135deg, #0f766e, var(--color-brand-600, #059669) 52%, #0284c7);
+        --drag-card-border: 1px solid rgb(15 118 110 / 0.42);
+        --drag-card-shadow:
+            0 18px 42px rgb(15 118 110 / 0.22), 0 1px 0 rgb(255 255 255 / 0.42),
+            inset 0 1px 0 rgb(255 255 255 / 0.24), inset 0 -18px 28px rgb(2 6 23 / 0.22);
+    }
+
+    .lab-header,
+    .lab-footer {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        text-transform: uppercase;
+        font-size: 0.72rem;
+        color: var(--lab-muted);
+    }
+
+    .lab-header strong {
+        color: var(--lab-accent);
+        font-weight: 700;
+    }
+
+    .lab-footer {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+    }
+
+    .lab-footer span {
+        min-height: 1.5rem;
+        display: inline-flex;
+        align-items: center;
+        border: 1px solid var(--lab-chip-border);
+        border-radius: 4px;
+        padding: 0.18rem 0.45rem;
+        background: var(--lab-chip-bg);
+    }
+
+    .stage-wrap {
+        position: relative;
+        display: grid;
+        place-items: center;
+        min-height: clamp(320px, 58vw, 480px);
+        border: 1px dashed var(--stage-border);
+        background-image:
+            linear-gradient(var(--stage-grid) 1px, transparent 1px),
+            linear-gradient(90deg, var(--stage-grid) 1px, transparent 1px);
+        background-size: 28px 28px;
+    }
+
+    .perspective-stage {
+        width: min(62vw, 380px);
+        aspect-ratio: 1;
+        display: grid;
+        place-items: center;
+        border: 1px solid var(--constraint-border);
+        border-radius: 8px;
+        background: var(--constraint-bg);
+    }
+
+    .axis-label {
+        position: absolute;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        text-transform: uppercase;
+        font-size: 0.68rem;
+        color: var(--axis-label);
+        pointer-events: none;
+    }
+
+    .axis-label-top {
+        top: 0.65rem;
+    }
+
+    .axis-label-bottom {
+        bottom: 0.65rem;
+    }
+
+    :global(.perspective-stage [aria-label='Draggable perspective card']) {
+        position: relative;
+        display: grid;
+        grid-template-rows: auto 1fr auto;
+        align-items: center;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        text-transform: uppercase;
+        font-size: 0.72rem;
+        font-weight: 800;
+        color: var(--drag-card-text);
+        letter-spacing: 0.08em;
+        user-select: none;
+        overflow: hidden;
+    }
+
+    :global(.perspective-stage [aria-label='Draggable perspective card']::before) {
+        content: '';
+        position: absolute;
+        inset: 9px;
+        border: 1px solid var(--drag-card-frame);
+        border-radius: 5px;
+        pointer-events: none;
+    }
+
+    .tile-mark,
+    .tile-label {
+        position: relative;
+        z-index: 1;
+        padding-inline: 0.75rem;
+    }
+
+    .tile-mark {
+        align-self: start;
+        padding-top: 0.7rem;
+        font-size: 0.66rem;
+        opacity: 0.74;
+    }
+
+    .tile-label {
+        align-self: end;
+        padding-bottom: 0.72rem;
+        justify-self: end;
+    }
+
+    .tile-grip {
+        position: relative;
+        z-index: 1;
+        justify-self: center;
+        display: grid;
+        grid-template-columns: repeat(2, 5px);
+        gap: 6px;
+        opacity: 0.52;
+    }
+
+    .tile-grip i {
+        width: 5px;
+        aspect-ratio: 1;
+        border-radius: 999px;
+        background: currentColor;
+    }
+
+    @media (max-width: 640px) {
+        .stage-wrap {
+            min-height: 360px;
+        }
+
+        .perspective-stage {
+            width: min(72vw, 320px);
+        }
+    }
+</style>

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -55,6 +55,11 @@ const EXAMPLES: Record<string, ExampleEntry> = {
         description:
             'A polished constrained-drag stage showing elastic overdrag, ref bounds, and spring settling.'
     },
+    'drag-transforms': {
+        title: 'Drag Transforms',
+        description:
+            'Drag translation composed with authored rotate, skew, perspective, and whileDrag transform channels.'
+    },
     'fancy-like-button': {
         title: 'Fancy Like Button',
         description: 'Interactive fancy like button animation example using Svelte Motion.'

--- a/docs/src/routes/examples/drag-transforms/+page.svelte
+++ b/docs/src/routes/examples/drag-transforms/+page.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        type ExampleSection,
+        formatSheetLabel
+    } from '@humanspeak/docs-kit'
+    import { Axis3d, Box, Hand, Layers, MousePointer2, RotateCw } from '@lucide/svelte'
+    import { demoCodeSample } from '$lib/demo-loaders'
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import DragTransformsAngled from '$lib/examples/drag-transforms/demos/Angled.svelte'
+    import DragTransformsPerspective from '$lib/examples/drag-transforms/demos/Perspective.svelte'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [
+            { title: 'Examples', href: '/examples' },
+            { title: 'Drag Transforms' }
+        ]
+    }
+    if (seo) {
+        seo.title = 'Drag Transforms | Svelte Motion'
+        seo.description =
+            'Drag a card that stays angled and tilts in 3D — translation composes with authored rotate, skew, perspective, and whileDrag channels.'
+        seo.ogTitle = 'Drag Transforms'
+        seo.h1 = { title: 'Drag Transforms', mode: 'sr-only' }
+        seo.ogTagline = 'Drag translation composed with rotate, skew, and perspective'
+        seo.ogFeatures = ['Drag', 'Rotate', 'Skew', 'Perspective']
+        seo.ogSlug = 'examples-drag-transforms'
+    }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    const sections: ExampleSection[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'DRAG',
+            title: { prefix: 'angled ', accent: 'drag composition', end: '.' },
+            description:
+                'The card rests at an authored angle. Dragging translates it without flattening that angle — the drag translation is composed into the same transform as the authored rotate and skew, rather than replacing it.',
+            snippet: angledSection,
+            codeSnippet: angledCode,
+            notes: angledNotes,
+            barCells: [{ k: 'channels', v: 'rotate · skewX · whileDrag' }],
+            sourceUrl: `${SOURCE_URL}drag-transforms/demos/Angled.svelte`
+        },
+        {
+            figId: 'FIG-002',
+            tag: 'DRAG',
+            title: { prefix: 'perspective ', accent: 'tilt on grab', end: '.' },
+            description:
+                'A 3D variant: grabbing the card tilts it on both axes under a transformPerspective, and it keeps tilting while it tracks the pointer. The perspective and rotation survive every live drag frame.',
+            snippet: perspectiveSection,
+            codeSnippet: perspectiveCode,
+            notes: perspectiveNotes,
+            barCells: [{ k: 'channels', v: 'transformPerspective · rotateX · rotateY' }],
+            sourceUrl: `${SOURCE_URL}drag-transforms/demos/Perspective.svelte`
+        }
+    ]
+</script>
+
+{#snippet angledSection()}
+    <DragTransformsAngled />
+{/snippet}
+{#snippet angledNotes()}
+    <ul>
+        <li>
+            <RotateCw />
+            <span>
+                The resting angle is authored as transform channels — <code>rotate</code> and
+                <code>skewX</code> on <code>style</code> — not as a raw CSS
+                <code>transform</code> string.
+            </span>
+        </li>
+        <li>
+            <Hand />
+            <span>
+                Grab and drag. The card keeps its angle the whole way: drag translation is written
+                into the same composed transform instead of overwriting it.
+            </span>
+        </li>
+        <li>
+            <Layers />
+            <span>
+                <code>whileDrag</code> layers a second <code>rotate</code> on top for the duration of
+                the gesture, which takes over the channel while the pointer is down and hands it back
+                on release.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet angledCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'drag-transforms/demos/Angled.svelte',
+                'drag-transforms-angled',
+                'Angled.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#snippet perspectiveSection()}
+    <DragTransformsPerspective />
+{/snippet}
+{#snippet perspectiveNotes()}
+    <ul>
+        <li>
+            <Box />
+            <span>
+                <code>transformPerspective</code> is set on the card itself, so the tilt reads as
+                depth without needing a <code>perspective</code> wrapper around the stage.
+            </span>
+        </li>
+        <li>
+            <Axis3d />
+            <span>
+                <code>whileDrag</code> applies <code>rotateX</code> and <code>rotateY</code> together.
+                Both 3D channels stay composed with the live translation for every frame of the drag.
+            </span>
+        </li>
+        <li>
+            <MousePointer2 />
+            <span>
+                Release and the spring returns the card to flat while it settles back inside the
+                bounds — the tilt unwinds instead of snapping.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet perspectiveCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'drag-transforms/demos/Perspective.svelte',
+                'drag-transforms-perspective',
+                'Perspective.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel={formatSheetLabel(i, sections.length)}
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/drag-transforms/+page.ts
+++ b/docs/src/routes/examples/drag-transforms/+page.ts
@@ -1,0 +1,11 @@
+import type { PageLoad } from './$types'
+
+/**
+ * Loads page metadata for the drag transforms example.
+ * @returns Page metadata with title and description.
+ */
+export const load: PageLoad = () => ({
+    title: 'Drag Transforms',
+    description:
+        'Drag translation composed with authored rotate, skew, perspective, and whileDrag transform channels.'
+})

--- a/e2e/_helpers/transform.ts
+++ b/e2e/_helpers/transform.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 /**
  * Read the rendered `matrix(...)` transform from an element and return the
@@ -59,3 +59,45 @@ export const readDragTranslate = (
 
         return { tx: read('X'), ty: read('Y') }
     }, selector)
+
+/** Await one rendered animation frame. */
+export const nextFrame = (page: Page) =>
+    page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())))
+
+/**
+ * Read the rotation (degrees) of a locator's computed transform via
+ * DOMMatrix decomposition. Handles skewed matrices, unlike the regex parser.
+ */
+export const readRotation = (card: Locator) =>
+    card.evaluate((element) => {
+        const matrix = new DOMMatrixReadOnly(getComputedStyle(element).transform)
+        return (Math.atan2(matrix.b, matrix.a) * 180) / Math.PI
+    })
+
+/** Sample a per-frame reader across `count` consecutive animation frames. */
+export const sampleFrames = async <T>(page: Page, read: () => Promise<T>, count = 8) => {
+    const samples: T[] = []
+    for (let frame = 0; frame < count; frame++) {
+        await nextFrame(page)
+        samples.push(await read())
+    }
+    return samples
+}
+
+/**
+ * Press the pointer at a locator's center and drag 56px right, leaving the
+ * pointer held down. Returns the press origin.
+ */
+export const beginHorizontalDrag = async (page: Page, card: Locator) => {
+    await card.waitFor({ state: 'visible' })
+    await card.scrollIntoViewIfNeeded()
+    const box = await card.boundingBox()
+    if (!box) throw new Error('missing drag-card bounds')
+
+    const x = box.x + box.width / 2
+    const y = box.y + box.height / 2
+    await page.mouse.move(x, y)
+    await page.mouse.down()
+    await page.mouse.move(x + 56, y, { steps: 6 })
+    return { x, y }
+}

--- a/e2e/drag/while-drag-transforms.spec.ts
+++ b/e2e/drag/while-drag-transforms.spec.ts
@@ -1,38 +1,7 @@
-import { expect, test, type Locator, type Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+import { beginHorizontalDrag, readRotation, sampleFrames } from '../_helpers/transform'
 
 const URL = '/tests/drag/while-drag-transforms?@isPlaywright=true'
-
-const nextFrame = (page: Page) =>
-    page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())))
-
-const beginHorizontalDrag = async (page: Page, card: Locator) => {
-    await card.waitFor({ state: 'visible' })
-    await card.scrollIntoViewIfNeeded()
-    const box = await card.boundingBox()
-    if (!box) throw new Error('missing drag-card bounds')
-
-    const x = box.x + box.width / 2
-    const y = box.y + box.height / 2
-    await page.mouse.move(x, y)
-    await page.mouse.down()
-    await page.mouse.move(x + 56, y, { steps: 6 })
-    return { x, y }
-}
-
-const sampleFrames = async <T>(page: Page, read: () => Promise<T>, count = 8) => {
-    const samples: T[] = []
-    for (let frame = 0; frame < count; frame++) {
-        await nextFrame(page)
-        samples.push(await read())
-    }
-    return samples
-}
-
-const readRotation = (card: Locator) =>
-    card.evaluate((element) => {
-        const matrix = new DOMMatrixReadOnly(getComputedStyle(element).transform)
-        return (Math.atan2(matrix.b, matrix.a) * 180) / Math.PI
-    })
 
 test.describe('drag/whileDrag transform composition', () => {
     test.beforeEach(async ({ page }) => {

--- a/e2e/drag/while-drag-transforms.spec.ts
+++ b/e2e/drag/while-drag-transforms.spec.ts
@@ -28,6 +28,12 @@ const sampleFrames = async <T>(page: Page, read: () => Promise<T>, count = 8) =>
     return samples
 }
 
+const readRotation = (card: Locator) =>
+    card.evaluate((element) => {
+        const matrix = new DOMMatrixReadOnly(getComputedStyle(element).transform)
+        return (Math.atan2(matrix.b, matrix.a) * 180) / Math.PI
+    })
+
 test.describe('drag/whileDrag transform composition', () => {
     test.beforeEach(async ({ page }) => {
         await page.goto(URL)
@@ -40,12 +46,7 @@ test.describe('drag/whileDrag transform composition', () => {
 
         try {
             await page.waitForTimeout(120)
-            const rotations = await sampleFrames(page, () =>
-                card.evaluate((element) => {
-                    const matrix = new DOMMatrixReadOnly(getComputedStyle(element).transform)
-                    return (Math.atan2(matrix.b, matrix.a) * 180) / Math.PI
-                })
-            )
+            const rotations = await sampleFrames(page, () => readRotation(card))
 
             expect(rotations).toHaveLength(8)
             expect(
@@ -179,15 +180,7 @@ test.describe('drag/whileDrag transform composition', () => {
         await page.waitForTimeout(120)
         await page.mouse.up()
 
-        const samples = await sampleFrames(
-            page,
-            () =>
-                card.evaluate((element) => {
-                    const matrix = new DOMMatrixReadOnly(getComputedStyle(element).transform)
-                    return (Math.atan2(matrix.b, matrix.a) * 180) / Math.PI
-                }),
-            45
-        )
+        const samples = await sampleFrames(page, () => readRotation(card), 45)
 
         // The restore must be continuous: a settle-to-neutral followed by a
         // snap to the authored angle shows up as a large single-frame jump.

--- a/e2e/drag/while-drag-transforms.spec.ts
+++ b/e2e/drag/while-drag-transforms.spec.ts
@@ -81,6 +81,132 @@ test.describe('drag/whileDrag transform composition', () => {
         }
     })
 
+    test('keeps a whileDrag override composed with an authored style channel', async ({ page }) => {
+        const card = page.getByTestId('authored-rotate-card')
+        const start = await beginHorizontalDrag(page, card)
+
+        try {
+            await page.waitForTimeout(120)
+            const samples = await sampleFrames(page, () =>
+                card.evaluate((element) => {
+                    const matrix = new DOMMatrixReadOnly(getComputedStyle(element).transform)
+                    return {
+                        degrees: (Math.atan2(matrix.b, matrix.a) * 180) / Math.PI,
+                        translateX: matrix.m41
+                    }
+                })
+            )
+
+            expect(samples).toHaveLength(8)
+
+            // whileDrag must win the channel that `style` also authors (-8deg -> 4deg).
+            expect(
+                samples.every(({ degrees }) => Math.abs(degrees - 4) < 1.5),
+                `sampled rotations: ${samples.map(({ degrees }) => degrees.toFixed(2)).join(', ')}`
+            ).toBe(true)
+
+            // ...and the drag translation must still be composed into the same transform.
+            expect(
+                samples.every(({ translateX }) => translateX > 40),
+                `sampled translateX: ${samples.map(({ translateX }) => translateX.toFixed(1)).join(', ')}`
+            ).toBe(true)
+
+            const box = await card.boundingBox()
+            if (!box) throw new Error('missing dragged card bounds')
+            expect(box.x).toBeGreaterThan(start.x - box.width / 2 + 40)
+        } finally {
+            await page.mouse.up()
+        }
+    })
+
+    test('drags under the full gesture stack over authored transform channels', async ({
+        page
+    }) => {
+        const card = page.getByTestId('gesture-stack-card')
+        const before = await card.boundingBox()
+        if (!before) throw new Error('missing pre-drag card bounds')
+
+        await beginHorizontalDrag(page, card)
+
+        try {
+            await page.waitForTimeout(120)
+            const samples = await sampleFrames(page, () =>
+                card.evaluate((element) => {
+                    const raw = getComputedStyle(element).transform
+                    const matrix = new DOMMatrixReadOnly(raw)
+                    return {
+                        raw,
+                        degrees: (Math.atan2(matrix.b, matrix.a) * 180) / Math.PI,
+                        translateX: matrix.m41
+                    }
+                })
+            )
+
+            expect(samples).toHaveLength(8)
+
+            // The composed transform must never collapse to `none`.
+            expect(
+                samples.every(({ raw }) => raw !== 'none'),
+                `sampled transforms: ${samples.map(({ raw }) => raw).join(' | ')}`
+            ).toBe(true)
+
+            // The drag translation must be painted.
+            expect(
+                samples.every(({ translateX }) => translateX > 40),
+                `sampled translateX: ${samples.map(({ translateX }) => translateX.toFixed(1)).join(', ')}`
+            ).toBe(true)
+
+            // whileDrag must win the rotate channel that `style` also authors.
+            expect(
+                samples.every(({ degrees }) => Math.abs(degrees - 4) < 2),
+                `sampled rotations: ${samples.map(({ degrees }) => degrees.toFixed(2)).join(', ')}`
+            ).toBe(true)
+
+            // And the element must have actually moved on screen.
+            const during = await card.boundingBox()
+            if (!during) throw new Error('missing mid-drag card bounds')
+            expect(during.x - before.x).toBeGreaterThan(40)
+        } finally {
+            await page.mouse.up()
+        }
+    })
+
+    test('release restores the authored rotate smoothly, without a settle-then-snap', async ({
+        page
+    }) => {
+        const card = page.getByTestId('gesture-stack-card')
+        await beginHorizontalDrag(page, card)
+        await page.waitForTimeout(120)
+        await page.mouse.up()
+
+        const samples = await sampleFrames(
+            page,
+            () =>
+                card.evaluate((element) => {
+                    const matrix = new DOMMatrixReadOnly(getComputedStyle(element).transform)
+                    return (Math.atan2(matrix.b, matrix.a) * 180) / Math.PI
+                }),
+            45
+        )
+
+        // The restore must be continuous: a settle-to-neutral followed by a
+        // snap to the authored angle shows up as a large single-frame jump.
+        const maxJump = Math.max(...samples.slice(1).map((deg, i) => Math.abs(deg - samples[i])))
+        expect(
+            maxJump,
+            `max single-frame rotation jump: ${maxJump.toFixed(2)}deg — samples: ${samples
+                .map((d) => d.toFixed(1))
+                .join(', ')}`
+        ).toBeLessThan(4)
+
+        // And it must settle on the style-authored angle, not neutral.
+        const settled = samples.at(-1)!
+        expect(
+            Math.abs(settled - -8),
+            `settled rotation: ${settled.toFixed(2)}deg (authored -8deg)`
+        ).toBeLessThan(1.5)
+    })
+
     test('keeps rotateX composed with perspective across live drag frames', async ({ page }) => {
         const card = page.getByTestId('rotate-x-card')
         await beginHorizontalDrag(page, card)

--- a/e2e/drag/while-drag-transforms.spec.ts
+++ b/e2e/drag/while-drag-transforms.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test, type Locator, type Page } from '@playwright/test'
+
+const URL = '/tests/drag/while-drag-transforms?@isPlaywright=true'
+
+const nextFrame = (page: Page) =>
+    page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())))
+
+const beginHorizontalDrag = async (page: Page, card: Locator) => {
+    await card.waitFor({ state: 'visible' })
+    const box = await card.boundingBox()
+    if (!box) throw new Error('missing drag-card bounds')
+
+    const x = box.x + box.width / 2
+    const y = box.y + box.height / 2
+    await page.mouse.move(x, y)
+    await page.mouse.down()
+    await page.mouse.move(x + 56, y, { steps: 6 })
+    return { x, y }
+}
+
+const sampleFrames = async <T>(page: Page, read: () => Promise<T>, count = 8) => {
+    const samples: T[] = []
+    for (let frame = 0; frame < count; frame++) {
+        await nextFrame(page)
+        samples.push(await read())
+    }
+    return samples
+}
+
+test.describe('drag/whileDrag transform composition', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto(URL)
+        await page.getByTestId('rotate-card').waitFor({ state: 'visible' })
+    })
+
+    test('keeps whileDrag rotation composed across live drag frames', async ({ page }) => {
+        const card = page.getByTestId('rotate-card')
+        await beginHorizontalDrag(page, card)
+
+        try {
+            await page.waitForTimeout(120)
+            const rotations = await sampleFrames(page, () =>
+                card.evaluate((element) => {
+                    const matrix = new DOMMatrixReadOnly(getComputedStyle(element).transform)
+                    return (Math.atan2(matrix.b, matrix.a) * 180) / Math.PI
+                })
+            )
+
+            expect(rotations).toHaveLength(8)
+            expect(
+                rotations.every((degrees) => Math.abs(degrees - 8) < 1.5),
+                `sampled rotations: ${rotations.join(', ')}`
+            ).toBe(true)
+        } finally {
+            await page.mouse.up()
+        }
+    })
+
+    test('keeps an x-only drag pinned on y when its layout slot moves', async ({ page }) => {
+        const card = page.getByTestId('cross-axis-card')
+        await beginHorizontalDrag(page, card)
+
+        try {
+            const before = await card.boundingBox()
+            if (!before) throw new Error('missing pre-insertion card bounds')
+
+            await page
+                .getByTestId('insert-above')
+                .evaluate((button: HTMLButtonElement) => button.click())
+            const ySamples = await sampleFrames(page, async () => {
+                const box = await card.boundingBox()
+                if (!box) throw new Error('missing post-insertion card bounds')
+                return box.y
+            })
+
+            const maxDrift = Math.max(...ySamples.map((y) => Math.abs(y - before.y)))
+            expect(maxDrift).toBeLessThanOrEqual(2)
+        } finally {
+            await page.mouse.up()
+        }
+    })
+
+    test('keeps rotateX composed with perspective across live drag frames', async ({ page }) => {
+        const card = page.getByTestId('rotate-x-card')
+        await beginHorizontalDrag(page, card)
+
+        try {
+            await page.waitForTimeout(120)
+            const rotateXTerms = await sampleFrames(page, () =>
+                card.evaluate((element) => {
+                    const matrix = new DOMMatrixReadOnly(getComputedStyle(element).transform)
+                    return {
+                        is2D: matrix.is2D,
+                        m23: Math.abs(matrix.m23)
+                    }
+                })
+            )
+
+            expect(rotateXTerms).toHaveLength(8)
+            expect(rotateXTerms.every(({ is2D }) => !is2D)).toBe(true)
+            expect(
+                rotateXTerms.every(({ m23 }) => m23 > 0.35),
+                `sampled m23 terms: ${rotateXTerms.map(({ m23 }) => m23).join(', ')}`
+            ).toBe(true)
+        } finally {
+            await page.mouse.up()
+        }
+    })
+
+    test('is linked from the root test index', async ({ page }) => {
+        await page.goto('/?@isPlaywright=true')
+        await expect(
+            page.getByRole('link', { name: 'Drag: whileDrag transform composition' })
+        ).toHaveAttribute('href', /\/tests\/drag\/while-drag-transforms/)
+    })
+})

--- a/e2e/drag/while-drag-transforms.spec.ts
+++ b/e2e/drag/while-drag-transforms.spec.ts
@@ -7,6 +7,7 @@ const nextFrame = (page: Page) =>
 
 const beginHorizontalDrag = async (page: Page, card: Locator) => {
     await card.waitFor({ state: 'visible' })
+    await card.scrollIntoViewIfNeeded()
     const box = await card.boundingBox()
     if (!box) throw new Error('missing drag-card bounds')
 

--- a/e2e/drag/while-drag-write-coalescing.spec.ts
+++ b/e2e/drag/while-drag-write-coalescing.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test, type Locator, type Page } from '@playwright/test'
+
+const URL = '/tests/drag/while-drag-transforms?@isPlaywright=true'
+
+const beginHorizontalDrag = async (page: Page, card: Locator) => {
+    await card.waitFor({ state: 'visible' })
+    await card.scrollIntoViewIfNeeded()
+    const box = await card.boundingBox()
+    if (!box) throw new Error('missing drag-card bounds')
+
+    const x = box.x + box.width / 2
+    const y = box.y + box.height / 2
+    await page.mouse.move(x, y)
+    await page.mouse.down()
+    await page.mouse.move(x + 56, y, { steps: 6 })
+}
+
+test.describe('drag/whileDrag write coalescing', () => {
+    test('composes at most one transform write per frame while channel springs animate', async ({
+        page
+    }) => {
+        await page.goto(URL)
+        const card = page.getByTestId('perf-spring-card')
+        await beginHorizontalDrag(page, card)
+
+        try {
+            // Pointer is now held still: every composer write during the window
+            // below is driven by the whileDrag channel springs, not pointermove.
+            // Each full recomposition writes data-svelte-motion-drag-transform,
+            // so attribute mutations count composes exactly.
+            const metrics = await card.evaluate(
+                (element) =>
+                    new Promise<{ frames: number; composes: number; rotationDelta: number }>(
+                        (resolve) => {
+                            let composes = 0
+                            const observer = new MutationObserver((records) => {
+                                composes += records.length
+                            })
+                            observer.observe(element, {
+                                attributes: true,
+                                attributeFilter: ['data-svelte-motion-drag-transform']
+                            })
+
+                            const readRotation = () => {
+                                const matrix = new DOMMatrixReadOnly(
+                                    getComputedStyle(element).transform
+                                )
+                                return (Math.atan2(matrix.b, matrix.a) * 180) / Math.PI
+                            }
+                            const startRotation = readRotation()
+
+                            let frames = 0
+                            const tick = () => {
+                                frames++
+                                if (frames >= 30) {
+                                    composes += observer.takeRecords().length
+                                    observer.disconnect()
+                                    resolve({
+                                        frames,
+                                        composes,
+                                        rotationDelta: Math.abs(readRotation() - startRotation)
+                                    })
+                                    return
+                                }
+                                requestAnimationFrame(tick)
+                            }
+                            requestAnimationFrame(tick)
+                        }
+                    )
+            )
+
+            // Guard against a vacuous pass: the springs must still have been
+            // animating during the measurement window.
+            expect(
+                metrics.rotationDelta,
+                `rotation moved ${metrics.rotationDelta.toFixed(2)}deg during the window`
+            ).toBeGreaterThan(1)
+
+            // Two animated channels (rotate, scale) must not each drive a full
+            // recomposition: one composed write per frame is enough. The 1.25
+            // budget tolerates scheduling jitter, not per-channel duplication.
+            const composesPerFrame = metrics.composes / metrics.frames
+            expect(
+                composesPerFrame,
+                `${metrics.composes} composes over ${metrics.frames} frames = ${composesPerFrame.toFixed(2)} per frame`
+            ).toBeLessThanOrEqual(1.25)
+        } finally {
+            await page.mouse.up()
+        }
+    })
+})

--- a/e2e/drag/while-drag-write-coalescing.spec.ts
+++ b/e2e/drag/while-drag-write-coalescing.spec.ts
@@ -1,19 +1,7 @@
-import { expect, test, type Locator, type Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+import { beginHorizontalDrag } from '../_helpers/transform'
 
 const URL = '/tests/drag/while-drag-transforms?@isPlaywright=true'
-
-const beginHorizontalDrag = async (page: Page, card: Locator) => {
-    await card.waitFor({ state: 'visible' })
-    await card.scrollIntoViewIfNeeded()
-    const box = await card.boundingBox()
-    if (!box) throw new Error('missing drag-card bounds')
-
-    const x = box.x + box.width / 2
-    const y = box.y + box.height / 2
-    await page.mouse.move(x, y)
-    await page.mouse.down()
-    await page.mouse.move(x + 56, y, { steps: 6 })
-}
 
 test.describe('drag/whileDrag write coalescing', () => {
     test('composes at most one transform write per frame while channel springs animate', async ({

--- a/e2e/motion/hover-authored-transforms.spec.ts
+++ b/e2e/motion/hover-authored-transforms.spec.ts
@@ -1,24 +1,7 @@
-import { expect, test, type Locator, type Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+import { readRotation, sampleFrames } from '../_helpers/transform'
 
 const URL = '/tests/motion/hover-authored-transforms?@isPlaywright=true'
-
-const nextFrame = (page: Page) =>
-    page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())))
-
-const readRotation = (card: Locator) =>
-    card.evaluate((element) => {
-        const matrix = new DOMMatrixReadOnly(getComputedStyle(element).transform)
-        return (Math.atan2(matrix.b, matrix.a) * 180) / Math.PI
-    })
-
-const sampleRotations = async (page: Page, card: Locator, count: number) => {
-    const samples: number[] = []
-    for (let frame = 0; frame < count; frame++) {
-        await nextFrame(page)
-        samples.push(await readRotation(card))
-    }
-    return samples
-}
 
 test.describe('motion/whileHover over authored transforms', () => {
     test.beforeEach(async ({ page }) => {
@@ -50,7 +33,7 @@ test.describe('motion/whileHover over authored transforms', () => {
         // Leave: move the pointer well away from the card.
         await page.mouse.move(4, 4)
 
-        const samples = await sampleRotations(page, card, 45)
+        const samples = await sampleFrames(page, () => readRotation(card), 45)
 
         // The restore must be continuous: settling to neutral and then
         // snapping to the authored angle shows up as a single-frame jump.

--- a/e2e/motion/hover-authored-transforms.spec.ts
+++ b/e2e/motion/hover-authored-transforms.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test, type Locator, type Page } from '@playwright/test'
+
+const URL = '/tests/motion/hover-authored-transforms?@isPlaywright=true'
+
+const nextFrame = (page: Page) =>
+    page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())))
+
+const readRotation = (card: Locator) =>
+    card.evaluate((element) => {
+        const matrix = new DOMMatrixReadOnly(getComputedStyle(element).transform)
+        return (Math.atan2(matrix.b, matrix.a) * 180) / Math.PI
+    })
+
+const sampleRotations = async (page: Page, card: Locator, count: number) => {
+    const samples: number[] = []
+    for (let frame = 0; frame < count; frame++) {
+        await nextFrame(page)
+        samples.push(await readRotation(card))
+    }
+    return samples
+}
+
+test.describe('motion/whileHover over authored transforms', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto(URL)
+        await page.getByTestId('hover-authored-rotate-card').waitFor({ state: 'visible' })
+    })
+
+    test('hover-enter animates the authored rotate to the whileHover value', async ({ page }) => {
+        const card = page.getByTestId('hover-authored-rotate-card')
+
+        expect(Math.abs((await readRotation(card)) - -8)).toBeLessThan(1)
+
+        await card.hover()
+        await page.waitForTimeout(600)
+
+        const hovered = await readRotation(card)
+        expect(Math.abs(hovered - 4), `hovered rotation: ${hovered.toFixed(2)}deg`).toBeLessThan(
+            1.5
+        )
+    })
+
+    test('hover-leave restores the authored rotate smoothly, without a settle-then-snap', async ({
+        page
+    }) => {
+        const card = page.getByTestId('hover-authored-rotate-card')
+        await card.hover()
+        await page.waitForTimeout(600)
+
+        // Leave: move the pointer well away from the card.
+        await page.mouse.move(4, 4)
+
+        const samples = await sampleRotations(page, card, 45)
+
+        // The restore must be continuous: settling to neutral and then
+        // snapping to the authored angle shows up as a single-frame jump.
+        const maxJump = Math.max(...samples.slice(1).map((deg, i) => Math.abs(deg - samples[i])))
+        expect(
+            maxJump,
+            `max single-frame rotation jump: ${maxJump.toFixed(2)}deg — samples: ${samples
+                .map((d) => d.toFixed(1))
+                .join(', ')}`
+        ).toBeLessThan(4)
+
+        // And it must settle on the style-authored angle, not neutral.
+        const settled = samples.at(-1)!
+        expect(
+            Math.abs(settled - -8),
+            `settled rotation: ${settled.toFixed(2)}deg (authored -8deg)`
+        ).toBeLessThan(1.5)
+    })
+
+    test('is linked from the root test index', async ({ page }) => {
+        await page.goto('/?@isPlaywright=true')
+        await expect(
+            page.getByRole('link', { name: 'Hover: whileHover over authored transforms' })
+        ).toHaveAttribute('href', /\/tests\/motion\/hover-authored-transforms/)
+    })
+})

--- a/e2e/motion/pan-authored-transforms.spec.ts
+++ b/e2e/motion/pan-authored-transforms.spec.ts
@@ -1,37 +1,7 @@
-import { expect, test, type Locator, type Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+import { beginHorizontalDrag as beginPan, readRotation, sampleFrames } from '../_helpers/transform'
 
 const URL = '/tests/motion/pan-authored-transforms?@isPlaywright=true'
-
-const nextFrame = (page: Page) =>
-    page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())))
-
-const readRotation = (card: Locator) =>
-    card.evaluate((element) => {
-        const matrix = new DOMMatrixReadOnly(getComputedStyle(element).transform)
-        return (Math.atan2(matrix.b, matrix.a) * 180) / Math.PI
-    })
-
-const sampleRotations = async (page: Page, card: Locator, count: number) => {
-    const samples: number[] = []
-    for (let frame = 0; frame < count; frame++) {
-        await nextFrame(page)
-        samples.push(await readRotation(card))
-    }
-    return samples
-}
-
-const beginPan = async (page: Page, card: Locator) => {
-    await card.waitFor({ state: 'visible' })
-    await card.scrollIntoViewIfNeeded()
-    const box = await card.boundingBox()
-    if (!box) throw new Error('missing pan-card bounds')
-
-    const x = box.x + box.width / 2
-    const y = box.y + box.height / 2
-    await page.mouse.move(x, y)
-    await page.mouse.down()
-    await page.mouse.move(x + 56, y, { steps: 6 })
-}
 
 test.describe('motion/whilePan over authored transforms', () => {
     test.beforeEach(async ({ page }) => {
@@ -65,7 +35,7 @@ test.describe('motion/whilePan over authored transforms', () => {
         await page.waitForTimeout(600)
         await page.mouse.up()
 
-        const samples = await sampleRotations(page, card, 45)
+        const samples = await sampleFrames(page, () => readRotation(card), 45)
 
         // The restore must be continuous: settling to neutral and then
         // snapping to the authored angle shows up as a single-frame jump.

--- a/e2e/motion/pan-authored-transforms.spec.ts
+++ b/e2e/motion/pan-authored-transforms.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test, type Locator, type Page } from '@playwright/test'
+
+const URL = '/tests/motion/pan-authored-transforms?@isPlaywright=true'
+
+const nextFrame = (page: Page) =>
+    page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())))
+
+const readRotation = (card: Locator) =>
+    card.evaluate((element) => {
+        const matrix = new DOMMatrixReadOnly(getComputedStyle(element).transform)
+        return (Math.atan2(matrix.b, matrix.a) * 180) / Math.PI
+    })
+
+const sampleRotations = async (page: Page, card: Locator, count: number) => {
+    const samples: number[] = []
+    for (let frame = 0; frame < count; frame++) {
+        await nextFrame(page)
+        samples.push(await readRotation(card))
+    }
+    return samples
+}
+
+const beginPan = async (page: Page, card: Locator) => {
+    await card.waitFor({ state: 'visible' })
+    await card.scrollIntoViewIfNeeded()
+    const box = await card.boundingBox()
+    if (!box) throw new Error('missing pan-card bounds')
+
+    const x = box.x + box.width / 2
+    const y = box.y + box.height / 2
+    await page.mouse.move(x, y)
+    await page.mouse.down()
+    await page.mouse.move(x + 56, y, { steps: 6 })
+}
+
+test.describe('motion/whilePan over authored transforms', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto(URL)
+        await page.getByTestId('pan-authored-rotate-card').waitFor({ state: 'visible' })
+    })
+
+    test('pan-start animates the authored rotate to the whilePan value', async ({ page }) => {
+        const card = page.getByTestId('pan-authored-rotate-card')
+
+        expect(Math.abs((await readRotation(card)) - -8)).toBeLessThan(1)
+
+        await beginPan(page, card)
+        try {
+            await page.waitForTimeout(600)
+            const panning = await readRotation(card)
+            expect(
+                Math.abs(panning - 4),
+                `panning rotation: ${panning.toFixed(2)}deg`
+            ).toBeLessThan(1.5)
+        } finally {
+            await page.mouse.up()
+        }
+    })
+
+    test('pan-end restores the authored rotate smoothly, without a settle-then-snap', async ({
+        page
+    }) => {
+        const card = page.getByTestId('pan-authored-rotate-card')
+        await beginPan(page, card)
+        await page.waitForTimeout(600)
+        await page.mouse.up()
+
+        const samples = await sampleRotations(page, card, 45)
+
+        // The restore must be continuous: settling to neutral and then
+        // snapping to the authored angle shows up as a single-frame jump.
+        const maxJump = Math.max(...samples.slice(1).map((deg, i) => Math.abs(deg - samples[i])))
+        expect(
+            maxJump,
+            `max single-frame rotation jump: ${maxJump.toFixed(2)}deg — samples: ${samples
+                .map((d) => d.toFixed(1))
+                .join(', ')}`
+        ).toBeLessThan(4)
+
+        // And it must settle on the style-authored angle, not neutral.
+        const settled = samples.at(-1)!
+        expect(
+            Math.abs(settled - -8),
+            `settled rotation: ${settled.toFixed(2)}deg (authored -8deg)`
+        ).toBeLessThan(1.5)
+    })
+
+    test('is linked from the root test index', async ({ page }) => {
+        await page.goto('/?@isPlaywright=true')
+        await expect(
+            page.getByRole('link', { name: 'Pan: whilePan over authored transforms' })
+        ).toHaveAttribute('href', /\/tests\/motion\/pan-authored-transforms/)
+    })
+})

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -28,10 +28,12 @@
     import { animate, type AnimationOptions, type DOMKeyframesDefinition } from 'motion'
     import {
         animateSingleValue,
+        isMotionValue,
         motionValue,
         readTransformValue,
         styleEffect,
         svgEffect,
+        transformProps,
         type MotionValue,
         type ValueAnimationTransition
     } from 'motion-dom'
@@ -325,12 +327,22 @@
 
     const serializedStyleProp = $derived(serializeMotionStyle(styleProp, transformTemplateProp))
     const userBaseTransform = $derived(extractTransform(styleProp))
+    const getStyleTransformValues = () => {
+        if (!styleProp || typeof styleProp !== 'object' || Array.isArray(styleProp)) return {}
+
+        const values: Record<string, string | number> = {}
+        for (const [key, source] of Object.entries(styleProp)) {
+            if (!transformProps.has(key)) continue
+            const value = isMotionValue(source) ? source.get() : source
+            if (typeof value === 'string' || typeof value === 'number') values[key] = value
+        }
+        return values
+    }
     let liveGestureTransform = $state<string | null>(null)
+    let liveGestureTransformValues: Record<string, string | number> | null = null
     const liveGestureComposedTransform = $derived.by(() => {
         if (!liveGestureTransform) return null
-
-        const { transform } = splitSerializedTransform(serializedStyleProp)
-        return [liveGestureTransform, transform].filter(Boolean).join(' ')
+        return liveGestureTransform
     })
     const serializedStyleWithLiveGestureTransform = $derived.by(() => {
         if (!liveGestureComposedTransform) return serializedStyleProp
@@ -1583,7 +1595,8 @@
                 if (styleValues.x) bound.x = styleValues.x as MotionValue<number>
                 if (styleValues.y) bound.y = styleValues.y as MotionValue<number>
                 return bound.x || bound.y ? bound : undefined
-            })()
+            })(),
+            getBaseTransformValues: getStyleTransformValues
         }))
         const opts = {
             axis,
@@ -1604,12 +1617,15 @@
                 onTransitionEnd: () => {
                     onDragTransitionEndProp?.()
                 },
-                onVisualUpdate: (transform: string) => {
+                onVisualUpdate: (transform: string, values: Record<string, string | number>) => {
                     liveGestureTransform = transform || null
+                    liveGestureTransformValues = { ...values }
                 }
             },
             baselineSources: dragRuntimeOptions.baselineSources,
-            getBaseTransform: () => splitSerializedTransform(serializedStyleProp).transform,
+            getBaseTransformValues: dragRuntimeOptions.getBaseTransformValues,
+            getBaseTransform: () => userBaseTransform,
+            transformTemplate: transformTemplateProp,
             propagation: !!dragPropagationProp,
             snapToOrigin: dragSnapToOriginProp,
             boundMotionValues: dragRuntimeOptions.boundMotionValues
@@ -2493,6 +2509,12 @@
             {
                 initial: (resolvedInitial ?? {}) as Record<string, unknown>,
                 animate: (resolvedAnimate ?? {}) as Record<string, unknown>
+            },
+            {
+                getBaseTransformValues: getStyleTransformValues,
+                getLiveTransformValues: () => liveGestureTransformValues,
+                getBaseTransform: () => userBaseTransform,
+                transformTemplate: transformTemplateProp
             }
         )
     })

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -340,22 +340,18 @@
     }
     let liveGestureTransform = $state<string | null>(null)
     let liveGestureTransformValues: Record<string, string | number> | null = null
-    const liveGestureComposedTransform = $derived.by(() => {
-        if (!liveGestureTransform) return null
-        return liveGestureTransform
-    })
     const serializedStyleWithLiveGestureTransform = $derived.by(() => {
-        if (!liveGestureComposedTransform) return serializedStyleProp
+        if (!liveGestureTransform) return serializedStyleProp
 
         const { rest } = splitSerializedTransform(serializedStyleProp)
-        return `${rest}${rest ? '; ' : ''}transform: ${liveGestureComposedTransform}`
+        return `${rest}${rest ? '; ' : ''}transform: ${liveGestureTransform}`
     })
 
     $effect(() => {
-        if (!element || !liveGestureComposedTransform) return
-        if (element.style.transform === liveGestureComposedTransform) return
+        if (!element || !liveGestureTransform) return
+        if (element.style.transform === liveGestureTransform) return
 
-        element.style.transform = liveGestureComposedTransform
+        element.style.transform = liveGestureTransform
     })
 
     const projectionParent = getProjectionParent()
@@ -1619,7 +1615,8 @@
                 },
                 onVisualUpdate: (transform: string, values: Record<string, string | number>) => {
                     liveGestureTransform = transform || null
-                    liveGestureTransformValues = { ...values }
+                    // `values` is freshly allocated per composer frame, so no copy.
+                    liveGestureTransformValues = values
                 }
             },
             baselineSources: dragRuntimeOptions.baselineSources,

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -1712,7 +1712,8 @@
                 whilePanBaseline = computeHoverBaseline(element, {
                     initial: initialKeyframes ?? {},
                     animate: (resolvedAnimate ?? {}) as Record<string, unknown>,
-                    whileHover: (resolvedWhilePan ?? {}) as Record<string, unknown>
+                    whileHover: (resolvedWhilePan ?? {}) as Record<string, unknown>,
+                    baseValues: getStyleTransformValues()
                 })
                 const { keyframes, transition } = splitHoverDefinition(
                     resolvedWhilePan as Record<string, unknown>

--- a/src/lib/utils/drag.spec.ts
+++ b/src/lib/utils/drag.spec.ts
@@ -1,5 +1,6 @@
+import { motionValue } from 'motion-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { applyElastic, attachDrag, resolveConstraints } from './drag.js'
+import { applyElastic, attachDrag, buildDragTransform, resolveConstraints } from './drag.js'
 
 vi.mock('motion', () => {
     const animateMock = vi.fn(() => ({ finished: Promise.resolve() }))
@@ -24,6 +25,46 @@ describe('utils/drag', () => {
     it('resolveConstraints: pixel object passthrough', () => {
         const c = resolveConstraints(null, { top: -10, left: -5, right: 5, bottom: 10 })
         expect(c).toMatchObject({ top: -10, left: -5, right: 5, bottom: 10 })
+    })
+
+    it('builds live drag transforms in upstream channel order', () => {
+        expect(buildDragTransform({ skewX: 3, rotate: 8, x: 20 })).toBe(
+            'translateX(20px) rotate(8deg) skewX(3deg)'
+        )
+    })
+
+    it('passes live drag values through transformTemplate', () => {
+        let received: Record<string, string | number> = {}
+        const transform = buildDragTransform({ x: 20, rotateX: 30 }, '', (latest, generated) => {
+            received = { ...latest }
+            return `perspective(600px) ${generated}`
+        })
+
+        expect(received).toMatchObject({ x: '20px', rotateX: '30deg' })
+        expect(transform).toBe('perspective(600px) translateX(20px) rotateX(30deg)')
+    })
+
+    it('leaves transform rendering to a bound MotionValue when no other channel is active', () => {
+        const el = document.createElement('div')
+        el.style.transform = 'rotate(12deg)'
+        document.body.appendChild(el)
+        const x = motionValue(0)
+        const cleanup = attachDrag(el, {
+            axis: 'x',
+            mergedTransition: { duration: 0 },
+            boundMotionValues: { x }
+        })
+
+        el.dispatchEvent(
+            new PointerEvent('pointerdown', { clientX: 10, clientY: 10, pointerId: 1 })
+        )
+        window.dispatchEvent(
+            new PointerEvent('pointermove', { clientX: 25, clientY: 10, pointerId: 1 })
+        )
+
+        expect(x.get()).toBe(15)
+        expect(el.style.transform).toBe('rotate(12deg)')
+        cleanup()
     })
 
     it('attachDrag: attaches pointerdown and animates during move', () => {

--- a/src/lib/utils/drag.spec.ts
+++ b/src/lib/utils/drag.spec.ts
@@ -65,6 +65,7 @@ describe('utils/drag', () => {
         expect(x.get()).toBe(15)
         expect(el.style.transform).toBe('rotate(12deg)')
         cleanup()
+        el.remove()
     })
 
     it('attachDrag: attaches pointerdown and animates during move', () => {

--- a/src/lib/utils/drag.ts
+++ b/src/lib/utils/drag.ts
@@ -715,11 +715,18 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
         stopTransformAnimation(key)
         const baseValues = opts.getBaseTransformValues?.() ?? {}
         const neutral = key.startsWith('scale') ? 1 : 0
-        const current =
+        // Seed with the same value type as the normalized target. Style-authored
+        // channels arrive as raw numbers, but the target above is typed (4 ->
+        // '4deg'); spring generators emit NaN when asked to animate a raw number
+        // into a unit string, and one NaN channel invalidates the entire
+        // composed transform ('rotate(NaNdeg)' -> the browser drops the write).
+        const current = getValueAsType(
             gestureTransformValues[key] ??
-            restingTransformValues[key] ??
-            baseValues[key] ??
-            getValueAsType(neutral, numberValueTypes[key])
+                restingTransformValues[key] ??
+                baseValues[key] ??
+                neutral,
+            numberValueTypes[key]
+        ) as AnyResolvedKeyframe
         const value = motionValue<AnyResolvedKeyframe>(current)
         gestureTransformValues[key] = current
         const unsubscribe = value.on('change', (latest) => {
@@ -794,6 +801,15 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
             animate: opts.baselineSources?.animate,
             whileHover: (opts.whileDrag ?? {}) as Record<string, unknown>
         })
+        // computeHoverBaseline cannot see style-authored transform channels and
+        // neutral-defaults them (rotate -> 0), so release would settle to
+        // neutral and then snap once the composer hands the channel back to
+        // the authored style. Restore those channels to their style values.
+        const styleBase = opts.getBaseTransformValues?.() ?? {}
+        for (const key of Object.keys(whileDragBaseline)) {
+            if (restingTransformValues[key] !== undefined) continue
+            if (styleBase[key] !== undefined) whileDragBaseline[key] = styleBase[key]
+        }
         const { keyframes, transition } = splitHoverDefinition(
             opts.whileDrag as Record<string, unknown>
         )

--- a/src/lib/utils/drag.ts
+++ b/src/lib/utils/drag.ts
@@ -729,9 +729,13 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
         ) as AnyResolvedKeyframe
         const value = motionValue<AnyResolvedKeyframe>(current)
         gestureTransformValues[key] = current
+        // Record only: the transform composer's frame loop is the single
+        // writer and repaints the latest channel values once per frame.
+        // Composing here as well multiplies the per-frame work by the number
+        // of animated channels (N getBaseTransformValues() scans + N
+        // buildTransform calls per frame).
         const unsubscribe = value.on('change', (latest) => {
             gestureTransformValues[key] = latest
-            setXYImmediate(applied.x, applied.y)
         })
         transformAnimations.set(key, { value, unsubscribe })
         setXYImmediate(applied.x, applied.y)

--- a/src/lib/utils/drag.ts
+++ b/src/lib/utils/drag.ts
@@ -31,8 +31,30 @@ import {
 } from '$lib/utils/dragMath'
 import { deriveBoundaryPhysics } from '$lib/utils/dragParams'
 import { computeHoverBaseline, splitHoverDefinition } from '$lib/utils/hover'
+import {
+    buildGestureTransform,
+    collectGestureTransformValues as collectTransformValues,
+    splitGestureTransformValues as splitTransformValues,
+    type GestureTransformValues as DragTransformValues
+} from '$lib/utils/transformComposer'
 import { animate, type AnimationOptions, type DOMKeyframesDefinition } from 'motion'
-import { animateValue, type AnimationPlaybackControlsWithThen, type MotionValue } from 'motion-dom'
+import {
+    animateMotionValue,
+    animateValue,
+    getValueAsType,
+    motionValue,
+    numberValueTypes,
+    type AnimationPlaybackControlsWithThen,
+    type AnyResolvedKeyframe,
+    type MotionValue,
+    type TransformTemplate,
+    type ValueAnimationTransition
+} from 'motion-dom'
+
+/**
+ * Drag-specific alias for the shared gesture transform writer.
+ */
+export const buildDragTransform = buildGestureTransform
 
 type Rect = {
     top: number
@@ -77,10 +99,12 @@ export type AttachDragOptions = {
         onEnd?: (e: PointerEvent, info: DragInfo) => void
         onDirectionLock?: (axis: 'x' | 'y') => void
         onTransitionEnd?: () => void
-        onVisualUpdate?: (transform: string) => void
+        onVisualUpdate?: (transform: string, values: DragTransformValues) => void
     }
     baselineSources?: { initial?: Record<string, unknown>; animate?: Record<string, unknown> }
+    getBaseTransformValues?: () => DragTransformValues
     getBaseTransform?: () => string
+    transformTemplate?: TransformTemplate
     propagation?: boolean
     snapToOrigin?: boolean | 'x' | 'y'
     /**
@@ -393,6 +417,18 @@ export type AttachDragCleanup = (() => void) & {
  */
 const sessionListenerOptions: AddEventListenerOptions = { passive: true, capture: true }
 
+const addPixelOffset = (
+    value: AnyResolvedKeyframe | undefined,
+    offset: number
+): AnyResolvedKeyframe => {
+    if (value === undefined || value === 0 || value === '0' || value === '0px') return offset
+    if (typeof value === 'number') return value + offset
+
+    const pxValue = value.match(/^(-?(?:\d+(?:\.\d+)?|\.\d+))px$/)
+    if (pxValue) return `${Number.parseFloat(pxValue[1]) + offset}px`
+    return `calc(${value} + ${offset}px)`
+}
+
 export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDragCleanup => {
     const EL_ID = el.getAttribute('data-testid') || el.id || el.tagName
     pwLog('[drag] attach', {
@@ -444,13 +480,21 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
     let history: Array<{ x: number; y: number; t: number }> = []
 
     let whileDragBaseline: Record<string, unknown> | null = null
+    const restingTransformValues: DragTransformValues = {
+        ...collectTransformValues(opts.baselineSources?.initial),
+        ...collectTransformValues(opts.baselineSources?.animate)
+    }
+    const gestureTransformValues: DragTransformValues = {}
+    const crossAxisOffset = { x: 0, y: 0 }
+    const transformAnimations = new Map<
+        string,
+        { value: MotionValue<AnyResolvedKeyframe>; unsubscribe: () => void }
+    >()
     let transformComposerRaf = 0
     let transformComposerActive = false
     let postReleaseAnimationActive = false
     let whileDragRestoreActive = false
-    let managedScaleActive = false
-    let managedScale = 1
-    let scaleAnimation: AnimationPlaybackControlsWithThen | null = null
+    let whileDragAnimationGeneration = 0
     let stopInertia: (() => void) | null = null
 
     const markDragTransformActive = (active: boolean) => {
@@ -532,60 +576,71 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
             : null
 
     /**
-     * Write absolute element-space translation by mutating
-     * `el.style.transform` DIRECTLY — no `animate()`, no epsilon skip,
-     * no Playwright retry. The translate channel is rewritten while any
-     * non-translate transform the element already carries (e.g. a
-     * `whileDrag` scale) is preserved as a suffix.
+     * Write the complete live transform directly and synchronously.
      *
-     * Why this exists separately from `setXY`: routing through
-     * `animate(el, _, { duration: 0 })` defers the write to Motion's
-     * scheduler, costing ~1 frame before the new position paints. For
-     * the projection-driven origin compensation (where a layout swap
-     * must keep the dragged element under the cursor in the SAME frame
-     * the swap commits), that frame of lag manifests as a visible
-     * wobble. This path lands synchronously. See #379 / the
-     * `adjustOrigin` hook below.
+     * Drag translation, projection compensation, style/animate baselines,
+     * and active gesture transforms all flow through motion-dom's canonical
+     * `buildTransform` ordering. The synchronous + microtask + rAF writes are
+     * intentional: projection compensation must paint in the same frame as a
+     * layout swap (#379), while the follow-up writes win races with reactive
+     * style effects without adding pointer lag.
      */
     const setXYImmediate = (x: number, y: number) => {
-        // An axis backed by a bound MotionValue is rendered through motion-dom's
-        // styleEffect (and reflected in `getBaseTransform()`). Emitting a translate
-        // for it here too would apply the offset twice (#421), so only non-bound
-        // axes get the synchronous, no-lag translate write (#379).
-        const parts: string[] = []
-        if (dragX && !boundX) parts.push(`translateX(${x}px)`)
-        if (dragY && !boundY) parts.push(`translateY(${y}px)`)
-        const scalePart =
-            managedScaleActive && Math.abs(managedScale - 1) > 0.0001
-                ? `scale(${managedScale})`
-                : ''
-        const liveTransform = [...parts, scalePart].filter(Boolean).join(' ')
+        if (dragX) applied.x = x
+        if (dragY) applied.y = y
 
-        // `liveTransform` is empty only when every dragged axis is
-        // MotionValue-backed and there's no managed scale — i.e. nothing here to
-        // write, so styleEffect owns the transform and writing an empty/stale
-        // value would clobber it (#421). Otherwise this is the unchanged no-lag
-        // write path (#379) — note a no-bound drag always has a translate, so
-        // `liveTransform` is non-empty and the write always runs.
-        if (liveTransform) {
-            el.dataset.svelteMotionDragTransform = liveTransform
+        // Bound MotionValues remain the public source of truth (#421). Update
+        // them before reading base transform values so the full composer sees
+        // the same value that styleEffect will render.
+        if (boundX && boundX.get() !== x) boundX.set(x)
+        if (boundY && boundY.get() !== y) boundY.set(y)
+
+        const latestValues: DragTransformValues = {
+            ...(opts.getBaseTransformValues?.() ?? {}),
+            ...restingTransformValues,
+            ...gestureTransformValues
+        }
+
+        // Unbound drag axes are offsets from their authored/resting channel.
+        // Bound axes are already represented by getBaseTransformValues().
+        if (dragX && !boundX) latestValues.x = addPixelOffset(latestValues.x, x)
+        if (dragY && !boundY) latestValues.y = addPixelOffset(latestValues.y, y)
+        if (!dragX && crossAxisOffset.x) {
+            latestValues.x = addPixelOffset(latestValues.x, crossAxisOffset.x)
+        }
+        if (!dragY && crossAxisOffset.y) {
+            latestValues.y = addPixelOffset(latestValues.y, crossAxisOffset.y)
+        }
+
+        // Preserve the bound-MotionValue empty writer branch: when every drag
+        // axis is styleEffect-owned and no gesture/projection channel is active,
+        // there is nothing for this synchronous path to paint (#421).
+        const shouldWrite =
+            (dragX && !boundX) ||
+            (dragY && !boundY) ||
+            crossAxisOffset.x !== 0 ||
+            crossAxisOffset.y !== 0 ||
+            Object.keys(gestureTransformValues).length > 0
+
+        let composedTransform = ''
+        if (shouldWrite) {
+            composedTransform =
+                buildDragTransform(
+                    latestValues,
+                    opts.getBaseTransform?.() ?? '',
+                    opts.transformTemplate
+                ) || 'none'
+            el.dataset.svelteMotionDragTransform = composedTransform
             const writeComposedTransform = () => {
-                if (el.dataset.svelteMotionDragTransform !== liveTransform) return
-                const baseTransform = opts.getBaseTransform?.() ?? ''
-                el.style.transform = [liveTransform, baseTransform].filter(Boolean).join(' ')
+                if (el.dataset.svelteMotionDragTransform !== composedTransform) return
+                el.style.transform = composedTransform
             }
 
             writeComposedTransform()
             queueMicrotask(writeComposedTransform)
             requestAnimationFrame(writeComposedTransform)
         }
-        if (dragX) applied.x = x
-        if (dragY) applied.y = y
-        // Dual-write the bound MotionValue(s) so `y.get()`, `style={{ y }}`, and a
-        // follow-up `animate(y, …)` stay in sync with the drag (#421).
-        if (boundX && boundX.get() !== x) boundX.set(x)
-        if (boundY && boundY.get() !== y) boundY.set(y)
-        opts.callbacks?.onVisualUpdate?.(liveTransform)
+        opts.callbacks?.onVisualUpdate?.(composedTransform, latestValues)
     }
 
     const startTransformComposer = () => {
@@ -619,62 +674,69 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
         })
     }
 
-    const readCurrentScale = () => {
-        const transform = getComputedStyle(el).transform
-        if (!transform || transform === 'none') return 1
-        const matrix = transform.match(/matrix\(([^)]+)\)/)
-        if (!matrix) return 1
-        const [a, b] = matrix[1]
-            .split(',')
-            .map((part) => Number.parseFloat(part.trim()))
-            .slice(0, 2)
-        if (!Number.isFinite(a)) return 1
-        if (!Number.isFinite(b)) return a
-        return Math.hypot(a, b)
+    const stopTransformAnimation = (key: string) => {
+        const active = transformAnimations.get(key)
+        if (!active) return
+        active.value.stop()
+        active.unsubscribe()
+        transformAnimations.delete(key)
     }
 
-    const animateManagedScale = (
+    const stopTransformAnimations = () => {
+        for (const key of [...transformAnimations.keys()]) stopTransformAnimation(key)
+    }
+
+    const normalizeTransformTarget = (
+        key: string,
+        target: unknown
+    ): AnyResolvedKeyframe | Array<AnyResolvedKeyframe | null> | undefined => {
+        const normalize = (value: unknown): AnyResolvedKeyframe | null | undefined => {
+            if (value === null) return null
+            if (typeof value !== 'string' && typeof value !== 'number') return undefined
+            const typedValue: unknown = getValueAsType(value, numberValueTypes[key])
+            return typeof typedValue === 'string' || typeof typedValue === 'number'
+                ? typedValue
+                : value
+        }
+
+        if (!Array.isArray(target)) return normalize(target) ?? undefined
+        const keyframes = target.map(normalize).filter((value) => value !== undefined)
+        return keyframes.length ? keyframes : undefined
+    }
+
+    const startTransformAnimation = (
+        key: string,
         target: unknown,
-        transition: AnimationOptions | undefined,
-        onComplete?: () => void
-    ) => {
-        const targetScale = Number(Array.isArray(target) ? target[target.length - 1] : target)
-        if (!Number.isFinite(targetScale)) {
-            onComplete?.()
-            return null
-        }
+        transition: AnimationOptions | undefined
+    ): AnimationPlaybackControlsWithThen | null => {
+        const normalizedTarget = normalizeTransformTarget(key, target)
+        if (normalizedTarget === undefined) return null
 
-        scaleAnimation?.stop()
-        managedScaleActive = true
-        managedScale = readCurrentScale()
-        const valueTransition = {
-            ...((transition ?? mergedTransition ?? {}) as Record<string, unknown>)
-        }
-        if (typeof valueTransition.duration === 'number') {
-            valueTransition.duration = valueTransition.duration * 1000
-        }
-        if (typeof valueTransition.delay === 'number') {
-            valueTransition.delay = valueTransition.delay * 1000
-        }
-        if (typeof valueTransition.repeatDelay === 'number') {
-            valueTransition.repeatDelay = valueTransition.repeatDelay * 1000
-        }
-
-        const controls = animateValue({
-            ...valueTransition,
-            keyframes: [managedScale, targetScale],
-            onUpdate: (value: number) => {
-                managedScale = value
-                setXYImmediate(applied.x, applied.y)
-            },
-            onComplete: () => {
-                managedScale = targetScale
-                setXYImmediate(applied.x, applied.y)
-                onComplete?.()
-            }
+        stopTransformAnimation(key)
+        const baseValues = opts.getBaseTransformValues?.() ?? {}
+        const neutral = key.startsWith('scale') ? 1 : 0
+        const current =
+            gestureTransformValues[key] ??
+            restingTransformValues[key] ??
+            baseValues[key] ??
+            getValueAsType(neutral, numberValueTypes[key])
+        const value = motionValue<AnyResolvedKeyframe>(current)
+        gestureTransformValues[key] = current
+        const unsubscribe = value.on('change', (latest) => {
+            gestureTransformValues[key] = latest
+            setXYImmediate(applied.x, applied.y)
         })
-        scaleAnimation = controls
-        return controls
+        transformAnimations.set(key, { value, unsubscribe })
+        setXYImmediate(applied.x, applied.y)
+        void value.start(
+            animateMotionValue(
+                key,
+                value,
+                normalizedTarget,
+                (transition ?? mergedTransition) as unknown as ValueAnimationTransition
+            )
+        )
+        return value.animation ?? null
     }
 
     /**
@@ -712,20 +774,20 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
         // slot can shift on either axis.
         origin.x += dx
         origin.y += dy
-        // The VISUAL write is `setXYImmediate`, which only writes the axis
-        // this drag manages (`opts.axis`). For the dragged axis that pins
-        // the element same-frame; the cross-axis case (e.g. drag="x" + a
-        // y-shift) only updates `origin`, not the transform. Fully
-        // rendering cross-axis compensation needs to route through the
-        // Motion value the move path uses (a direct write here would be
-        // wiped by the next `setXY`), so it's finalized when this hook is
-        // wired in #310. The common Reorder case (drag axis === the shift
-        // axis) is fully compensated today.
-        setXYImmediate(applied.x + dx, applied.y + dy)
+        // Dragged axes update their gesture offset. Non-dragged axes retain a
+        // dedicated projection offset in the shared transform map, so a
+        // drag="x" item remains pinned when its layout slot moves on y (and
+        // vice versa). Every composer frame now paints both kinds of delta.
+        if (!dragX) crossAxisOffset.x += dx
+        if (!dragY) crossAxisOffset.y += dy
+        setXYImmediate(applied.x + (dragX ? dx : 0), applied.y + (dragY ? dy : 0))
     }
 
     const startWhileDrag = () => {
         if (!opts.whileDrag) return
+        whileDragAnimationGeneration++
+        whileDragRestoreActive = false
+        stopTransformAnimations()
         // Baseline restore target: compute from sources
         whileDragBaseline = computeHoverBaseline(el, {
             initial: opts.baselineSources?.initial,
@@ -736,8 +798,10 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
             opts.whileDrag as Record<string, unknown>
         )
         startTransformComposer()
-        const { scale, ...nativeKeyframes } = keyframes
-        if (scale != null) animateManagedScale(scale, transition)
+        const { transform, native: nativeKeyframes } = splitTransformValues(keyframes)
+        for (const [key, target] of Object.entries(transform)) {
+            startTransformAnimation(key, target, transition)
+        }
         if (Object.keys(nativeKeyframes).length > 0) {
             animate(el, nativeKeyframes as DOMKeyframesDefinition, transition ?? mergedTransition)
         }
@@ -750,7 +814,8 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
             return
         }
         whileDragRestoreActive = true
-        const { scale, ...nativeBaseline } = baseline
+        const generation = ++whileDragAnimationGeneration
+        const { transform, native: nativeBaseline } = splitTransformValues(baseline)
         const restore =
             Object.keys(nativeBaseline).length > 0
                 ? animate(el, nativeBaseline as unknown as DOMKeyframesDefinition, mergedTransition)
@@ -758,29 +823,20 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
         whileDragBaseline = null
 
         const finishRestore = () => {
+            if (generation !== whileDragAnimationGeneration) return
+            stopTransformAnimations()
+            for (const key of Object.keys(transform)) delete gestureTransformValues[key]
+            setXYImmediate(applied.x, applied.y)
             whileDragRestoreActive = false
-            if (managedScaleActive && Math.abs(managedScale - 1) <= 0.0001) {
-                managedScale = 1
-                setXYImmediate(applied.x, applied.y)
-                managedScaleActive = false
-            }
             maybeStopTransformComposer()
         }
 
-        const scaleRestore =
-            scale != null || managedScaleActive
-                ? animateManagedScale(scale ?? 1, mergedTransition, () => {
-                      managedScale = Number(scale ?? 1)
-                      if (Math.abs(managedScale - 1) <= 0.0001) {
-                          managedScale = 1
-                          setXYImmediate(applied.x, applied.y)
-                          managedScaleActive = false
-                      }
-                  })
-                : null
-
         const restorePromises: PromiseLike<unknown>[] = []
-        for (const control of [restore, scaleRestore]) {
+        for (const [key, target] of Object.entries(transform)) {
+            const control = startTransformAnimation(key, target, mergedTransition)
+            if (control) restorePromises.push(control.finished)
+        }
+        for (const control of [restore]) {
             if (control && typeof (control as PromiseLike<unknown>).then === 'function') {
                 restorePromises.push(control as PromiseLike<unknown>)
             }
@@ -1459,7 +1515,7 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
         pwLog('[drag] detach', { el: EL_ID })
         markDragTransformActive(false)
         stopTransformComposer()
-        scaleAnimation?.stop()
+        stopTransformAnimations()
         stopConstraintResizeObserver?.()
         el.removeEventListener('pointerdown', onPointerDown)
         el.removeEventListener('pointermove', onPointerMove as EventListener)

--- a/src/lib/utils/drag.ts
+++ b/src/lib/utils/drag.ts
@@ -795,21 +795,15 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
         whileDragAnimationGeneration++
         whileDragRestoreActive = false
         stopTransformAnimations()
-        // Baseline restore target: compute from sources
+        // Baseline restore target: compute from sources. baseValues carries the
+        // style-authored transform channels so release restores to the authored
+        // value instead of settling to neutral and snapping.
         whileDragBaseline = computeHoverBaseline(el, {
             initial: opts.baselineSources?.initial,
             animate: opts.baselineSources?.animate,
-            whileHover: (opts.whileDrag ?? {}) as Record<string, unknown>
+            whileHover: (opts.whileDrag ?? {}) as Record<string, unknown>,
+            baseValues: opts.getBaseTransformValues?.()
         })
-        // computeHoverBaseline cannot see style-authored transform channels and
-        // neutral-defaults them (rotate -> 0), so release would settle to
-        // neutral and then snap once the composer hands the channel back to
-        // the authored style. Restore those channels to their style values.
-        const styleBase = opts.getBaseTransformValues?.() ?? {}
-        for (const key of Object.keys(whileDragBaseline)) {
-            if (restingTransformValues[key] !== undefined) continue
-            if (styleBase[key] !== undefined) whileDragBaseline[key] = styleBase[key]
-        }
         const { keyframes, transition } = splitHoverDefinition(
             opts.whileDrag as Record<string, unknown>
         )
@@ -852,10 +846,8 @@ export const attachDrag = (el: HTMLElement, opts: AttachDragOptions): AttachDrag
             const control = startTransformAnimation(key, target, mergedTransition)
             if (control) restorePromises.push(control.finished)
         }
-        for (const control of [restore]) {
-            if (control && typeof (control as PromiseLike<unknown>).then === 'function') {
-                restorePromises.push(control as PromiseLike<unknown>)
-            }
+        if (restore && typeof (restore as PromiseLike<unknown>).then === 'function') {
+            restorePromises.push(restore as PromiseLike<unknown>)
         }
 
         if (restorePromises.length > 0) {

--- a/src/lib/utils/drag.ts
+++ b/src/lib/utils/drag.ts
@@ -53,6 +53,14 @@ import {
 
 /**
  * Drag-specific alias for the shared gesture transform writer.
+ *
+ * @param latestValues Current transform-channel values.
+ * @param baseTransform An authored raw CSS transform that cannot be represented as channels.
+ * @param transformTemplate Optional user transform template applied to the live values.
+ * @returns The composed CSS transform string.
+ * @example
+ * buildDragTransform({ x: '20px', rotateX: 30 }, '', (_, generated) => `perspective(600px) ${generated}`)
+ * // => 'perspective(600px) translateX(20px) rotateX(30deg)'
  */
 export const buildDragTransform = buildGestureTransform
 

--- a/src/lib/utils/hover.spec.ts
+++ b/src/lib/utils/hover.spec.ts
@@ -18,7 +18,8 @@ const { animate: animateMock } = (await import('motion')) as unknown as {
 // Mock motion-dom.hover
 let hoverCallback: ((element: HTMLElement) => (() => void) | void) | null = null
 let hoverCleanup: (() => void) | null = null
-vi.mock('motion-dom', () => {
+vi.mock('motion-dom', async () => {
+    const actual = await vi.importActual<typeof import('motion-dom')>('motion-dom')
     const hoverMock = vi.fn(
         (el: HTMLElement, callback: (element: HTMLElement) => (() => void) | void) => {
             hoverCallback = callback
@@ -42,7 +43,7 @@ vi.mock('motion-dom', () => {
             return { stop: vi.fn(), then: vi.fn() }
         }
     )
-    return { animateValue: animateValueMock, hover: hoverMock }
+    return { ...actual, animateValue: animateValueMock, hover: hoverMock }
 })
 
 describe('utils/hover', () => {
@@ -212,6 +213,41 @@ describe('utils/hover', () => {
         hoverEnd!()
         await Promise.resolve()
         expect(onEnd).toHaveBeenCalledOnce()
+        cleanup()
+    })
+
+    it('attachWhileHover: preserves a pre-existing rotateX while animating scale', () => {
+        const el = document.createElement('div')
+        el.style.transform = 'rotateX(30deg)'
+        const cleanup = attachWhileHover(el, { scale: 1.2 }, { duration: 0 })
+
+        const hoverEnd = hoverCallback!(el)
+        expect(el.style.transform).toBe('scale(1.2) rotateX(30deg)')
+
+        hoverEnd?.()
+        expect(el.style.transform).toBe('rotateX(30deg)')
+        cleanup()
+    })
+
+    it('attachWhileHover: preserves settled drag channels when hover ends', () => {
+        const el = document.createElement('div')
+        const liveDrag = { x: 199, y: 120, rotate: 12 }
+        const cleanup = attachWhileHover(
+            el,
+            { scale: 1.02 },
+            { duration: 0 },
+            undefined,
+            undefined,
+            { getLiveTransformValues: () => liveDrag }
+        )
+
+        const hoverEnd = hoverCallback!(el)
+        expect(el.style.transform).toBe(
+            'translateX(199px) translateY(120px) scale(1.02) rotate(12deg)'
+        )
+
+        hoverEnd?.()
+        expect(el.style.transform).toBe('translateX(199px) translateY(120px) rotate(12deg)')
         cleanup()
     })
 

--- a/src/lib/utils/hover.ts
+++ b/src/lib/utils/hover.ts
@@ -74,11 +74,15 @@ const toMillisecondsTransition = (
 /**
  * Compute the baseline values to restore to on hover end.
  *
- * Preference order per key: `animate` → `initial` → neutral transform defaults
- * → computed style value if present.
+ * Preference order per key: `animate` → `initial` → style-authored base values
+ * → neutral transform defaults → computed style value if present.
  *
  * @param el Target element.
- * @param opts Source records for baseline computation.
+ * @param opts Source records for baseline computation. `baseValues` carries
+ * style-authored transform channels, which this function cannot read from the
+ * element itself; without them a style-authored channel (e.g. rotate) would
+ * neutral-default and the gesture would settle to neutral, then snap once the
+ * authored style repaints.
  * @return Minimal baseline record to restore on hover end.
  */
 export const computeHoverBaseline = (
@@ -87,11 +91,13 @@ export const computeHoverBaseline = (
         initial?: Record<string, unknown>
         animate?: Record<string, unknown>
         whileHover?: Record<string, unknown>
+        baseValues?: Record<string, unknown>
     }
 ): Record<string, unknown> => {
     const baseline: Record<string, unknown> = {}
     const initialRecord = opts.initial ?? {}
     const animateRecord = opts.animate ?? {}
+    const baseValuesRecord = opts.baseValues ?? {}
     const whileHoverRecordRaw = opts.whileHover ?? {}
     const whileHoverRecord = { ...whileHoverRecordRaw } as Record<string, unknown>
     delete whileHoverRecord.transition
@@ -143,6 +149,8 @@ export const computeHoverBaseline = (
             baseline[key] = animateRecord[key]
         } else if (Object.prototype.hasOwnProperty.call(initialRecord, key)) {
             baseline[key] = initialRecord[key]
+        } else if (baseValuesRecord[key] !== undefined) {
+            baseline[key] = baseValuesRecord[key]
         } else if (key in neutralTransformDefaults) {
             baseline[key] = neutralTransformDefaults[key]
         } else {
@@ -255,18 +263,10 @@ export const attachWhileHover = (
         hoverBaseline = computeHoverBaseline(el, {
             initial: baselineSources?.initial,
             animate: baselineSources?.animate,
-            whileHover
+            whileHover,
+            baseValues: transformComposer?.getBaseTransformValues?.()
         })
-        // computeHoverBaseline cannot see style-authored transform channels and
-        // neutral-defaults them (rotate -> 0), so hover-leave would settle to
-        // neutral instead of the authored value. Restore those channels to
-        // their style values (mirrors the whileDrag baseline fix in drag.ts).
-        const styleBase = transformComposer?.getBaseTransformValues?.() ?? {}
-        for (const key of Object.keys(hoverBaseline)) {
-            if (restingTransformValues[key] !== undefined) continue
-            if (styleBase[key] !== undefined) hoverBaseline[key] = styleBase[key]
-        }
-        fallbackBaseTransform = transformComposer ? '' : el.style.transform
+        if (!transformComposer) fallbackBaseTransform = el.style.transform
         callbacks?.onStart?.()
         const { keyframes, transition } = splitHoverDefinition(whileHover)
         const { scale, ...nativeKeyframes } = keyframes

--- a/src/lib/utils/hover.ts
+++ b/src/lib/utils/hover.ts
@@ -257,6 +257,15 @@ export const attachWhileHover = (
             animate: baselineSources?.animate,
             whileHover
         })
+        // computeHoverBaseline cannot see style-authored transform channels and
+        // neutral-defaults them (rotate -> 0), so hover-leave would settle to
+        // neutral instead of the authored value. Restore those channels to
+        // their style values (mirrors the whileDrag baseline fix in drag.ts).
+        const styleBase = transformComposer?.getBaseTransformValues?.() ?? {}
+        for (const key of Object.keys(hoverBaseline)) {
+            if (restingTransformValues[key] !== undefined) continue
+            if (styleBase[key] !== undefined) hoverBaseline[key] = styleBase[key]
+        }
         fallbackBaseTransform = transformComposer ? '' : el.style.transform
         callbacks?.onStart?.()
         const { keyframes, transition } = splitHoverDefinition(whileHover)

--- a/src/lib/utils/hover.ts
+++ b/src/lib/utils/hover.ts
@@ -1,6 +1,10 @@
-import { parseMatrixTranslate } from '$lib/utils/dragMath'
-import { type AnimationOptions, type DOMKeyframesDefinition, animate } from 'motion'
-import { animateValue, hover } from 'motion-dom'
+import {
+    buildGestureTransform,
+    collectGestureTransformValues,
+    type GestureTransformValues
+} from '$lib/utils/transformComposer'
+import { animate, type AnimationOptions, type DOMKeyframesDefinition } from 'motion'
+import { animateValue, hover, type TransformTemplate } from 'motion-dom'
 
 /**
  * Determine whether the current environment supports true hover.
@@ -49,24 +53,6 @@ const readTransformScale = (el: HTMLElement): number => {
     return Math.hypot(a, b)
 }
 
-const readTransformRotation = (el: HTMLElement): string | undefined => {
-    const inlineTransform = el.style.transform || ''
-    const rotateMatch = inlineTransform.match(/(?:^|\s)rotate\(([^)]+)\)/)
-    if (rotateMatch) return rotateMatch[1]
-
-    const computedTransform = getComputedStyle(el).transform
-    if (!computedTransform || computedTransform === 'none') return undefined
-    const matrix = computedTransform.match(/matrix\(([^)]+)\)/)
-    if (!matrix) return undefined
-
-    const [a, b] = matrix[1].split(',').map((part) => Number.parseFloat(part.trim()))
-    if (!Number.isFinite(a) || !Number.isFinite(b)) return undefined
-
-    const degrees = Math.atan2(b, a) * (180 / Math.PI)
-    if (Math.abs(degrees) < 0.001) return undefined
-    return `${degrees}deg`
-}
-
 const getFinalNumber = (value: unknown): number | null => {
     const raw: unknown = Array.isArray(value) ? value[value.length - 1] : value
     const parsed = typeof raw === 'number' ? raw : Number.parseFloat(String(raw))
@@ -83,20 +69,6 @@ const toMillisecondsTransition = (
         }
     }
     return valueTransition
-}
-
-const writeComposedScale = (el: HTMLElement, scale: number) => {
-    const { tx, ty } = parseMatrixTranslate(getComputedStyle(el).transform || 'none')
-    const rotate = readTransformRotation(el)
-
-    el.style.transform = [
-        `translateX(${tx}px)`,
-        `translateY(${ty}px)`,
-        Math.abs(scale - 1) > 0.0001 ? `scale(${scale})` : '',
-        rotate == null ? '' : `rotate(${rotate})`
-    ]
-        .filter(Boolean)
-        .join(' ')
 }
 
 /**
@@ -186,6 +158,13 @@ export const computeHoverBaseline = (
     return baseline
 }
 
+type HoverTransformComposerOptions = {
+    getBaseTransformValues?: () => GestureTransformValues
+    getLiveTransformValues?: () => GestureTransformValues | null
+    getBaseTransform?: () => string
+    transformTemplate?: TransformTemplate
+}
+
 /**
  * Attach whileHover interactions to an element with capability gating.
  *
@@ -199,6 +178,7 @@ export const computeHoverBaseline = (
  * @param mergedTransition Root/component merged transition.
  * @param callbacks Optional lifecycle callbacks for hover start/end.
  * @param baselineSources Optional sources used to compute baseline.
+ * @param transformComposer Optional shared transform sources used by scale animation.
  * @return Cleanup function to remove hover listeners.
  */
 export const attachWhileHover = (
@@ -206,12 +186,33 @@ export const attachWhileHover = (
     whileHover: Record<string, unknown> | undefined,
     mergedTransition: AnimationOptions,
     callbacks?: { onStart?: () => void; onEnd?: () => void },
-    baselineSources?: { initial?: Record<string, unknown>; animate?: Record<string, unknown> }
+    baselineSources?: { initial?: Record<string, unknown>; animate?: Record<string, unknown> },
+    transformComposer?: HoverTransformComposerOptions
 ): (() => void) => {
     if (!whileHover) return () => {}
 
     let hoverBaseline: Record<string, unknown> | null = null
     let scaleAnimation: { stop?: () => void } | null = null
+    let fallbackBaseTransform = ''
+    const restingTransformValues: GestureTransformValues = {
+        ...collectGestureTransformValues(baselineSources?.initial),
+        ...collectGestureTransformValues(baselineSources?.animate)
+    }
+
+    const writeComposedScale = (scale: number) => {
+        const transform =
+            buildGestureTransform(
+                {
+                    ...(transformComposer?.getBaseTransformValues?.() ?? {}),
+                    ...restingTransformValues,
+                    ...(transformComposer?.getLiveTransformValues?.() ?? {}),
+                    scale
+                },
+                transformComposer?.getBaseTransform?.() ?? fallbackBaseTransform,
+                transformComposer?.transformTemplate
+            ) || 'none'
+        el.style.transform = transform
+    }
 
     const stopScaleAnimation = () => {
         scaleAnimation?.stop?.()
@@ -234,10 +235,10 @@ export const attachWhileHover = (
             ...toMillisecondsTransition(transition ?? mergedTransition),
             keyframes: [readTransformScale(el), targetScale],
             onUpdate: (value: number) => {
-                writeComposedScale(el, value)
+                writeComposedScale(value)
             },
             onComplete: () => {
-                writeComposedScale(el, targetScale)
+                writeComposedScale(targetScale)
                 scaleAnimation = null
                 onComplete?.()
             }
@@ -256,6 +257,7 @@ export const attachWhileHover = (
             animate: baselineSources?.animate,
             whileHover
         })
+        fallbackBaseTransform = transformComposer ? '' : el.style.transform
         callbacks?.onStart?.()
         const { keyframes, transition } = splitHoverDefinition(whileHover)
         const { scale, ...nativeKeyframes } = keyframes

--- a/src/lib/utils/transformComposer.ts
+++ b/src/lib/utils/transformComposer.ts
@@ -1,0 +1,67 @@
+import {
+    buildTransform,
+    transformProps,
+    type AnyResolvedKeyframe,
+    type TransformTemplate
+} from 'motion-dom'
+
+/** Transform-channel values accepted by Motion's HTML transform builder. */
+export type GestureTransformValues = Record<string, AnyResolvedKeyframe>
+
+const getLastValue = (values: readonly unknown[]): unknown => values.at(-1)
+
+/**
+ * Build a gesture-owned transform in Motion's canonical channel order.
+ *
+ * @param latestValues Current transform-channel values.
+ * @param baseTransform An authored raw CSS transform that cannot be represented as channels.
+ * @param transformTemplate Optional user transform template applied to the live values.
+ * @returns The composed CSS transform string.
+ */
+export const buildGestureTransform = (
+    latestValues: GestureTransformValues,
+    baseTransform = '',
+    transformTemplate?: TransformTemplate
+): string => {
+    const generated = buildTransform(latestValues, {}, transformTemplate)
+    return [generated === 'none' ? '' : generated, baseTransform].filter(Boolean).join(' ')
+}
+
+/**
+ * Resolve the final transform-channel values from a Motion target record.
+ *
+ * @param source Motion target whose transform channels should be collected.
+ * @returns Only recognized transform channels with scalar final values.
+ */
+export const collectGestureTransformValues = (
+    source: Record<string, unknown> | undefined
+): GestureTransformValues => {
+    const values: GestureTransformValues = {}
+    if (!source) return values
+
+    for (const [key, value] of Object.entries(source)) {
+        if (!transformProps.has(key)) continue
+        const finalValue = Array.isArray(value) ? getLastValue(value) : value
+        if (typeof finalValue === 'string' || typeof finalValue === 'number') {
+            values[key] = finalValue
+        }
+    }
+    return values
+}
+
+/**
+ * Partition a Motion target into transform and native style channels.
+ *
+ * @param source Motion target to partition.
+ * @returns Separate transform and native style records.
+ */
+export const splitGestureTransformValues = (source: Record<string, unknown>) => {
+    const transform: Record<string, unknown> = {}
+    const native: Record<string, unknown> = {}
+
+    for (const [key, value] of Object.entries(source)) {
+        if (transformProps.has(key)) transform[key] = value
+        else native[key] = value
+    }
+    return { transform, native }
+}

--- a/src/lib/utils/transformComposer.ts
+++ b/src/lib/utils/transformComposer.ts
@@ -17,6 +17,9 @@ const getLastValue = (values: readonly unknown[]): unknown => values.at(-1)
  * @param baseTransform An authored raw CSS transform that cannot be represented as channels.
  * @param transformTemplate Optional user transform template applied to the live values.
  * @returns The composed CSS transform string.
+ * @example
+ * buildGestureTransform({ x: '20px', rotate: 4 }, 'perspective(600px)')
+ * // => 'translateX(20px) rotate(4deg) perspective(600px)'
  */
 export const buildGestureTransform = (
     latestValues: GestureTransformValues,
@@ -32,6 +35,9 @@ export const buildGestureTransform = (
  *
  * @param source Motion target whose transform channels should be collected.
  * @returns Only recognized transform channels with scalar final values.
+ * @example
+ * collectGestureTransformValues({ rotate: [0, 8], scale: 1.1, opacity: 0.5 })
+ * // => { rotate: 8, scale: 1.1 } — keyframe arrays resolve to their final value
  */
 export const collectGestureTransformValues = (
     source: Record<string, unknown> | undefined
@@ -54,6 +60,9 @@ export const collectGestureTransformValues = (
  *
  * @param source Motion target to partition.
  * @returns Separate transform and native style records.
+ * @example
+ * splitGestureTransformValues({ rotate: 4, cursor: 'grabbing' })
+ * // => { transform: { rotate: 4 }, native: { cursor: 'grabbing' } }
  */
 export const splitGestureTransformValues = (source: Record<string, unknown>) => {
     const transform: Record<string, unknown> = {}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -160,6 +160,14 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/motion/hover-authored-transforms') + searchParams}
+                    >
+                        Hover: whileHover over authored transforms
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/motion/rapid-tap') + searchParams}
                     >
                         Rapid Tap (spring runaway guard)

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -444,6 +444,14 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/drag/while-drag-transforms') + searchParams}
+                    >
+                        Drag: whileDrag transform composition
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/mobile-drawer') + searchParams}
                     >
                         Drag Close Drawer (mobile drawer)

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -168,6 +168,14 @@
                 <li>
                     <a
                         class="text-blue-300 hover:underline"
+                        href={resolve('/tests/motion/pan-authored-transforms') + searchParams}
+                    >
+                        Pan: whilePan over authored transforms
+                    </a>
+                </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
                         href={resolve('/tests/motion/rapid-tap') + searchParams}
                     >
                         Rapid Tap (spring runaway guard)

--- a/src/routes/tests/drag/while-drag-transforms/+page.svelte
+++ b/src/routes/tests/drag/while-drag-transforms/+page.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+    /**
+     * Characterization page for transform channels that the drag composer
+     * currently overwrites or fails to paint while the pointer is held.
+     */
+    import { motion } from '$lib'
+
+    let inserted = $state(false)
+</script>
+
+<svelte:head>
+    <title>Drag · whileDrag transform composition</title>
+</svelte:head>
+
+<main>
+    <h1>whileDrag transform composition</h1>
+    <p>
+        Hold each card while dragging. Rotation, 3D transforms, and cross-axis layout pinning should
+        remain composed with the live drag translation.
+    </p>
+
+    <section>
+        <h2>2D rotation</h2>
+        <div class="stage">
+            <motion.div
+                class="card rotate-card"
+                data-testid="rotate-card"
+                drag="x"
+                dragMomentum={false}
+                whileDrag={{ rotate: 8 }}
+                transition={{ duration: 0.05 }}
+            >
+                rotate 8°
+            </motion.div>
+        </div>
+    </section>
+
+    <section>
+        <h2>Cross-axis layout pinning</h2>
+        <button
+            type="button"
+            data-testid="insert-above"
+            onclick={() => (inserted = true)}
+            disabled={inserted}
+        >
+            Insert content above
+        </button>
+        <div class="pin-stage">
+            {#if inserted}
+                <div class="inserted" data-testid="inserted-content">New layout content</div>
+            {/if}
+            <motion.div
+                class="card pin-card"
+                data-testid="cross-axis-card"
+                drag="x"
+                dragMomentum={false}
+                layout
+            >
+                drag x · stay pinned on y
+            </motion.div>
+        </div>
+    </section>
+
+    <section>
+        <h2>3D rotation with perspective</h2>
+        <div class="stage perspective-stage">
+            <motion.div
+                class="card rotate-x-card"
+                data-testid="rotate-x-card"
+                drag="x"
+                dragMomentum={false}
+                whileDrag={{ rotateX: 30 }}
+                transition={{ duration: 0.05 }}
+                style={{ transformPerspective: '600px' }}
+            >
+                rotateX 30°
+            </motion.div>
+        </div>
+    </section>
+</main>
+
+<style>
+    :global(body) {
+        margin: 0;
+        background: #07100f;
+        color: #e8fffa;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+
+    main {
+        width: min(920px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 32px 0 64px;
+    }
+
+    h1,
+    h2,
+    p {
+        margin-top: 0;
+    }
+
+    section {
+        margin-top: 24px;
+        padding: 20px;
+        border: 1px solid #28504a;
+        background: #0b1816;
+    }
+
+    .stage,
+    .pin-stage {
+        min-height: 150px;
+        display: grid;
+        place-items: center;
+        overflow: hidden;
+        border: 1px dashed #35786c;
+        background: #091311;
+    }
+
+    .pin-stage {
+        margin-top: 12px;
+        align-content: start;
+        padding: 24px;
+    }
+
+    .inserted {
+        width: min(420px, 100%);
+        height: 72px;
+        display: grid;
+        place-items: center;
+        margin-bottom: 16px;
+        border: 1px solid #f59e0b;
+        color: #fbbf24;
+        background: #2a1c08;
+    }
+
+    :global(.card) {
+        width: 160px;
+        height: 88px;
+        display: grid;
+        place-items: center;
+        border: 1px solid #76ead3;
+        border-radius: 12px;
+        color: #06110f;
+        background: #54dbbc;
+        cursor: grab;
+        user-select: none;
+        touch-action: none;
+        will-change: transform;
+    }
+
+    :global(.pin-card) {
+        width: 220px;
+    }
+
+    :global(.rotate-card) {
+        transform-origin: center;
+    }
+
+    .perspective-stage {
+        perspective: 900px;
+    }
+
+    button {
+        padding: 8px 12px;
+        border: 1px solid #76ead3;
+        color: #e8fffa;
+        background: #12352f;
+        font: inherit;
+        cursor: pointer;
+    }
+
+    button:disabled {
+        opacity: 0.55;
+        cursor: default;
+    }
+</style>

--- a/src/routes/tests/drag/while-drag-transforms/+page.svelte
+++ b/src/routes/tests/drag/while-drag-transforms/+page.svelte
@@ -110,6 +110,28 @@
     </section>
 
     <section>
+        <h2>Write coalescing under multi-channel whileDrag springs</h2>
+        <p class="hint">
+            Two whileDrag channels animate under a slow spring while the pointer is held still. The
+            composer should paint at most one composed transform per frame — not one per animated
+            channel.
+        </p>
+        <div class="stage">
+            <motion.div
+                class="card perf-spring-card"
+                data-testid="perf-spring-card"
+                drag="x"
+                dragMomentum={false}
+                whileDrag={{ rotate: 90, scale: 1.3 }}
+                transition={{ type: 'spring', stiffness: 60, damping: 10 }}
+                style={{ rotate: -8 }}
+            >
+                slow spring · 2 channels
+            </motion.div>
+        </div>
+    </section>
+
+    <section>
         <h2>3D rotation with perspective</h2>
         <div class="stage perspective-stage">
             <motion.div

--- a/src/routes/tests/drag/while-drag-transforms/+page.svelte
+++ b/src/routes/tests/drag/while-drag-transforms/+page.svelte
@@ -6,6 +6,7 @@
     import { motion } from '$lib'
 
     let inserted = $state(false)
+    let stackBounds: HTMLElement | null = $state(null)
 </script>
 
 <svelte:head>
@@ -57,6 +58,53 @@
                 layout
             >
                 drag x · stay pinned on y
+            </motion.div>
+        </div>
+    </section>
+
+    <section>
+        <h2>whileDrag overriding an authored style channel</h2>
+        <p class="hint">
+            The card authors <code>rotate</code> on <code>style</code>, and <code>whileDrag</code>
+            overrides that same channel. Both the override and the drag translation must survive.
+        </p>
+        <div class="stage">
+            <motion.div
+                class="card authored-rotate-card"
+                data-testid="authored-rotate-card"
+                drag="x"
+                dragMomentum={false}
+                style={{ rotate: -8 }}
+                whileDrag={{ rotate: 4 }}
+                transition={{ duration: 0.05 }}
+            >
+                style rotate −8° · whileDrag 4°
+            </motion.div>
+        </div>
+    </section>
+
+    <section>
+        <h2>Full gesture stack over authored transform channels</h2>
+        <p class="hint">
+            Mirrors the docs example: constrained two-axis drag, <code>whileHover</code> and
+            <code>whileDrag</code> both owning <code>scale</code>, a spring transition, over
+            authored
+            <code>rotate</code>/<code>skewX</code>. Drag translation and the whileDrag rotate must
+            both survive.
+        </p>
+        <div bind:this={stackBounds} class="stage stack-stage">
+            <motion.div
+                class="card gesture-stack-card"
+                data-testid="gesture-stack-card"
+                drag
+                dragConstraints={stackBounds}
+                dragElastic={0.28}
+                whileHover={{ scale: 1.03 }}
+                whileDrag={{ rotate: 4, scale: 1.08, cursor: 'grabbing' }}
+                transition={{ type: 'spring', stiffness: 420, damping: 32 }}
+                style={{ rotate: -8, skewX: -5 }}
+            >
+                full gesture stack
             </motion.div>
         </div>
     </section>
@@ -158,6 +206,16 @@
 
     .perspective-stage {
         perspective: 900px;
+    }
+
+    .hint {
+        margin: 0 0 12px;
+        color: #9fd9cd;
+        font-size: 13px;
+    }
+
+    .stack-stage {
+        min-height: 280px;
     }
 
     button {

--- a/src/routes/tests/drag/while-drag-transforms/+page.svelte
+++ b/src/routes/tests/drag/while-drag-transforms/+page.svelte
@@ -2,6 +2,8 @@
     /**
      * Characterization page for transform channels that the drag composer
      * currently overwrites or fails to paint while the pointer is held.
+     *
+     * @component
      */
     import { motion } from '$lib'
 

--- a/src/routes/tests/motion/hover-authored-transforms/+page.svelte
+++ b/src/routes/tests/motion/hover-authored-transforms/+page.svelte
@@ -4,6 +4,8 @@
      * that `style` also authors. The hover-enter animation must compose
      * with the authored channels, and hover-leave must restore the
      * style-authored value smoothly — not settle to neutral and snap.
+     *
+     * @component
      */
     import { motion } from '$lib'
 </script>

--- a/src/routes/tests/motion/hover-authored-transforms/+page.svelte
+++ b/src/routes/tests/motion/hover-authored-transforms/+page.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+    /**
+     * Characterization page for whileHover overriding a transform channel
+     * that `style` also authors. The hover-enter animation must compose
+     * with the authored channels, and hover-leave must restore the
+     * style-authored value smoothly — not settle to neutral and snap.
+     */
+    import { motion } from '$lib'
+</script>
+
+<svelte:head>
+    <title>Motion · whileHover over authored transforms</title>
+</svelte:head>
+
+<main>
+    <h1>whileHover over authored transforms</h1>
+    <p>
+        The card authors <code>rotate</code> on <code>style</code>; <code>whileHover</code>
+        overrides the same channel with a spring. Enter must animate −8° → 4°, and leave must return smoothly
+        to −8°.
+    </p>
+
+    <section>
+        <div class="stage">
+            <motion.div
+                class="card"
+                data-testid="hover-authored-rotate-card"
+                whileHover={{ rotate: 4 }}
+                transition={{ type: 'spring', stiffness: 420, damping: 32 }}
+                style={{ rotate: -8 }}
+            >
+                style −8° · hover 4°
+            </motion.div>
+        </div>
+    </section>
+</main>
+
+<style>
+    :global(body) {
+        margin: 0;
+        background: #07100f;
+        color: #e8fffa;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+
+    main {
+        width: min(920px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 32px 0 64px;
+    }
+
+    h1,
+    p {
+        margin-top: 0;
+    }
+
+    section {
+        margin-top: 24px;
+        padding: 20px;
+        border: 1px solid #28504a;
+        background: #0b1816;
+    }
+
+    .stage {
+        min-height: 200px;
+        display: grid;
+        place-items: center;
+        border: 1px dashed #35786c;
+        background: #091311;
+    }
+
+    :global(.card) {
+        width: 160px;
+        height: 88px;
+        display: grid;
+        place-items: center;
+        border: 1px solid #76ead3;
+        border-radius: 12px;
+        color: #06110f;
+        background: #54dbbc;
+        user-select: none;
+    }
+</style>

--- a/src/routes/tests/motion/pan-authored-transforms/+page.svelte
+++ b/src/routes/tests/motion/pan-authored-transforms/+page.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+    /**
+     * Characterization page for whilePan overriding a transform channel
+     * that `style` also authors. The pan-start animation must compose
+     * with the authored channels, and pan-end must restore the
+     * style-authored value smoothly — not settle to neutral and snap.
+     */
+    import { motion } from '$lib'
+</script>
+
+<svelte:head>
+    <title>Motion · whilePan over authored transforms</title>
+</svelte:head>
+
+<main>
+    <h1>whilePan over authored transforms</h1>
+    <p>
+        The card authors <code>rotate</code> on <code>style</code>; <code>whilePan</code>
+        overrides the same channel with a spring. Pan-start must animate −8° → 4°, and pan-end must return
+        smoothly to −8°.
+    </p>
+
+    <section>
+        <div class="stage">
+            <motion.div
+                class="card"
+                data-testid="pan-authored-rotate-card"
+                whilePan={{ rotate: 4 }}
+                transition={{ type: 'spring', stiffness: 420, damping: 32 }}
+                style={{ rotate: -8 }}
+            >
+                style −8° · pan 4°
+            </motion.div>
+        </div>
+    </section>
+</main>
+
+<style>
+    :global(body) {
+        margin: 0;
+        background: #07100f;
+        color: #e8fffa;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+
+    main {
+        width: min(920px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 32px 0 64px;
+    }
+
+    h1,
+    p {
+        margin-top: 0;
+    }
+
+    section {
+        margin-top: 24px;
+        padding: 20px;
+        border: 1px solid #28504a;
+        background: #0b1816;
+    }
+
+    .stage {
+        min-height: 200px;
+        display: grid;
+        place-items: center;
+        border: 1px dashed #35786c;
+        background: #091311;
+    }
+
+    :global(.card) {
+        width: 160px;
+        height: 88px;
+        display: grid;
+        place-items: center;
+        border: 1px solid #76ead3;
+        border-radius: 12px;
+        color: #06110f;
+        background: #54dbbc;
+        user-select: none;
+        touch-action: none;
+    }
+</style>

--- a/src/routes/tests/motion/pan-authored-transforms/+page.svelte
+++ b/src/routes/tests/motion/pan-authored-transforms/+page.svelte
@@ -4,6 +4,8 @@
      * that `style` also authors. The pan-start animation must compose
      * with the authored channels, and pan-end must restore the
      * style-authored value smoothly — not settle to neutral and snap.
+     *
+     * @component
      */
     import { motion } from '$lib'
 </script>


### PR DESCRIPTION
## Summary

While a drag was active, `el.style.transform` was rebuilt every frame from only translate + scale + a static base transform, clobbering every other channel — `whileDrag={{ rotate }}` flickered to 0, `rotateX`/`perspective` vanished mid-drag, `transformTemplate` only ever saw static values, and cross-axis pinning compensation was bookkept but never painted. This PR routes drag translation, cross-axis projection compensation, active whileDrag transform channels, authored style channels, and live `transformTemplate` through a single writer built on motion-dom's canonical `buildTransform`, and replaces hover's partial translate/scale/rotate rebuild with the same writer. The #379 same-frame no-lag write and #421 bound-MotionValue dual-write/empty-write behaviors are preserved.

Implements plan `003-drag-transform-composition` (upstream-parity batch). Guard close-out: **PASS** — all done criteria reproduced, characterization tests red-verified against pre-fix source; see `.agents/.plans/upstream-parity-top3/003-drag-transform-composition.guard-report.md`. Maintainer signed off on the live demo.

Closes #436
Refs #403, #396 (previously closed; this lands the full composition + cross-axis paint they described)

## Changes

- 🐛 `src/lib/utils/drag.ts` — replace translate+scale string splicing in `setXYImmediate` with full-composition writer; whileDrag transform channels each animate as their own MotionValue feeding the composer (no DOM reads); cross-axis `adjustOrigin` deltas now paint via a dedicated offset (removes the #310 deferral)
- ✨ `src/lib/utils/transformComposer.ts` — new shared writer wrapping motion-dom `buildTransform`/`transformProps`; the seam Plan 004 builds on
- 🐛 `src/lib/utils/hover.ts` — hover scale now composes through the same writer, preserving pre-existing channels (e.g. `rotateX`) and settled drag channels
- 🔧 `src/lib/html/_MotionContainer.svelte` — thread live style transform values and `transformTemplate` into drag and hover
- 🧪 New e2e characterization suite `e2e/drag/while-drag-transforms.spec.ts` + demo route `/tests/drag/while-drag-transforms` (rotation persistence, cross-axis pinning under layout insertion, rotateX+perspective) — verified red pre-fix, green post-fix; unit coverage for channel ordering, live `transformTemplate`, the #421 empty-write guard, and hover channel survival
- 📚 Batch README status row + guard log/report for plan 003

## Test evidence

- `pnpm check` — 0 errors · `pnpm test` — 759/759
- `pnpm exec playwright test e2e/drag e2e/reorder` — 76 passed / 1 skipped, including the `siblings-flip` drift-sampling specs that encode #379

## Commits

- [`e0a88c7`](https://github.com/humanspeak/svelte-motion/commit/e0a88c7fb38c31e3bd27cd8bbfef194f1fb203ee) test(drag): capture transform composition regressions
- [`c3525d0`](https://github.com/humanspeak/svelte-motion/commit/c3525d0) fix(drag): compose full transform during drag via buildTransform
- [`30bc4c8`](https://github.com/humanspeak/svelte-motion/commit/30bc4c8) docs(plans): guard close-out for plan 003 — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
