### PR TITLE
fix(animate-presence): exit in place — placeholder slot anchoring, clone position, key={0}

### DIFF
--- a/docs/src/lib/examples/animate-presence-custom/demos/Default.svelte
+++ b/docs/src/lib/examples/animate-presence-custom/demos/Default.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { ArrowLeft, ArrowRight, Sparkles } from '@lucide/svelte'
-    import { AnimatePresence, motion, type Variants } from '@humanspeak/svelte-motion'
+    import { AnimatePresence, motion, styleString, type Variants } from '@humanspeak/svelte-motion'
 
     type Feature = {
         id: string
@@ -63,25 +63,44 @@
         direction = nextDirection
         index = (index + nextDirection + features.length) % features.length
     }
+
+    const navButtonStyle = styleString(() => ({
+        width: 44,
+        height: 44,
+        display: 'grid',
+        placeItems: 'center',
+        border: '1px solid var(--brut-rule-2, #bbc4c0)',
+        backgroundColor: 'var(--brut-bg, #f8fcfb)',
+        color: 'var(--brut-ink, #0a0a0a)',
+        cursor: 'pointer'
+    }))
 </script>
 
 <!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
 <div class="dk-demo-shell">
     <div class="stage" aria-label="Directional AnimatePresence custom demo">
-        <div class="rail" aria-hidden="true">
-            {#each features as feature, i (feature.id)}
-                <span class:active={i === index}></span>
-            {/each}
+        <div class="stage-head">
+            <span class="micro">// presence custom</span>
+            <div class="rail" aria-hidden="true">
+                {#each features as feature, i (feature.id)}
+                    <span class:active={i === index}></span>
+                {/each}
+            </div>
         </div>
 
-        <button
-            class="nav-button previous"
-            type="button"
-            onclick={() => move(-1)}
-            aria-label="Previous feature"
-        >
-            <ArrowLeft size={16} />
-        </button>
+        <div class="nav-slot previous">
+            <motion.button
+                type="button"
+                onclick={() => move(-1)}
+                aria-label="Previous feature"
+                whileHover={{ scale: 1.08 }}
+                whileTap={{ scale: 0.92 }}
+                transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+                style={navButtonStyle}
+            >
+                <ArrowLeft size={16} />
+            </motion.button>
+        </div>
 
         <div class="viewport">
             <div class="track-line"></div>
@@ -105,7 +124,7 @@
                         }}
                     >
                         <div class="panel-topline">
-                            <div class="icon"><Sparkles size={20} /></div>
+                            <div class="icon"><Sparkles size={18} /></div>
                             <span>{active.label}</span>
                         </div>
                         <strong>{active.title}</strong>
@@ -119,14 +138,19 @@
             </AnimatePresence>
         </div>
 
-        <button
-            class="nav-button next"
-            type="button"
-            onclick={() => move(1)}
-            aria-label="Next feature"
-        >
-            <ArrowRight size={16} />
-        </button>
+        <div class="nav-slot next">
+            <motion.button
+                type="button"
+                onclick={() => move(1)}
+                aria-label="Next feature"
+                whileHover={{ scale: 1.08 }}
+                whileTap={{ scale: 0.92 }}
+                transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+                style={navButtonStyle}
+            >
+                <ArrowRight size={16} />
+            </motion.button>
+        </div>
 
         <output class="direction-readout">
             <span>{direction > 0 ? 'next' : 'previous'}</span>
@@ -138,42 +162,58 @@
 <style>
     .dk-demo-shell {
         width: 100%;
-        min-height: 560px;
+        min-height: 520px;
         display: flex;
         align-items: center;
         justify-content: center;
         padding: clamp(1.25rem, 4vw, 2.5rem);
-        background:
-            radial-gradient(circle at 18% 16%, rgba(245, 183, 223, 0.22), transparent 24%),
-            radial-gradient(circle at 78% 78%, rgba(103, 232, 249, 0.16), transparent 28%), #081014;
-        color: #eef6fb;
+    }
+
+    .micro {
+        font-family: var(--brut-mono, monospace);
+        font-size: 0.6875rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--brut-ink-3, #9a9a9a);
     }
 
     .stage {
         position: relative;
         width: 100%;
         max-width: 720px;
-        min-height: 440px;
+        min-height: 420px;
         display: grid;
         place-items: center;
         overflow: hidden;
-        border: 1px solid rgba(103, 232, 249, 0.22);
-        border-radius: 8px;
+        border: 1px solid var(--brut-rule-2, #bbc4c0);
         background:
-            linear-gradient(90deg, rgba(103, 232, 249, 0.11) 1px, transparent 1px),
-            linear-gradient(0deg, rgba(103, 232, 249, 0.11) 1px, transparent 1px),
-            linear-gradient(135deg, rgba(245, 183, 223, 0.12), transparent 38%), #0b151b;
+            linear-gradient(90deg, var(--brut-rule, #d6dedb) 1px, transparent 1px),
+            linear-gradient(0deg, var(--brut-rule, #d6dedb) 1px, transparent 1px),
+            var(--brut-bg-2, #eef4f1);
         background-size:
             54px 54px,
             54px 54px,
-            auto,
             auto;
+    }
+
+    .stage-head {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 0.75rem 1rem;
+        border-bottom: 1px dashed var(--brut-rule-2, #bbc4c0);
+        background: var(--brut-bg, #f8fcfb);
     }
 
     .viewport {
         position: relative;
         width: min(100%, 520px);
-        height: 310px;
+        height: 300px;
         display: grid;
         place-items: center;
         isolation: isolate;
@@ -183,7 +223,7 @@
         position: absolute;
         inset: 50% -120px auto;
         height: 1px;
-        background: linear-gradient(90deg, transparent, rgba(103, 232, 249, 0.45), transparent);
+        background: var(--brut-rule-2, #bbc4c0);
         transform: translateY(-50%);
     }
 
@@ -191,11 +231,9 @@
         position: absolute;
         width: 250px;
         height: 170px;
-        border: 1px solid rgba(103, 232, 249, 0.2);
-        border-radius: 8px;
-        background: rgba(19, 32, 42, 0.42);
-        filter: blur(0.2px);
-        opacity: 0.5;
+        border: 1px dashed var(--brut-rule-2, #bbc4c0);
+        background: var(--brut-bg-2, #eef4f1);
+        opacity: 0.6;
     }
 
     .ghost-left {
@@ -215,13 +253,10 @@
         display: grid;
         align-content: stretch;
         gap: 14px;
-        padding: 26px;
-        border: 1px solid rgba(103, 232, 249, 0.74);
-        border-radius: 8px;
-        background: linear-gradient(145deg, rgba(245, 183, 223, 0.1), transparent 32%), #13202a;
-        box-shadow:
-            0 30px 90px rgba(0, 0, 0, 0.42),
-            0 0 42px rgba(103, 232, 249, 0.1);
+        padding: 24px;
+        border: 1px solid var(--brut-ink, #0a0a0a);
+        background: var(--brut-bg, #f8fcfb);
+        box-shadow: 8px 8px 0 var(--brut-accent-soft, rgba(36, 119, 104, 0.1));
         transform-origin: 50% 50%;
         z-index: 2;
     }
@@ -233,36 +268,36 @@
     }
 
     .icon {
-        width: 40px;
-        height: 40px;
+        width: 36px;
+        height: 36px;
         display: grid;
         place-items: center;
-        border: 1px solid #425b6a;
-        border-radius: 6px;
-        color: #f5b7df;
-        background: #0e161c;
+        border: 1px solid var(--brut-rule-2, #bbc4c0);
+        color: var(--brut-accent, #247768);
+        background: var(--brut-accent-soft, rgba(36, 119, 104, 0.1));
     }
 
     :global(.panel span) {
-        color: #72d9f7;
-        font-size: 12px;
-        font-weight: 800;
+        color: var(--brut-accent, #247768);
+        font-family: var(--brut-mono, monospace);
+        font-size: 0.6875rem;
+        font-weight: 700;
         letter-spacing: 0.08em;
         text-transform: uppercase;
     }
 
     :global(.panel strong) {
-        color: #f4f8fc;
-        font-size: clamp(26px, 4vw, 40px);
-        line-height: 0.98;
-        max-width: 10ch;
+        color: var(--brut-ink, #0a0a0a);
+        font-size: clamp(24px, 4vw, 36px);
+        line-height: 1;
+        max-width: 12ch;
     }
 
     :global(.panel p) {
         margin: 0;
-        color: #b5c6d3;
+        color: var(--brut-ink-2, #525252);
         line-height: 1.5;
-        max-width: 32ch;
+        max-width: 34ch;
     }
 
     .panel-footer {
@@ -271,16 +306,17 @@
         justify-content: space-between;
         align-self: end;
         gap: 16px;
-        color: #8ea5b4;
-        font-size: 12px;
-        font-weight: 800;
+        color: var(--brut-ink-3, #9a9a9a);
+        font-family: var(--brut-mono, monospace);
+        font-size: 0.6875rem;
+        font-weight: 700;
         letter-spacing: 0.08em;
         text-transform: uppercase;
     }
 
     .panel-footer small {
-        color: #72d9f7;
-        font-size: 30px;
+        color: var(--brut-accent, #247768);
+        font-size: 26px;
         line-height: 1;
     }
 
@@ -289,49 +325,25 @@
     }
 
     .rail {
-        position: absolute;
-        top: 22px;
-        left: 24px;
         display: flex;
-        gap: 7px;
+        gap: 6px;
     }
 
     .rail span {
-        width: 26px;
-        height: 4px;
-        border-radius: 999px;
-        background: rgba(142, 165, 180, 0.35);
+        width: 22px;
+        height: 5px;
+        background: var(--brut-rule-2, #bbc4c0);
     }
 
     .rail span.active {
-        background: linear-gradient(90deg, #72d9f7, #f5b7df);
+        background: var(--brut-accent, #247768);
     }
 
-    .nav-button {
+    .nav-slot {
         position: absolute;
         top: 50%;
         z-index: 3;
-        width: 52px;
-        height: 52px;
-        display: grid;
-        place-items: center;
-        border: 1px solid rgba(103, 232, 249, 0.36);
-        border-radius: 999px;
-        background: rgba(18, 28, 36, 0.8);
-        color: #eef6fb;
-        cursor: pointer;
         transform: translateY(-50%);
-        backdrop-filter: blur(14px);
-        transition:
-            border-color 160ms ease,
-            background 160ms ease,
-            transform 160ms ease;
-    }
-
-    .nav-button:hover {
-        border-color: #67e8f9;
-        background: rgba(26, 43, 55, 0.92);
-        transform: translateY(-50%) scale(1.04);
     }
 
     .previous {
@@ -344,29 +356,29 @@
 
     .direction-readout {
         position: absolute;
-        right: 22px;
-        bottom: 20px;
+        right: 16px;
+        bottom: 14px;
         display: flex;
         align-items: center;
         gap: 8px;
-        padding: 8px 10px;
-        border: 1px solid rgba(103, 232, 249, 0.22);
-        border-radius: 999px;
-        background: rgba(8, 16, 20, 0.68);
-        color: #b5c6d3;
-        font-size: 12px;
-        font-weight: 800;
+        padding: 6px 10px;
+        border: 1px solid var(--brut-rule-2, #bbc4c0);
+        background: var(--brut-bg, #f8fcfb);
+        color: var(--brut-ink-3, #9a9a9a);
+        font-family: var(--brut-mono, monospace);
+        font-size: 0.6875rem;
+        font-weight: 700;
         letter-spacing: 0.08em;
         text-transform: uppercase;
     }
 
     .direction-readout span {
-        color: #f5b7df;
+        color: var(--brut-ink-2, #525252);
     }
 
     .direction-readout b {
-        color: #72d9f7;
-        font-weight: 800;
+        color: var(--brut-accent, #247768);
+        font-weight: 700;
         text-transform: none;
     }
 
@@ -380,14 +392,10 @@
             height: 350px;
         }
 
-        .nav-button {
+        .nav-slot {
             top: auto;
             bottom: 24px;
             transform: none;
-        }
-
-        .nav-button:hover {
-            transform: scale(1.04);
         }
 
         .previous {
@@ -401,7 +409,7 @@
         .direction-readout {
             right: auto;
             left: 50%;
-            bottom: 34px;
+            bottom: 76px;
             translate: -50% 0;
         }
     }

--- a/docs/src/lib/examples/animate-presence-custom/demos/PresenceDataSlide.svelte
+++ b/docs/src/lib/examples/animate-presence-custom/demos/PresenceDataSlide.svelte
@@ -37,13 +37,22 @@
     animate="center"
     exit="exit"
     style={`background-color: ${color};`}
-/>
+>
+    {String(slideKey).padStart(2, '0')}
+</motion.div>
 
 <style>
     :global(.dk-demo-shell .box) {
         width: 150px;
         height: 150px;
-        border-radius: 10px;
+        display: grid;
+        place-items: center;
+        border: 1px solid var(--brut-ink, #0a0a0a);
+        box-shadow: 6px 6px 0 var(--brut-rule, #d6dedb);
         transform-origin: 50% 50%;
+        font-family: var(--brut-mono, monospace);
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: #ffffff;
     }
 </style>

--- a/docs/src/lib/examples/animate-presence-custom/demos/UsePresenceData.svelte
+++ b/docs/src/lib/examples/animate-presence-custom/demos/UsePresenceData.svelte
@@ -33,42 +33,55 @@
 <!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
 <div class="dk-demo-shell">
     <MotionConfig>
-        <div class="container">
-            <motion.button
-                initial={false}
-                animate={{ backgroundColor: color }}
-                aria-label="Previous"
-                class="button"
-                onclick={() => setSlide(-1)}
-                whileFocus={{ outline: `2px solid ${color}` }}
-                whileTap={{ scale: 0.9 }}
-            >
-                <svg {...iconsProps}>
-                    <path d="m12 19-7-7 7-7" />
-                    <path d="M19 12H5" />
-                </svg>
-            </motion.button>
+        <div class="strip">
+            <div class="strip-head">
+                <span class="micro">// use-presence-data</span>
+                <span class="micro readout">
+                    slide {String(selectedItem).padStart(2, '0')} / custom={direction}
+                </span>
+            </div>
 
-            <AnimatePresence custom={direction} initial={false} mode="popLayout">
-                {#key selectedItem}
-                    <PresenceDataSlide slideKey={selectedItem} {color} />
-                {/key}
-            </AnimatePresence>
+            <div class="container">
+                <motion.button
+                    initial={false}
+                    animate={{ backgroundColor: color }}
+                    aria-label="Previous"
+                    class="button"
+                    onclick={() => setSlide(-1)}
+                    whileFocus={{ outline: `2px solid ${color}` }}
+                    whileTap={{ scale: 0.9 }}
+                >
+                    <svg {...iconsProps}>
+                        <path d="m12 19-7-7 7-7" />
+                        <path d="M19 12H5" />
+                    </svg>
+                </motion.button>
 
-            <motion.button
-                initial={false}
-                animate={{ backgroundColor: color }}
-                aria-label="Next"
-                class="button"
-                onclick={() => setSlide(1)}
-                whileFocus={{ outline: `2px solid ${color}` }}
-                whileTap={{ scale: 0.9 }}
-            >
-                <svg {...iconsProps}>
-                    <path d="M5 12h14" />
-                    <path d="m12 5 7 7-7 7" />
-                </svg>
-            </motion.button>
+                <AnimatePresence custom={direction} initial={false} mode="popLayout">
+                    {#key selectedItem}
+                        <PresenceDataSlide slideKey={selectedItem} {color} />
+                    {/key}
+                </AnimatePresence>
+
+                <motion.button
+                    initial={false}
+                    animate={{ backgroundColor: color }}
+                    aria-label="Next"
+                    class="button"
+                    onclick={() => setSlide(1)}
+                    whileFocus={{ outline: `2px solid ${color}` }}
+                    whileTap={{ scale: 0.9 }}
+                >
+                    <svg {...iconsProps}>
+                        <path d="M5 12h14" />
+                        <path d="m12 5 7 7-7 7" />
+                    </svg>
+                </motion.button>
+            </div>
+
+            <div class="strip-foot">
+                <span class="micro">mode: poplayout / exit reads usePresenceData()</span>
+            </div>
         </div>
     </MotionConfig>
 </div>
@@ -83,22 +96,58 @@
         --hue-6: #4ff0b7;
 
         min-height: 360px;
-        display: grid;
-        place-items: center;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         padding: 2rem;
-        background:
-            linear-gradient(90deg, rgba(114, 217, 247, 0.1) 1px, transparent 1px),
-            linear-gradient(0deg, rgba(114, 217, 247, 0.1) 1px, transparent 1px), #0e161c;
-        background-size: 44px 44px;
-        color: white;
+    }
+
+    .strip {
+        width: 100%;
+        max-width: 420px;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .micro {
+        font-family: var(--brut-mono, monospace);
+        font-size: 0.6875rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--brut-ink-3, #9a9a9a);
+    }
+
+    .readout {
+        color: var(--brut-accent, #247768);
+        font-variant-numeric: tabular-nums;
+    }
+
+    .strip-head,
+    .strip-foot {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        border-bottom: 1px dashed var(--brut-rule-2, #bbc4c0);
+        padding-bottom: 0.5rem;
+    }
+
+    .strip-foot {
+        border-bottom: none;
+        border-top: 1px dashed var(--brut-rule-2, #bbc4c0);
+        padding-top: 0.75rem;
+        padding-bottom: 0;
+        justify-content: center;
     }
 
     .container {
         position: relative;
+        height: 12rem;
         display: flex;
         align-items: center;
         justify-content: center;
-        gap: 10px;
+        gap: 1rem;
     }
 
     .dk-demo-shell :global(.button) {
@@ -109,10 +158,9 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        border: 0;
-        border-radius: 50%;
+        border: 1px solid var(--brut-ink, #0a0a0a);
         outline-offset: 2px;
-        color: white;
+        color: #ffffff;
         cursor: pointer;
     }
 

--- a/docs/src/lib/examples/animate-presence/demos/Default.svelte
+++ b/docs/src/lib/examples/animate-presence/demos/Default.svelte
@@ -3,63 +3,93 @@
 
     // A `motion.*` element inside `<AnimatePresence>` with an `exit` prop runs
     // that animation when the element is removed from the DOM. Toggle the
-    // visibility — the cyan box scales + fades in on mount, then runs its
-    // `exit` (scale + fade out) when it leaves, all on the same spring.
+    // unit — the card scales + fades in on mount, then runs its `exit`
+    // (scale + fade out) when it leaves, all on the same spring.
     let isVisible = $state(true)
 </script>
 
 <!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
 <div class="dk-demo-shell">
     <MotionConfig transition={{ duration: 0.6 }}>
-        <!-- Fixed height container prevents the button from moving as the box enters/exits. -->
-        <div class="stage">
-            <AnimatePresence>
-                {#if isVisible}
-                    <motion.div
-                        key="box"
-                        initial={{ opacity: 0, scale: 0 }}
-                        animate={{ opacity: 1, scale: 1 }}
-                        exit={{ opacity: 0, scale: 0 }}
-                        transition={{ type: 'spring', stiffness: 300, damping: 25 }}
-                        style={styleString(() => ({
-                            width: 100,
-                            height: 100,
-                            borderRadius: 16,
-                            backgroundColor: '#06b6d4',
-                            color: '#0f1115',
-                            fontWeight: 600,
-                            transformOrigin: 'center',
-                            textAlign: 'center',
-                            lineHeight: '100px'
-                        }))}
-                    >
-                        Hello
-                    </motion.div>
-                {/if}
-            </AnimatePresence>
-        </div>
+        <div class="strip">
+            <div class="strip-head">
+                <span class="micro">// presence</span>
+                <span class="micro state">
+                    state: {isVisible ? 'mounted' : 'unmounted'}
+                </span>
+            </div>
 
-        <motion.button
-            onclick={() => (isVisible = !isVisible)}
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-            style={styleString(() => ({
-                width: 100,
-                padding: '0.75rem 1.5rem',
-                borderRadius: 8,
-                border: 'none',
-                backgroundColor: '#06b6d4',
-                color: '#0f1115',
-                cursor: 'pointer',
-                fontWeight: 600,
-                textAlign: 'center'
-            }))}
-        >
-            {isVisible ? 'Hide' : 'Show'}
-        </motion.button>
+            <!-- Fixed-height stage so the footer never moves as the unit enters/exits. -->
+            <div class="stage">
+                <AnimatePresence>
+                    {#if isVisible}
+                        <motion.div
+                            key="unit"
+                            initial={{ opacity: 0, scale: 0 }}
+                            animate={{ opacity: 1, scale: 1 }}
+                            exit={{ opacity: 0, scale: 0 }}
+                            transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+                            style={styleString(() => ({
+                                transformOrigin: 'center'
+                            }))}
+                        >
+                            <article class="unit">
+                                <header class="unit-head">
+                                    <motion.span
+                                        animate={{ opacity: [1, 0.35, 1] }}
+                                        transition={{
+                                            duration: 1.6,
+                                            repeat: Infinity,
+                                            ease: 'easeInOut'
+                                        }}
+                                        style={styleString(() => ({
+                                            flex: 'none',
+                                            width: 8,
+                                            height: 8,
+                                            borderRadius: '50%',
+                                            backgroundColor: 'var(--brut-accent, #247768)'
+                                        }))}
+                                    ></motion.span>
+                                    <span class="unit-name">unit.01</span>
+                                </header>
+                                <dl class="unit-meta">
+                                    <div>
+                                        <dt>enter</dt>
+                                        <dd>scale 0 → 1</dd>
+                                    </div>
+                                    <div>
+                                        <dt>exit</dt>
+                                        <dd>scale 1 → 0</dd>
+                                    </div>
+                                </dl>
+                            </article>
+                        </motion.div>
+                    {/if}
+                </AnimatePresence>
+            </div>
 
-        <div class="status">
-            State: <span class="state-value">{isVisible ? 'visible' : 'hidden'}</span>
+            <div class="strip-foot">
+                <motion.button
+                    onclick={() => (isVisible = !isVisible)}
+                    whileHover={{ scale: 1.04 }}
+                    whileTap={{ scale: 0.96 }}
+                    transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+                    style={styleString(() => ({
+                        fontFamily: 'var(--brut-mono, monospace)',
+                        fontSize: '0.6875rem',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.08em',
+                        border: '1px solid var(--brut-accent, #247768)',
+                        backgroundColor: 'var(--brut-accent-soft, rgba(36, 119, 104, 0.1))',
+                        color: 'var(--brut-accent, #247768)',
+                        padding: '0.5rem 0.875rem',
+                        cursor: 'pointer'
+                    }))}
+                >
+                    {isVisible ? '– unmount unit' : '+ mount unit'}
+                </motion.button>
+                <span class="micro">spring: 300 / 25</span>
+            </div>
         </div>
     </MotionConfig>
 </div>
@@ -67,29 +97,105 @@
 <style>
     .dk-demo-shell {
         display: flex;
-        flex-direction: column;
         align-items: center;
         justify-content: center;
-        gap: 1rem;
-        padding: 2rem;
+        padding: 1.5rem;
         min-height: 360px;
     }
 
+    .strip {
+        width: 100%;
+        max-width: 420px;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .micro {
+        font-family: var(--brut-mono, monospace);
+        font-size: 0.6875rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--brut-ink-3, #9a9a9a);
+    }
+
+    .state {
+        color: var(--brut-accent, #247768);
+    }
+
+    .strip-head,
+    .strip-foot {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        border-bottom: 1px dashed var(--brut-rule-2, #bbc4c0);
+        padding-bottom: 0.5rem;
+    }
+
+    .strip-foot {
+        border-bottom: none;
+        border-top: 1px dashed var(--brut-rule-2, #bbc4c0);
+        padding-top: 0.75rem;
+        padding-bottom: 0;
+    }
+
     .stage {
-        height: 100px;
+        height: 9rem;
         display: flex;
         align-items: center;
         justify-content: center;
     }
 
-    .status {
-        font-size: 0.875rem;
-        color: var(--color-text-secondary);
+    .unit {
+        width: 13rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        border: 1px solid var(--brut-rule-2, #bbc4c0);
+        background: var(--brut-bg-2, #eef4f1);
+        padding: 0.875rem;
+        box-shadow: 6px 6px 0 var(--brut-rule, #d6dedb);
     }
 
-    .state-value {
-        font-family: monospace;
-        font-weight: 600;
-        color: var(--color-text-primary);
+    .unit-head {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
+    .unit-name {
+        font-family: var(--brut-mono, monospace);
+        font-size: 0.75rem;
+        font-weight: 700;
+        color: var(--brut-ink, #0a0a0a);
+    }
+
+    .unit-meta {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        margin: 0;
+    }
+
+    .unit-meta div {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.5rem;
+    }
+
+    .unit-meta dt {
+        font-family: var(--brut-mono, monospace);
+        font-size: 0.625rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--brut-ink-3, #9a9a9a);
+    }
+
+    .unit-meta dd {
+        margin: 0;
+        font-family: var(--brut-mono, monospace);
+        font-size: 0.6875rem;
+        color: var(--brut-ink-2, #525252);
     }
 </style>

--- a/docs/src/lib/examples/grid-exit/demos/Default.svelte
+++ b/docs/src/lib/examples/grid-exit/demos/Default.svelte
@@ -1,0 +1,302 @@
+<script lang="ts">
+    import { AnimatePresence, motion, styleString } from '@humanspeak/svelte-motion'
+
+    // A fixed 3-column "processing strip". Every card has `layout` plus
+    // enter/exit animations inside `<AnimatePresence>`: completing a job
+    // fades its card out IN PLACE (sync mode holds the grid slot until the
+    // exit finishes), then the survivors FLIP smoothly into the freed
+    // column — no snapping, no double jumps.
+    type Job = {
+        id: number
+        name: string
+        rows: number
+        startedAt: number
+    }
+
+    const JOB_NAMES = [
+        'cdc.inv_transaction',
+        'sync.orders_v2',
+        'ingest.users',
+        'etl.payments',
+        'index.search_docs',
+        'vacuum.analytics'
+    ]
+
+    const MAX_SLOTS = 3
+
+    let nextId = 0
+    let now = $state(Date.now())
+
+    const spawnJob = (): Job => ({
+        id: nextId++,
+        name: JOB_NAMES[nextId % JOB_NAMES.length],
+        rows: 12_000 + Math.floor(Math.random() * 90_000),
+        startedAt: Date.now()
+    })
+
+    let jobs = $state<Job[]>([spawnJob(), spawnJob(), spawnJob()])
+
+    // Live row counters + elapsed clocks make the strip feel like real work.
+    $effect(() => {
+        const tick = setInterval(() => {
+            now = Date.now()
+            for (const job of jobs) {
+                job.rows += 800 + Math.floor(Math.random() * 4200)
+            }
+        }, 1000)
+        return () => clearInterval(tick)
+    })
+
+    const complete = (id: number) => {
+        jobs = jobs.filter((job) => job.id !== id)
+    }
+
+    const enqueue = () => {
+        if (jobs.length < MAX_SLOTS) {
+            jobs = [...jobs, spawnJob()]
+        }
+    }
+
+    const elapsed = (job: Job): string => {
+        const seconds = Math.max(0, Math.floor((now - job.startedAt) / 1000))
+        return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, '0')}`
+    }
+</script>
+
+<!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
+<div class="dk-demo-shell">
+    <div class="strip">
+        <div class="strip-head">
+            <span class="micro">// processing queue</span>
+            <span class="micro counter">
+                {String(jobs.length).padStart(2, '0')} / {String(MAX_SLOTS).padStart(2, '0')} slots
+            </span>
+        </div>
+
+        <div class="stage">
+            {#if jobs.length === 0}
+                <div class="empty">
+                    <span class="micro">// idle — queue drained</span>
+                </div>
+            {:else}
+                <div class="grid">
+                    <AnimatePresence>
+                        {#each jobs as job (job.id)}
+                            <motion.div
+                                key={job.id}
+                                layout
+                                initial={{ opacity: 0, y: 14, scale: 0.96 }}
+                                animate={{ opacity: 1, y: 0, scale: 1 }}
+                                exit={{ opacity: 0, y: -14, scale: 0.96 }}
+                                transition={{ type: 'spring', stiffness: 400, damping: 32 }}
+                                style={styleString(() => ({
+                                    height: '100%',
+                                    minWidth: 0
+                                }))}
+                            >
+                                <article class="card">
+                                    <header class="card-head">
+                                        <motion.span
+                                            animate={{ opacity: [1, 0.35, 1] }}
+                                            transition={{
+                                                duration: 1.6,
+                                                repeat: Infinity,
+                                                ease: 'easeInOut'
+                                            }}
+                                            style={styleString(() => ({
+                                                flex: 'none',
+                                                width: 8,
+                                                height: 8,
+                                                borderRadius: '50%',
+                                                backgroundColor: 'var(--brut-accent, #247768)'
+                                            }))}
+                                        ></motion.span>
+                                        <span class="name">{job.name}</span>
+                                        <motion.button
+                                            aria-label={`complete ${job.name}`}
+                                            onclick={() => complete(job.id)}
+                                            whileHover={{ scale: 1.15 }}
+                                            whileTap={{ scale: 0.85 }}
+                                            style={styleString(() => ({
+                                                marginLeft: 'auto',
+                                                flex: 'none',
+                                                border: '1px solid var(--brut-rule-2, #bbc4c0)',
+                                                backgroundColor: 'transparent',
+                                                color: 'var(--brut-ink-2, #525252)',
+                                                fontSize: '0.6875rem',
+                                                lineHeight: 1,
+                                                width: '1.25rem',
+                                                height: '1.25rem',
+                                                cursor: 'pointer'
+                                            }))}
+                                        >
+                                            ✕
+                                        </motion.button>
+                                    </header>
+                                    <dl class="card-meta">
+                                        <div>
+                                            <dt>rows</dt>
+                                            <dd>{job.rows.toLocaleString()}</dd>
+                                        </div>
+                                        <div>
+                                            <dt>elapsed</dt>
+                                            <dd>{elapsed(job)}</dd>
+                                        </div>
+                                    </dl>
+                                </article>
+                            </motion.div>
+                        {/each}
+                    </AnimatePresence>
+                </div>
+            {/if}
+        </div>
+
+        <div class="strip-foot">
+            <motion.button
+                onclick={enqueue}
+                disabled={jobs.length >= MAX_SLOTS}
+                whileHover={{ scale: 1.04 }}
+                whileTap={{ scale: 0.96 }}
+                transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+                style={styleString(() => ({
+                    fontFamily: 'var(--brut-mono, monospace)',
+                    fontSize: '0.6875rem',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.08em',
+                    border: '1px solid var(--brut-accent, #247768)',
+                    backgroundColor: 'var(--brut-accent-soft, rgba(36, 119, 104, 0.1))',
+                    color: 'var(--brut-accent, #247768)',
+                    padding: '0.5rem 0.875rem',
+                    cursor: jobs.length >= MAX_SLOTS ? 'not-allowed' : 'pointer',
+                    opacity: jobs.length >= MAX_SLOTS ? 0.4 : 1
+                }))}
+            >
+                + enqueue job
+            </motion.button>
+            <span class="micro">mode: sync / layout: flip</span>
+        </div>
+    </div>
+</div>
+
+<style>
+    .dk-demo-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1.5rem;
+        min-height: 360px;
+    }
+
+    .strip {
+        width: 100%;
+        max-width: 640px;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .micro {
+        font-family: var(--brut-mono, monospace);
+        font-size: 0.6875rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--brut-ink-3, #9a9a9a);
+    }
+
+    .strip-head,
+    .strip-foot {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        border-bottom: 1px dashed var(--brut-rule-2, #bbc4c0);
+        padding-bottom: 0.5rem;
+    }
+
+    .strip-foot {
+        border-bottom: none;
+        border-top: 1px dashed var(--brut-rule-2, #bbc4c0);
+        padding-top: 0.75rem;
+        padding-bottom: 0;
+    }
+
+    .counter {
+        color: var(--brut-accent, #247768);
+    }
+
+    .stage {
+        height: 8.5rem;
+    }
+
+    .grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0.75rem;
+        height: 100%;
+    }
+
+    .empty {
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: 1px dashed var(--brut-rule-2, #bbc4c0);
+    }
+
+    .card {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        border: 1px solid var(--brut-rule-2, #bbc4c0);
+        background: var(--brut-bg-2, #eef4f1);
+        padding: 0.75rem;
+        min-width: 0;
+    }
+
+    .card-head {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        min-width: 0;
+    }
+
+    .name {
+        font-family: var(--brut-mono, monospace);
+        font-size: 0.75rem;
+        font-weight: 700;
+        color: var(--brut-ink, #0a0a0a);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .card-meta {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        margin: 0;
+    }
+
+    .card-meta div {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.5rem;
+    }
+
+    .card-meta dt {
+        font-family: var(--brut-mono, monospace);
+        font-size: 0.625rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--brut-ink-3, #9a9a9a);
+    }
+
+    .card-meta dd {
+        margin: 0;
+        font-family: var(--brut-mono, monospace);
+        font-size: 0.6875rem;
+        font-variant-numeric: tabular-nums;
+        color: var(--brut-ink-2, #525252);
+    }
+</style>

--- a/docs/src/routes/examples/+page.ts
+++ b/docs/src/routes/examples/+page.ts
@@ -64,6 +64,11 @@ const EXAMPLES: Record<string, ExampleEntry> = {
         title: 'Fancy Like Button',
         description: 'Interactive fancy like button animation example using Svelte Motion.'
     },
+    'grid-exit': {
+        title: 'Grid Exit',
+        description:
+            'Complete a card out of a CSS grid — the exit fades in place while surviving cards FLIP into the freed slot.'
+    },
     'hover-and-tap': {
         title: 'Hover and Tap',
         description: 'Interactive hover and tap animation example using Svelte Motion.'

--- a/docs/src/routes/examples/animate-presence/+page.svelte
+++ b/docs/src/routes/examples/animate-presence/+page.svelte
@@ -63,7 +63,7 @@
         <li>
             <Sparkles />
             <span>
-                The cyan box has <code>initial</code>, <code>animate</code>, and <code>exit</code>
+                The unit card has <code>initial</code>, <code>animate</code>, and <code>exit</code>
                 props. On mount, motion tweens from <code>initial → animate</code>; on unmount
                 inside <code>AnimatePresence</code>, it tweens from <code>animate → exit</code> before
                 the DOM node is removed.

--- a/docs/src/routes/examples/grid-exit/+page.svelte
+++ b/docs/src/routes/examples/grid-exit/+page.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+    import {
+        CodeReferenceV2,
+        ExampleV2,
+        type ExampleSection,
+        formatSheetLabel
+    } from '@humanspeak/docs-kit'
+    import { Grid3x3, LogOut, MoveHorizontal } from '@lucide/svelte'
+    import { demoCodeSample } from '$lib/demo-loaders'
+    import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
+    import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import GridExitDefault from '$lib/examples/grid-exit/demos/Default.svelte'
+
+    const breadcrumbs = getBreadcrumbContext()
+    const seo = getSeoContext()
+    if (breadcrumbs) {
+        breadcrumbs.breadcrumbs = [{ title: 'Examples', href: '/examples' }, { title: 'Grid Exit' }]
+    }
+    if (seo) {
+        seo.title = 'Grid Exit | Svelte Motion'
+        seo.description =
+            'Remove cards from a CSS grid with AnimatePresence exit animations that hold their slot until the exit finishes, then FLIP the surviving cards into place with the layout prop.'
+        seo.ogTitle = 'Grid Exit'
+        seo.h1 = { title: 'Grid Exit', mode: 'sr-only' }
+        seo.ogTagline =
+            'Exit a grid card in place, then slide the survivors into the freed slot — AnimatePresence + layout'
+        seo.ogFeatures = ['Exit In Place', 'Slot Preservation', 'Sibling FLIP', 'Keyed Lists']
+        seo.ogSlug = 'examples-grid-exit'
+    }
+
+    const SOURCE_URL =
+        'https://github.com/humanspeak/svelte-motion/blob/main/docs/src/lib/examples/'
+
+    const sections: ExampleSection[] = [
+        {
+            figId: 'FIG-001',
+            tag: 'GRID-EXIT',
+            title: { prefix: 'exit in place, then ', accent: 'FLIP', end: ' the survivors.' },
+            description:
+                'A fixed 3-column processing strip. Each card combines `layout` with enter/exit animations inside `<AnimatePresence>`: completing a job fades its card out in the slot it currently occupies, and only then do the surviving cards slide over — one smooth FLIP, no snapping.',
+            snippet: defaultSection,
+            codeSnippet: defaultCode,
+            notes: defaultNotes,
+            barCells: [{ k: 'pattern', v: 'exit + FLIP' }],
+            sourceUrl: `${SOURCE_URL}grid-exit/demos/Default.svelte`
+        }
+    ]
+</script>
+
+{#snippet defaultSection()}
+    <GridExitDefault />
+{/snippet}
+{#snippet defaultNotes()}
+    <ul>
+        <li>
+            <LogOut />
+            <span>
+                In the default <code>sync</code> mode, an exiting card keeps its grid slot until its
+                <code>exit</code> animation finishes — the card fades out exactly where it stands, even
+                when earlier removals have already moved it to a new column. Survivors don't reflow mid-exit.
+            </span>
+        </li>
+        <li>
+            <MoveHorizontal />
+            <span>
+                The <code>layout</code> prop does the second half: once the slot frees up, each surviving
+                card FLIPs from its old column to its new one on the same spring — position is animated
+                with transforms, so nothing repaints or stutters.
+            </span>
+        </li>
+        <li>
+            <Grid3x3 />
+            <span>
+                The cards render from a keyed <code>&#123;#each&#125;</code> with a stable
+                <code>key</code> per job. Stable keys are what let
+                <code>AnimatePresence</code> distinguish "this card left" from "every card changed" —
+                without them, exits and FLIPs can't be attributed to the right element.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet defaultCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample('grid-exit/demos/Default.svelte', 'grid-exit-default', 'Default.svelte')
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#each sections as section, i (section.figId)}
+    <ExampleV2
+        figId={section.figId}
+        tag={section.tag}
+        title={section.title}
+        description={section.description}
+        mode={section.mode ?? 'live'}
+        sheetLabel={formatSheetLabel(i, sections.length)}
+        barCells={section.barCells}
+        sourceUrl={section.sourceUrl}
+        codeSnippet={section.codeSnippet}
+        codeLabel="show code"
+        notes={section.notes}
+    >
+        {@render section.snippet()}
+    </ExampleV2>
+{/each}

--- a/docs/src/routes/examples/grid-exit/+page.ts
+++ b/docs/src/routes/examples/grid-exit/+page.ts
@@ -1,0 +1,9 @@
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => {
+    return {
+        title: 'Grid Exit',
+        description:
+            'Remove cards from a CSS grid with exit animations that hold their slot, then FLIP the survivors into place'
+    }
+}

--- a/e2e/_helpers/transform.ts
+++ b/e2e/_helpers/transform.ts
@@ -160,3 +160,41 @@ export const sampleTransformSeries = (
             ),
         { selectors, ms }
     )
+
+/** One per-frame rect sample from `sampleRectLeftSeries`. */
+export type RectLeftSample = { atMs: number; lefts: Record<string, number | null> }
+
+/**
+ * Sample the viewport left edge of one or more keyed selectors every
+ * animation frame for `ms` milliseconds, entirely in-page (same rationale as
+ * `sampleTransformSeries`: no protocol round trip between frames). A selector
+ * that matches nothing yields `null` for that frame — presence/absence is
+ * part of the signal (e.g. an exit clone's lifetime).
+ */
+export const sampleRectLeftSeries = (
+    page: Page,
+    selectors: Record<string, string>,
+    ms: number
+): Promise<RectLeftSample[]> =>
+    page.evaluate(
+        ({ selectors, ms }) =>
+            new Promise<Array<{ atMs: number; lefts: Record<string, number | null> }>>(
+                (resolve) => {
+                    const samples: Array<{ atMs: number; lefts: Record<string, number | null> }> =
+                        []
+                    const start = performance.now()
+                    const read = () => {
+                        const lefts: Record<string, number | null> = {}
+                        for (const [key, selector] of Object.entries(selectors)) {
+                            const el = document.querySelector(selector)
+                            lefts[key] = el ? el.getBoundingClientRect().left : null
+                        }
+                        samples.push({ atMs: Math.round(performance.now() - start), lefts })
+                        if (performance.now() - start < ms) requestAnimationFrame(read)
+                        else resolve(samples)
+                    }
+                    requestAnimationFrame(read)
+                }
+            ),
+        { selectors, ms }
+    )

--- a/e2e/animate-presence/grid-exit.spec.ts
+++ b/e2e/animate-presence/grid-exit.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test, type Page } from '@playwright/test'
+
+/**
+ * Regression coverage for exit-placeholder slot preservation in a CSS grid
+ * (three `layout` cards inside `AnimatePresence`). Removing a card must:
+ *
+ * 1. Hold the exiting card's grid slot until its exit finishes — surviving
+ *    cards do not move while the clone fades.
+ * 2. Then FLIP the survivors into their new slots — a smooth slide with
+ *    intermediate frames, never an instant snap or a jump-then-return.
+ *
+ * Previously the placeholder was inserted before the whole AnimatePresence
+ * `display: contents` container (always column 1), shoving every survivor a
+ * column over during the exit and back after it.
+ */
+
+type FrameSample = {
+    t: number
+    lefts: Record<string, number | null>
+    cloneVisible: boolean
+}
+
+const gotoGridExit = async (page: Page) => {
+    await page.goto('/tests/animate-presence/grid-exit?@isPlaywright=true')
+    await expect(page.getByTestId('card-c')).toBeVisible()
+    // Wait for enter animations to settle so FLIP measurements start clean.
+    await page.waitForFunction(() => {
+        const el = document.querySelector('[data-testid="card-c"]')
+        if (!el) return false
+        const tf = getComputedStyle(el).transform
+        return tf === 'none' || tf === 'matrix(1, 0, 0, 1, 0, 0)'
+    })
+    await page.waitForTimeout(250)
+}
+
+/**
+ * Click a remove button and record every card's viewport left edge each
+ * animation frame until the exit clone is gone and the layout settles.
+ */
+const sampleRemoval = async (page: Page, buttonId: string): Promise<FrameSample[]> => {
+    const samplesPromise = page.evaluate(
+        () =>
+            new Promise<FrameSample[]>((resolve) => {
+                const out: FrameSample[] = []
+                const t0 = performance.now()
+                const sample = () => {
+                    const lefts: Record<string, number | null> = {}
+                    for (const id of ['a', 'b', 'c']) {
+                        const el = document.querySelector(
+                            `[data-testid="card-${id}"]:not([data-clone])`
+                        )
+                        lefts[id] = el ? el.getBoundingClientRect().left : null
+                    }
+                    const clone = document.querySelector('[data-clone="true"]')
+                    out.push({
+                        t: performance.now() - t0,
+                        lefts,
+                        cloneVisible: !!clone
+                    })
+                    if (performance.now() - t0 < 1400) requestAnimationFrame(sample)
+                    else resolve(out)
+                }
+                requestAnimationFrame(sample)
+            })
+    )
+    await page.waitForTimeout(30)
+    await page.getByTestId(buttonId).click()
+    return samplesPromise
+}
+
+const settledLeft = (samples: FrameSample[], id: string): number => {
+    const last = samples[samples.length - 1].lefts[id]
+    expect(last, `card-${id} should still be in the DOM`).not.toBeNull()
+    return last as number
+}
+
+/** Frames captured while the exit clone was fading (the hold window). */
+const holdFrames = (samples: FrameSample[]): FrameSample[] => samples.filter((s) => s.cloneVisible)
+
+/** Frames captured after the exit finished (the FLIP window). */
+const flipFrames = (samples: FrameSample[]): FrameSample[] => {
+    const lastCloneIndex = samples.map((s) => s.cloneVisible).lastIndexOf(true)
+    return samples.slice(lastCloneIndex + 1)
+}
+
+const expectHeld = (frames: FrameSample[], id: string, at: number) => {
+    expect(frames.length, 'exit clone should be observable while it fades').toBeGreaterThan(3)
+    for (const frame of frames) {
+        expect(
+            Math.abs((frame.lefts[id] ?? Number.NaN) - at),
+            `card-${id} must hold its slot while the exit runs (t=${Math.round(frame.t)}ms)`
+        ).toBeLessThan(2)
+    }
+}
+
+const expectSmoothSlide = (frames: FrameSample[], id: string, from: number, to: number) => {
+    const lefts = frames.map((f) => f.lefts[id]).filter((l): l is number => l !== null)
+    const min = Math.min(from, to)
+    const max = Math.max(from, to)
+    const intermediate = new Set(
+        lefts.filter((l) => l > min + 2 && l < max - 2).map((l) => Math.round(l))
+    )
+    expect(
+        intermediate.size,
+        `card-${id} must animate ${from}→${to} through intermediate frames, not snap`
+    ).toBeGreaterThanOrEqual(3)
+    expect(Math.abs(lefts[lefts.length - 1] - to), `card-${id} must settle at ${to}`).toBeLessThan(
+        2
+    )
+}
+
+test.describe('AnimatePresence grid exit', () => {
+    test('middle card exit: survivors hold, then the right card slides into the gap', async ({
+        page
+    }) => {
+        await gotoGridExit(page)
+        const a0 = await page.getByTestId('card-a').boundingBox()
+        const b0 = await page.getByTestId('card-b').boundingBox()
+        const c0 = await page.getByTestId('card-c').boundingBox()
+
+        const samples = await sampleRemoval(page, 'remove-middle')
+
+        expectHeld(holdFrames(samples), 'a', a0!.x)
+        expectHeld(holdFrames(samples), 'c', c0!.x)
+        expectSmoothSlide(flipFrames(samples), 'c', c0!.x, b0!.x)
+        expect(Math.abs(settledLeft(samples, 'a') - a0!.x)).toBeLessThan(2)
+    })
+
+    test('first card exit: both survivors hold, then slide left together', async ({ page }) => {
+        await gotoGridExit(page)
+        const a0 = await page.getByTestId('card-a').boundingBox()
+        const b0 = await page.getByTestId('card-b').boundingBox()
+        const c0 = await page.getByTestId('card-c').boundingBox()
+
+        const samples = await sampleRemoval(page, 'remove-first')
+
+        expectHeld(holdFrames(samples), 'b', b0!.x)
+        expectHeld(holdFrames(samples), 'c', c0!.x)
+        expectSmoothSlide(flipFrames(samples), 'b', b0!.x, a0!.x)
+        expectSmoothSlide(flipFrames(samples), 'c', c0!.x, b0!.x)
+    })
+
+    test('last card exit: survivors never move', async ({ page }) => {
+        await gotoGridExit(page)
+        const a0 = await page.getByTestId('card-a').boundingBox()
+        const b0 = await page.getByTestId('card-b').boundingBox()
+
+        const samples = await sampleRemoval(page, 'remove-last')
+
+        expectHeld(holdFrames(samples), 'a', a0!.x)
+        expectHeld(holdFrames(samples), 'b', b0!.x)
+        for (const frame of samples) {
+            expect(Math.abs((frame.lefts.a ?? Number.NaN) - a0!.x)).toBeLessThan(2)
+            expect(Math.abs((frame.lefts.b ?? Number.NaN) - b0!.x)).toBeLessThan(2)
+        }
+    })
+})

--- a/e2e/animate-presence/grid-exit.spec.ts
+++ b/e2e/animate-presence/grid-exit.spec.ts
@@ -1,11 +1,13 @@
 import { expect, test, type Page } from '@playwright/test'
+import { sampleRectLeftSeries, type RectLeftSample } from '../_helpers/transform'
 
 /**
  * Regression coverage for exit-placeholder slot preservation in a CSS grid
  * (three `layout` cards inside `AnimatePresence`). Removing a card must:
  *
  * 1. Hold the exiting card's grid slot until its exit finishes — surviving
- *    cards do not move while the clone fades.
+ *    cards do not move while the clone fades, and the clone fades in the
+ *    card's CURRENT slot (not its registration-time slot).
  * 2. Then FLIP the survivors into their new slots — a smooth slide with
  *    intermediate frames, never an instant snap or a jump-then-return.
  *
@@ -14,11 +16,11 @@ import { expect, test, type Page } from '@playwright/test'
  * column over during the exit and back after it.
  */
 
-type FrameSample = {
-    t: number
-    lefts: Record<string, number | null>
-    cloneVisible: boolean
-    cloneLeft: number | null
+const SAMPLE_SELECTORS = {
+    a: '[data-testid="card-a"]:not([data-clone])',
+    b: '[data-testid="card-b"]:not([data-clone])',
+    c: '[data-testid="card-c"]:not([data-clone])',
+    clone: '[data-clone="true"]'
 }
 
 const gotoGridExit = async (page: Page) => {
@@ -35,68 +37,45 @@ const gotoGridExit = async (page: Page) => {
 }
 
 /**
- * Click a remove button and record every card's viewport left edge each
- * animation frame until the exit clone is gone and the layout settles.
+ * Click a remove button and record every tracked element's viewport left
+ * edge each animation frame until the exit clone is gone and the layout
+ * settles.
  */
-const sampleRemoval = async (page: Page, buttonId: string): Promise<FrameSample[]> => {
-    const samplesPromise = page.evaluate(
-        () =>
-            new Promise<FrameSample[]>((resolve) => {
-                const out: FrameSample[] = []
-                const t0 = performance.now()
-                const sample = () => {
-                    const lefts: Record<string, number | null> = {}
-                    for (const id of ['a', 'b', 'c']) {
-                        const el = document.querySelector(
-                            `[data-testid="card-${id}"]:not([data-clone])`
-                        )
-                        lefts[id] = el ? el.getBoundingClientRect().left : null
-                    }
-                    const clone = document.querySelector('[data-clone="true"]')
-                    out.push({
-                        t: performance.now() - t0,
-                        lefts,
-                        cloneVisible: !!clone,
-                        cloneLeft: clone ? clone.getBoundingClientRect().left : null
-                    })
-                    if (performance.now() - t0 < 1400) requestAnimationFrame(sample)
-                    else resolve(out)
-                }
-                requestAnimationFrame(sample)
-            })
-    )
+const sampleRemoval = async (page: Page, buttonId: string): Promise<RectLeftSample[]> => {
+    const samplesPromise = sampleRectLeftSeries(page, SAMPLE_SELECTORS, 1400)
     await page.waitForTimeout(30)
     await page.getByTestId(buttonId).click()
     return samplesPromise
 }
 
-const settledLeft = (samples: FrameSample[], id: string): number => {
-    const last = samples[samples.length - 1].lefts[id]
-    expect(last, `card-${id} should still be in the DOM`).not.toBeNull()
+const settledLeft = (samples: RectLeftSample[], key: string): number => {
+    const last = samples[samples.length - 1].lefts[key]
+    expect(last, `card-${key} should still be in the DOM`).not.toBeNull()
     return last as number
 }
 
 /** Frames captured while the exit clone was fading (the hold window). */
-const holdFrames = (samples: FrameSample[]): FrameSample[] => samples.filter((s) => s.cloneVisible)
+const holdFrames = (samples: RectLeftSample[]): RectLeftSample[] =>
+    samples.filter((s) => s.lefts.clone !== null)
 
 /** Frames captured after the exit finished (the FLIP window). */
-const flipFrames = (samples: FrameSample[]): FrameSample[] => {
-    const lastCloneIndex = samples.map((s) => s.cloneVisible).lastIndexOf(true)
+const flipFrames = (samples: RectLeftSample[]): RectLeftSample[] => {
+    const lastCloneIndex = samples.map((s) => s.lefts.clone !== null).lastIndexOf(true)
     return samples.slice(lastCloneIndex + 1)
 }
 
-const expectHeld = (frames: FrameSample[], id: string, at: number) => {
+const expectHeld = (frames: RectLeftSample[], key: string, at: number) => {
     expect(frames.length, 'exit clone should be observable while it fades').toBeGreaterThan(3)
     for (const frame of frames) {
         expect(
-            Math.abs((frame.lefts[id] ?? Number.NaN) - at),
-            `card-${id} must hold its slot while the exit runs (t=${Math.round(frame.t)}ms)`
+            Math.abs((frame.lefts[key] ?? Number.NaN) - at),
+            `${key} must hold its slot while the exit runs (t=${frame.atMs}ms)`
         ).toBeLessThan(2)
     }
 }
 
-const expectSmoothSlide = (frames: FrameSample[], id: string, from: number, to: number) => {
-    const lefts = frames.map((f) => f.lefts[id]).filter((l): l is number => l !== null)
+const expectSmoothSlide = (frames: RectLeftSample[], key: string, from: number, to: number) => {
+    const lefts = frames.map((f) => f.lefts[key]).filter((l): l is number => l !== null)
     const min = Math.min(from, to)
     const max = Math.max(from, to)
     const intermediate = new Set(
@@ -104,11 +83,9 @@ const expectSmoothSlide = (frames: FrameSample[], id: string, from: number, to: 
     )
     expect(
         intermediate.size,
-        `card-${id} must animate ${from}→${to} through intermediate frames, not snap`
+        `${key} must animate ${from}→${to} through intermediate frames, not snap`
     ).toBeGreaterThanOrEqual(3)
-    expect(Math.abs(lefts[lefts.length - 1] - to), `card-${id} must settle at ${to}`).toBeLessThan(
-        2
-    )
+    expect(Math.abs(lefts[lefts.length - 1] - to), `${key} must settle at ${to}`).toBeLessThan(2)
 }
 
 test.describe('AnimatePresence grid exit', () => {
@@ -121,9 +98,10 @@ test.describe('AnimatePresence grid exit', () => {
         const c0 = await page.getByTestId('card-c').boundingBox()
 
         const samples = await sampleRemoval(page, 'remove-middle')
+        const hold = holdFrames(samples)
 
-        expectHeld(holdFrames(samples), 'a', a0!.x)
-        expectHeld(holdFrames(samples), 'c', c0!.x)
+        expectHeld(hold, 'a', a0!.x)
+        expectHeld(hold, 'c', c0!.x)
         expectSmoothSlide(flipFrames(samples), 'c', c0!.x, b0!.x)
         expect(Math.abs(settledLeft(samples, 'a') - a0!.x)).toBeLessThan(2)
     })
@@ -135,9 +113,10 @@ test.describe('AnimatePresence grid exit', () => {
         const c0 = await page.getByTestId('card-c').boundingBox()
 
         const samples = await sampleRemoval(page, 'remove-first')
+        const hold = holdFrames(samples)
 
-        expectHeld(holdFrames(samples), 'b', b0!.x)
-        expectHeld(holdFrames(samples), 'c', c0!.x)
+        expectHeld(hold, 'b', b0!.x)
+        expectHeld(hold, 'c', c0!.x)
         expectSmoothSlide(flipFrames(samples), 'b', b0!.x, a0!.x)
         expectSmoothSlide(flipFrames(samples), 'c', c0!.x, b0!.x)
     })
@@ -164,13 +143,8 @@ test.describe('AnimatePresence grid exit', () => {
         // must fade where B currently is — not at B's registration-time slot.
         const samples = await sampleRemoval(page, 'remove-first')
         const hold = holdFrames(samples)
-        expect(hold.length, 'exit clone should be observable while it fades').toBeGreaterThan(3)
-        for (const frame of hold) {
-            expect(
-                Math.abs((frame.cloneLeft ?? Number.NaN) - a0!.x),
-                `exit clone must fade in the current slot (t=${Math.round(frame.t)}ms)`
-            ).toBeLessThan(2)
-        }
+
+        expectHeld(hold, 'clone', a0!.x)
         expectHeld(hold, 'c', b0!.x)
         expectSmoothSlide(flipFrames(samples), 'c', b0!.x, a0!.x)
     })

--- a/e2e/animate-presence/grid-exit.spec.ts
+++ b/e2e/animate-presence/grid-exit.spec.ts
@@ -18,6 +18,7 @@ type FrameSample = {
     t: number
     lefts: Record<string, number | null>
     cloneVisible: boolean
+    cloneLeft: number | null
 }
 
 const gotoGridExit = async (page: Page) => {
@@ -55,7 +56,8 @@ const sampleRemoval = async (page: Page, buttonId: string): Promise<FrameSample[
                     out.push({
                         t: performance.now() - t0,
                         lefts,
-                        cloneVisible: !!clone
+                        cloneVisible: !!clone,
+                        cloneLeft: clone ? clone.getBoundingClientRect().left : null
                     })
                     if (performance.now() - t0 < 1400) requestAnimationFrame(sample)
                     else resolve(out)
@@ -138,6 +140,39 @@ test.describe('AnimatePresence grid exit', () => {
         expectHeld(holdFrames(samples), 'c', c0!.x)
         expectSmoothSlide(flipFrames(samples), 'b', b0!.x, a0!.x)
         expectSmoothSlide(flipFrames(samples), 'c', c0!.x, b0!.x)
+    })
+
+    test('sequential removals: the exit clone fades in the current slot, not the registration slot', async ({
+        page
+    }) => {
+        await gotoGridExit(page)
+        const a0 = await page.getByTestId('card-a').boundingBox()
+        const b0 = await page.getByTestId('card-b').boundingBox()
+
+        // First removal: A exits, B slides into column 1, C into column 2.
+        await page.getByTestId('remove-first').click()
+        await expect
+            .poll(async () => {
+                const b = await page.getByTestId('card-b').boundingBox()
+                const clones = await page.locator('[data-clone="true"]').count()
+                return clones === 0 && Math.abs((b?.x ?? Number.NaN) - a0!.x) < 2
+            })
+            .toBe(true)
+        await page.waitForTimeout(150)
+
+        // Second removal: B (now first, sitting in column 1) exits. Its clone
+        // must fade where B currently is — not at B's registration-time slot.
+        const samples = await sampleRemoval(page, 'remove-first')
+        const hold = holdFrames(samples)
+        expect(hold.length, 'exit clone should be observable while it fades').toBeGreaterThan(3)
+        for (const frame of hold) {
+            expect(
+                Math.abs((frame.cloneLeft ?? Number.NaN) - a0!.x),
+                `exit clone must fade in the current slot (t=${Math.round(frame.t)}ms)`
+            ).toBeLessThan(2)
+        }
+        expectHeld(hold, 'c', b0!.x)
+        expectSmoothSlide(flipFrames(samples), 'c', b0!.x, a0!.x)
     })
 
     test('last card exit: survivors never move', async ({ page }) => {

--- a/src/lib/components/__tests__/PresenceKeyHarness.svelte
+++ b/src/lib/components/__tests__/PresenceKeyHarness.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import { motion } from '$lib'
+    import AnimatePresence from '$lib/components/AnimatePresence.svelte'
+
+    /**
+     * Renders a motion element as a direct AnimatePresence child with a
+     * caller-controlled `key`, so specs can exercise the direct-child key
+     * validation — including falsy-but-valid keys like `0`.
+     */
+    let { key }: { key?: string | number } = $props()
+</script>
+
+<AnimatePresence>
+    <!-- Cast until `key` accepts numbers — the fix widens the prop type. -->
+    <motion.div key={key as string} data-testid="presence-key-box">box</motion.div>
+</AnimatePresence>

--- a/src/lib/components/__tests__/PresenceKeyHarness.svelte
+++ b/src/lib/components/__tests__/PresenceKeyHarness.svelte
@@ -11,6 +11,5 @@
 </script>
 
 <AnimatePresence>
-    <!-- Cast until `key` accepts numbers — the fix widens the prop type. -->
-    <motion.div key={key as string} data-testid="presence-key-box">box</motion.div>
+    <motion.div {key} data-testid="presence-key-box">box</motion.div>
 </AnimatePresence>

--- a/src/lib/components/animatePresenceKey.component.spec.ts
+++ b/src/lib/components/animatePresenceKey.component.spec.ts
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/svelte'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import PresenceKeyHarness from './__tests__/PresenceKeyHarness.svelte'
+
+describe('AnimatePresence direct-child key validation', () => {
+    beforeEach(() => {
+        vi.stubGlobal(
+            'ResizeObserver',
+            class {
+                observe() {}
+                unobserve() {}
+                disconnect() {}
+            }
+        )
+    })
+
+    it('accepts falsy-but-valid keys like 0', () => {
+        const { container } = render(PresenceKeyHarness, { props: { key: 0 } })
+        expect(container.querySelector('[data-testid="presence-key-box"]')).toBeTruthy()
+    })
+
+    it('accepts string keys', () => {
+        const { container } = render(PresenceKeyHarness, { props: { key: 'box' } })
+        expect(container.querySelector('[data-testid="presence-key-box"]')).toBeTruthy()
+    })
+
+    it('throws a helpful error when the key is missing', () => {
+        expect(() => render(PresenceKeyHarness)).toThrow(/must have a `key` prop/)
+    })
+})

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -408,8 +408,9 @@
     const presenceDepth = getPresenceDepth()
 
     // Validate key prop only for direct children of AnimatePresence (depth 0)
-    // This matches Framer Motion behavior where only immediate children need keys
-    if (context && presenceDepth === 0 && !keyProp) {
+    // This matches Framer Motion behavior where only immediate children need
+    // keys. Null-check rather than falsiness: 0 and '' are valid keys.
+    if (context && presenceDepth === 0 && keyProp == null) {
         throw new Error(
             'motion elements that are direct children of AnimatePresence must have a `key` prop. ' +
                 'Example: <motion.div key="unique-id" />'
@@ -426,10 +427,12 @@
     // conditional unmounts are immediate unless wrapped in another boundary.
     const shouldRegisterPresenceExit = !!context && presenceDepth === 0 && !inPresenceChild
 
-    // Use the provided key for presence tracking
-    // When not inside AnimatePresence, use a stable identifier based on component instance
+    // Use the provided key for presence tracking, normalized to a string so
+    // numeric keys (e.g. 0) address the same registry entries as their
+    // string form. When not inside AnimatePresence, use a stable identifier
+    // based on component instance.
     // trunk-ignore(eslint/no-useless-assignment): false positive — presenceKey is used throughout the component
-    const presenceKey = keyProp ?? `motion-${++keyCounter}`
+    const presenceKey = keyProp != null ? String(keyProp) : `motion-${++keyCounter}`
 
     // Track previous key for key-change detection (simulates React's key-based remounting)
     // Plain variables (not $state) to avoid self-triggering the key-change $effect

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -523,6 +523,9 @@ export type MotionProps = {
      * Required when inside an AnimatePresence component.
      * Used to track enter/exit state and determine whether to animate.
      *
+     * Numbers are accepted (and normalized to strings internally), so keyed
+     * each-blocks can pass numeric ids — including falsy-but-valid `0`.
+     *
      * @example
      * ```svelte
      * <AnimatePresence>
@@ -532,7 +535,7 @@ export type MotionProps = {
      * </AnimatePresence>
      * ```
      */
-    key?: string
+    key?: string | number
     /** Variants define named animation states */
     variants?: Variants
     /**

--- a/src/lib/utils/presence.spec.ts
+++ b/src/lib/utils/presence.spec.ts
@@ -731,3 +731,113 @@ describe('presence depth context', () => {
         expect(deepDepth).toBe(3)
     })
 })
+
+describe('exit placeholder slot preservation', () => {
+    // Mirrors the real AnimatePresence DOM: a grid whose direct child is the
+    // `display: contents` presence container, with the motion children (and
+    // Svelte-injected <script> nodes) inside it. Svelte detaches a keyed
+    // child BEFORE unregisterChild runs, so the placeholder has to land in
+    // the exiting child's slot from captured sibling anchors alone.
+    let grid: HTMLElement
+    let wrapper: HTMLElement
+    let cardA: HTMLElement
+    let cardB: HTMLElement
+    let cardC: HTMLElement
+    let scriptB: HTMLElement
+
+    const detach = (...nodes: HTMLElement[]) => nodes.forEach((n) => n.remove())
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        document.body.innerHTML = ''
+
+        grid = document.createElement('div')
+        wrapper = document.createElement('div')
+        wrapper.className = 'animate-presence-container'
+        grid.appendChild(wrapper)
+        document.body.appendChild(grid)
+
+        cardA = document.createElement('div')
+        cardB = document.createElement('div')
+        cardC = document.createElement('div')
+        scriptB = document.createElement('script')
+        wrapper.append(cardA, cardB, scriptB, cardC)
+
+        vi.spyOn(window, 'getComputedStyle').mockImplementation((target) =>
+            mockComputedStyle(
+                target === wrapper
+                    ? { display: 'contents', position: 'static' }
+                    : { display: 'block', position: 'static' }
+            )
+        )
+        vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+            cb(0)
+            return 1
+        })
+    })
+
+    const registerAll = () => {
+        const ctx = createAnimatePresenceContext({ mode: 'sync' })
+        ctx.registerChild('a', cardA, { opacity: 0 })
+        ctx.registerChild('b', cardB, { opacity: 0 })
+        ctx.registerChild('c', cardC, { opacity: 0 })
+        return ctx
+    }
+
+    const placeholders = () =>
+        Array.from(document.querySelectorAll<HTMLElement>('[data-presence-placeholder="true"]'))
+
+    it('holds a detached middle child slot between its registered siblings', () => {
+        const ctx = registerAll()
+
+        detach(cardB, scriptB)
+        ctx.unregisterChild('b')
+
+        const [placeholder] = placeholders()
+        expect(placeholder).toBeTruthy()
+        expect(placeholder.parentElement).toBe(wrapper)
+        expect(placeholder.nextElementSibling).toBe(cardC)
+        expect(placeholder.previousElementSibling).toBe(cardA)
+    })
+
+    it('holds a detached last child slot after every surviving sibling', () => {
+        const ctx = registerAll()
+
+        detach(cardC)
+        ctx.unregisterChild('c')
+
+        const [placeholder] = placeholders()
+        expect(placeholder).toBeTruthy()
+        expect(placeholder.parentElement).toBe(wrapper)
+        expect(placeholder.previousElementSibling).toBe(scriptB)
+        expect(placeholder.nextElementSibling).toBeNull()
+    })
+
+    it('holds a detached first child slot before every surviving sibling', () => {
+        const ctx = registerAll()
+
+        detach(cardA)
+        ctx.unregisterChild('a')
+
+        const [placeholder] = placeholders()
+        expect(placeholder).toBeTruthy()
+        expect(placeholder.parentElement).toBe(wrapper)
+        expect(placeholder.nextElementSibling).toBe(cardB)
+    })
+
+    it('keeps slot order when two children detach in the same update', () => {
+        const ctx = registerAll()
+
+        detach(cardB, scriptB, cardC)
+        ctx.unregisterChild('b')
+        ctx.unregisterChild('c')
+
+        const [first, second] = placeholders()
+        expect(first).toBeTruthy()
+        expect(second).toBeTruthy()
+        expect(first.parentElement).toBe(wrapper)
+        expect(second.parentElement).toBe(wrapper)
+        expect(cardA.nextElementSibling).toBe(first)
+        expect(first.nextElementSibling).toBe(second)
+    })
+})

--- a/src/lib/utils/presence.spec.ts
+++ b/src/lib/utils/presence.spec.ts
@@ -33,6 +33,21 @@ vi.mock('motion', () => {
     }
 })
 
+// Shared DOMRect mock factory
+function makeRect(left: number, top = 0, width = 100, height = 100): DOMRect {
+    return {
+        x: left,
+        y: top,
+        top,
+        left,
+        bottom: top + height,
+        right: left + width,
+        width,
+        height,
+        toJSON: () => {}
+    }
+}
+
 // Minimal CSSStyleDeclaration mock factory
 function mockComputedStyle(overrides: Partial<CSSStyleDeclaration> = {}): CSSStyleDeclaration {
     const entries: string[] = ['borderRadius']
@@ -61,29 +76,8 @@ describe('presence context', () => {
         parent.appendChild(el)
 
         // Provide stable rects
-        vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
-            x: 10,
-            y: 20,
-            top: 20,
-            left: 10,
-            bottom: 120,
-            right: 110,
-            width: 100,
-            height: 100,
-            toJSON: () => {}
-        })
-
-        vi.spyOn(parent, 'getBoundingClientRect').mockReturnValue({
-            x: 0,
-            y: 0,
-            top: 0,
-            left: 0,
-            bottom: 200,
-            right: 200,
-            width: 200,
-            height: 200,
-            toJSON: () => {}
-        })
+        vi.spyOn(el, 'getBoundingClientRect').mockReturnValue(makeRect(10, 20))
+        vi.spyOn(parent, 'getBoundingClientRect').mockReturnValue(makeRect(0, 0, 200, 200))
 
         vi.spyOn(window, 'getComputedStyle').mockImplementation(() =>
             mockComputedStyle({ borderRadius: '8px', boxSizing: 'border-box' })
@@ -100,19 +94,7 @@ describe('presence context', () => {
         const ctx = createAnimatePresenceContext({})
         ctx.registerChild('k', el, { opacity: 0 })
 
-        const newRect = {
-            x: 12,
-            y: 22,
-            top: 22,
-            left: 12,
-            bottom: 122,
-            right: 112,
-            width: 100,
-            height: 100,
-            toJSON: () => {}
-        } as unknown as DOMRect
-
-        ctx.updateChildState('k', newRect, mockComputedStyle({ borderRadius: '12px' }))
+        ctx.updateChildState('k', makeRect(12, 22), mockComputedStyle({ borderRadius: '12px' }))
 
         // Trigger exit (also exercises clone creation)
         ctx.unregisterChild('k')
@@ -826,18 +808,6 @@ describe('exit placeholder slot preservation', () => {
     })
 
     it('positions the exit clone at the current slot, not the stale registration rect', () => {
-        const makeRect = (left: number): DOMRect => ({
-            x: left,
-            y: 0,
-            top: 0,
-            left,
-            bottom: 100,
-            right: left + 100,
-            width: 100,
-            height: 100,
-            toJSON: () => {}
-        })
-
         // B registers while sitting in column 2…
         vi.spyOn(cardB, 'getBoundingClientRect').mockReturnValue(makeRect(200))
         // …and the slot-holding placeholder (inserted at unregister time)

--- a/src/lib/utils/presence.spec.ts
+++ b/src/lib/utils/presence.spec.ts
@@ -825,6 +825,43 @@ describe('exit placeholder slot preservation', () => {
         expect(placeholder.nextElementSibling).toBe(cardB)
     })
 
+    it('positions the exit clone at the current slot, not the stale registration rect', () => {
+        const makeRect = (left: number): DOMRect => ({
+            x: left,
+            y: 0,
+            top: 0,
+            left,
+            bottom: 100,
+            right: left + 100,
+            width: 100,
+            height: 100,
+            toJSON: () => {}
+        })
+
+        // B registers while sitting in column 2…
+        vi.spyOn(cardB, 'getBoundingClientRect').mockReturnValue(makeRect(200))
+        // …and the slot-holding placeholder (inserted at unregister time)
+        // reflects where B's slot ACTUALLY is by then: column 1. A layout
+        // FLIP moved B there after a sibling exit — a position-only change
+        // the ResizeObserver-driven updateChildState never sees.
+        vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+            this: HTMLElement
+        ) {
+            return this.getAttribute?.('data-presence-placeholder') === 'true'
+                ? makeRect(0)
+                : makeRect(-1)
+        })
+
+        const ctx = registerAll()
+
+        detach(cardB, scriptB)
+        ctx.unregisterChild('b')
+
+        const clone = document.querySelector<HTMLElement>('[data-clone="true"]')
+        expect(clone).toBeTruthy()
+        expect(clone!.style.left).toBe('1px')
+    })
+
     it('keeps slot order when two children detach in the same update', () => {
         const ctx = registerAll()
 

--- a/src/lib/utils/presence.ts
+++ b/src/lib/utils/presence.ts
@@ -802,7 +802,7 @@ export const createAnimatePresenceContext = (context: {
 
         const elementIsLive = child.element.isConnected
         const staleScrollDelta = measureScrollDelta(child.lastScrollSnapshot)
-        const rect = elementIsLive
+        let rect = elementIsLive
             ? child.element.getBoundingClientRect()
             : translateRectByScrollDelta(child.lastRect, staleScrollDelta)
         const computed = elementIsLive ? getComputedStyle(child.element) : child.lastComputedStyle
@@ -860,6 +860,18 @@ export const createAnimatePresenceContext = (context: {
             const before = anchor?.parentElement === layoutInsertion.parent ? anchor : null
             layoutInsertion.parent.insertBefore(placeholder, before)
             exitPlaceholders.set(key, placeholder)
+
+            // `lastRect` only refreshes on SIZE changes (ResizeObserver), so
+            // a child that FLIPed to a new slot after a sibling's exit still
+            // carries its old position. The placeholder now occupies the
+            // child's real slot — measure IT so the exit clone fades where
+            // the child currently is, not where it registered.
+            if (!elementIsLive) {
+                const slotRect = placeholder.getBoundingClientRect()
+                if (slotRect.width > 0 || slotRect.height > 0) {
+                    rect = slotRect
+                }
+            }
         }
 
         // Clone original node to preserve structure/classes, then inline computed styles to freeze look

--- a/src/lib/utils/presence.ts
+++ b/src/lib/utils/presence.ts
@@ -42,6 +42,14 @@ type PresenceChild = {
     lastPosition: string
     lastPopLayoutSnapshot?: PopLayoutSnapshot
     layoutInsertion?: { parent: HTMLElement; before?: HTMLElement }
+    /**
+     * The element's next sibling captured while it was still connected.
+     * Svelte detaches keyed nodes before `unregisterChild` runs, so the exit
+     * placeholder can't anchor on the element itself — it anchors on this
+     * sibling (walking past siblings that detached in the same update) to
+     * land in the exiting element's real layout slot.
+     */
+    lastNextSibling?: Element | null
     hasScrollableAncestor: boolean
     lastScrollSnapshot: ScrollSnapshot[]
     /** Last captured mid-animation opacity (from rAF polling). */
@@ -194,15 +202,14 @@ const resetTransforms = (element: HTMLElement): void => {
 const findLayoutInsertionParent = (
     element: HTMLElement
 ): { parent: HTMLElement; before?: HTMLElement } | null => {
-    let before = element
-    let parent = element.parentElement
-
-    while (parent && getComputedStyle(parent).display === 'contents') {
-        before = parent
-        parent = parent.parentElement
-    }
-
-    return parent ? { parent, before } : null
+    // Insert the placeholder at the element's own position — even inside a
+    // `display: contents` parent (e.g. AnimatePresence's container), where
+    // children still occupy their slot in the grandparent's grid/flex layout
+    // in DOM order. Walking up to the first non-contents ancestor and
+    // anchoring before the WRAPPER would push the placeholder in front of
+    // every sibling, shifting all surviving children one slot over.
+    const parent = element.parentElement
+    return parent ? { parent, before: element } : null
 }
 
 const canElementScroll = (element: HTMLElement): boolean => {
@@ -541,6 +548,58 @@ export const createAnimatePresenceContext = (context: {
 
     const children = new Map<string, PresenceChild>()
     const exitPlaceholders = new Map<string, HTMLElement>()
+
+    /**
+     * Re-capture every still-connected child's next sibling. Called whenever
+     * the child set changes so each child's `lastNextSibling` reflects the
+     * DOM order just before the next detach — the exit placeholder's anchor.
+     */
+    const refreshSiblingAnchors = () => {
+        // Only registered sibling elements and live exit placeholders are
+        // usable anchors: anything else adjacent to a child (Svelte-injected
+        // <script>/comment nodes, the child's own effects DOM) detaches with
+        // it, leaving a dangling reference the placeholder can't anchor on.
+        const isAnchorCandidate = (el: Element): boolean => {
+            if (el.hasAttribute('data-presence-placeholder')) return true
+            for (const other of children.values()) {
+                if (other.element === el) return true
+            }
+            return false
+        }
+        for (const child of children.values()) {
+            if (!child.element.isConnected) continue
+            let next = child.element.nextElementSibling
+            while (next && !isAnchorCandidate(next)) {
+                next = next.nextElementSibling
+            }
+            child.lastNextSibling = next
+        }
+    }
+
+    /**
+     * Resolve the connected node the exit placeholder should be inserted
+     * before. Prefers the exiting element itself (still connected when Svelte
+     * tears down after unregister), then walks the captured sibling chain,
+     * hopping over siblings that detached in the same update.
+     */
+    const resolvePlaceholderAnchor = (child: PresenceChild): Element | null => {
+        if (child.element.isConnected) return child.element
+
+        let anchor = child.lastNextSibling ?? null
+        const visited = new Set<Element>()
+        while (anchor && !anchor.isConnected && !visited.has(anchor)) {
+            visited.add(anchor)
+            let next: Element | null = null
+            for (const other of children.values()) {
+                if (other.element === anchor) {
+                    next = other.lastNextSibling ?? null
+                    break
+                }
+            }
+            anchor = next
+        }
+        return anchor?.isConnected ? anchor : null
+    }
     // Track number of in-flight exit animations to invoke onExitComplete once
     let inFlightExits = 0
 
@@ -553,6 +612,10 @@ export const createAnimatePresenceContext = (context: {
         if (!current || current === target) {
             exitPlaceholders.delete(key)
         }
+        // Anchors captured while this placeholder was in the DOM may point at
+        // it — re-capture from the reflowed DOM so later exits don't anchor
+        // on a removed node.
+        refreshSiblingAnchors()
     }
 
     /**
@@ -670,9 +733,13 @@ export const createAnimatePresenceContext = (context: {
             lastPopLayoutSnapshot:
                 mode === 'popLayout' ? measurePopLayoutSnapshot(element, initialStyle) : undefined,
             layoutInsertion: findLayoutInsertionParent(element) ?? undefined,
+            lastNextSibling: element.nextElementSibling,
             hasScrollableAncestor: initialScrollSnapshot.length > 0,
             lastScrollSnapshot: initialScrollSnapshot
         })
+        // A new sibling may have landed between existing children — re-anchor
+        // everyone while the whole set is still connected.
+        refreshSiblingAnchors()
     }
 
     /**
@@ -789,10 +856,8 @@ export const createAnimatePresenceContext = (context: {
             if (computed.gridRowEnd) {
                 placeholder.style.gridRowEnd = computed.gridRowEnd
             }
-            const before =
-                layoutInsertion.before?.parentElement === layoutInsertion.parent
-                    ? layoutInsertion.before
-                    : null
+            const anchor = resolvePlaceholderAnchor(child)
+            const before = anchor?.parentElement === layoutInsertion.parent ? anchor : null
             layoutInsertion.parent.insertBefore(placeholder, before)
             exitPlaceholders.set(key, placeholder)
         }

--- a/src/lib/utils/presence.ts
+++ b/src/lib/utils/presence.ts
@@ -41,7 +41,14 @@ type PresenceChild = {
      */
     lastPosition: string
     lastPopLayoutSnapshot?: PopLayoutSnapshot
-    layoutInsertion?: { parent: HTMLElement; before?: HTMLElement }
+    /**
+     * The element's parent captured at registration. The exit placeholder is
+     * inserted here when the element is already detached — even a
+     * `display: contents` parent (e.g. AnimatePresence's container) works,
+     * since its children still occupy their slots in the grandparent's
+     * grid/flex layout in DOM order.
+     */
+    insertionParent?: HTMLElement
     /**
      * The element's next sibling captured while it was still connected.
      * Svelte detaches keyed nodes before `unregisterChild` runs, so the exit
@@ -197,19 +204,6 @@ const resetTransforms = (element: HTMLElement): void => {
     s.msTransform = 'none'
     s.MozTransform = 'none'
     s.OTransform = 'none'
-}
-
-const findLayoutInsertionParent = (
-    element: HTMLElement
-): { parent: HTMLElement; before?: HTMLElement } | null => {
-    // Insert the placeholder at the element's own position — even inside a
-    // `display: contents` parent (e.g. AnimatePresence's container), where
-    // children still occupy their slot in the grandparent's grid/flex layout
-    // in DOM order. Walking up to the first non-contents ancestor and
-    // anchoring before the WRAPPER would push the placeholder in front of
-    // every sibling, shifting all surviving children one slot over.
-    const parent = element.parentElement
-    return parent ? { parent, before: element } : null
 }
 
 const canElementScroll = (element: HTMLElement): boolean => {
@@ -549,27 +543,31 @@ export const createAnimatePresenceContext = (context: {
     const children = new Map<string, PresenceChild>()
     const exitPlaceholders = new Map<string, HTMLElement>()
 
+    const childByElement = (el: Element): PresenceChild | undefined => {
+        for (const child of children.values()) {
+            if (child.element === el) return child
+        }
+        return undefined
+    }
+
     /**
      * Re-capture every still-connected child's next sibling. Called whenever
      * the child set changes so each child's `lastNextSibling` reflects the
      * DOM order just before the next detach — the exit placeholder's anchor.
      */
     const refreshSiblingAnchors = () => {
-        // Only registered sibling elements and live exit placeholders are
-        // usable anchors: anything else adjacent to a child (Svelte-injected
-        // <script>/comment nodes, the child's own effects DOM) detaches with
-        // it, leaving a dangling reference the placeholder can't anchor on.
-        const isAnchorCandidate = (el: Element): boolean => {
-            if (el.hasAttribute('data-presence-placeholder')) return true
-            for (const other of children.values()) {
-                if (other.element === el) return true
-            }
-            return false
-        }
+        // Only registered sibling elements and THIS context's live exit
+        // placeholders are usable anchors: anything else adjacent to a child
+        // (Svelte-injected <script>/comment nodes, a nested AnimatePresence's
+        // placeholders) can detach without this context noticing, leaving a
+        // dangling reference the placeholder can't anchor on.
+        const childElements = new Set<Element>()
+        for (const child of children.values()) childElements.add(child.element)
+        const ownPlaceholders = new Set<Element>(exitPlaceholders.values())
         for (const child of children.values()) {
             if (!child.element.isConnected) continue
             let next = child.element.nextElementSibling
-            while (next && !isAnchorCandidate(next)) {
+            while (next && !childElements.has(next) && !ownPlaceholders.has(next)) {
                 next = next.nextElementSibling
             }
             child.lastNextSibling = next
@@ -580,25 +578,18 @@ export const createAnimatePresenceContext = (context: {
      * Resolve the connected node the exit placeholder should be inserted
      * before. Prefers the exiting element itself (still connected when Svelte
      * tears down after unregister), then walks the captured sibling chain,
-     * hopping over siblings that detached in the same update.
+     * hopping over siblings that detached in the same update. The chain is
+     * acyclic by construction — every pointer comes from one forward
+     * DOM-order pass in `refreshSiblingAnchors` — so the walk terminates.
      */
     const resolvePlaceholderAnchor = (child: PresenceChild): Element | null => {
         if (child.element.isConnected) return child.element
 
         let anchor = child.lastNextSibling ?? null
-        const visited = new Set<Element>()
-        while (anchor && !anchor.isConnected && !visited.has(anchor)) {
-            visited.add(anchor)
-            let next: Element | null = null
-            for (const other of children.values()) {
-                if (other.element === anchor) {
-                    next = other.lastNextSibling ?? null
-                    break
-                }
-            }
-            anchor = next
+        while (anchor && !anchor.isConnected) {
+            anchor = childByElement(anchor)?.lastNextSibling ?? null
         }
-        return anchor?.isConnected ? anchor : null
+        return anchor
     }
     // Track number of in-flight exit animations to invoke onExitComplete once
     let inFlightExits = 0
@@ -732,13 +723,12 @@ export const createAnimatePresenceContext = (context: {
             lastPosition: initialStyle.position,
             lastPopLayoutSnapshot:
                 mode === 'popLayout' ? measurePopLayoutSnapshot(element, initialStyle) : undefined,
-            layoutInsertion: findLayoutInsertionParent(element) ?? undefined,
-            lastNextSibling: element.nextElementSibling,
+            insertionParent: element.parentElement ?? undefined,
             hasScrollableAncestor: initialScrollSnapshot.length > 0,
             lastScrollSnapshot: initialScrollSnapshot
         })
         // A new sibling may have landed between existing children — re-anchor
-        // everyone while the whole set is still connected.
+        // everyone (including this child) while the whole set is connected.
         refreshSiblingAnchors()
     }
 
@@ -797,6 +787,9 @@ export const createAnimatePresenceContext = (context: {
         if (!child.exit && !child.resolveExit) {
             pwLog('[presence] unregisterChild - no exit animation, removing immediately')
             children.delete(key)
+            // Anchors pointing at the removed child would sever the sibling
+            // chain for a same-update multi-detach — re-anchor around it.
+            refreshSiblingAnchors()
             return
         }
 
@@ -823,11 +816,10 @@ export const createAnimatePresenceContext = (context: {
         const exitPosition = elementIsLive ? computed.position : child.lastPosition
         const isOutOfFlow = exitPosition === 'absolute' || exitPosition === 'fixed'
         let placeholder: HTMLElement | null = null
-        const liveLayoutInsertion = findLayoutInsertionParent(child.element)
-        const layoutInsertion =
-            liveLayoutInsertion ??
-            (child.layoutInsertion?.parent.isConnected ? child.layoutInsertion : null)
-        if (shouldPreserveLayout && !isOutOfFlow && layoutInsertion) {
+        const insertionParent =
+            child.element.parentElement ??
+            (child.insertionParent?.isConnected ? child.insertionParent : null)
+        if (shouldPreserveLayout && !isOutOfFlow && insertionParent) {
             placeholder = document.createElement(child.element.tagName.toLowerCase())
             placeholder.setAttribute('data-presence-placeholder', 'true')
             placeholder.style.display = computed.display === 'contents' ? 'block' : computed.display
@@ -857,8 +849,8 @@ export const createAnimatePresenceContext = (context: {
                 placeholder.style.gridRowEnd = computed.gridRowEnd
             }
             const anchor = resolvePlaceholderAnchor(child)
-            const before = anchor?.parentElement === layoutInsertion.parent ? anchor : null
-            layoutInsertion.parent.insertBefore(placeholder, before)
+            const before = anchor?.parentElement === insertionParent ? anchor : null
+            insertionParent.insertBefore(placeholder, before)
             exitPlaceholders.set(key, placeholder)
 
             // `lastRect` only refreshes on SIZE changes (ResizeObserver), so
@@ -904,10 +896,7 @@ export const createAnimatePresenceContext = (context: {
         // last known rect. Svelte can detach keyed nodes before unregister runs,
         // so fall back to the parent captured at registration time instead of
         // escaping to <body>, which would bypass clipping parents.
-        let parent =
-            child.element.parentElement ??
-            (child.layoutInsertion?.parent.isConnected ? child.layoutInsertion.parent : null) ??
-            document.body
+        let parent = insertionParent ?? document.body
         let positioningParent = parent
 
         // Walk up to find a parent that has actual layout (not display: contents)

--- a/src/lib/utils/presence.ts
+++ b/src/lib/utils/presence.ts
@@ -543,6 +543,17 @@ export const createAnimatePresenceContext = (context: {
     const children = new Map<string, PresenceChild>()
     const exitPlaceholders = new Map<string, HTMLElement>()
 
+    /**
+     * Find the registered `PresenceChild` whose element is `el`.
+     *
+     * @param el The DOM element to look up.
+     * @returns The matching child record, or `undefined` if `el` is not a
+     *   registered child element.
+     * @example
+     * ```ts
+     * const sibling = childByElement(anchor)
+     * ```
+     */
     const childByElement = (el: Element): PresenceChild | undefined => {
         for (const child of children.values()) {
             if (child.element === el) return child
@@ -554,6 +565,13 @@ export const createAnimatePresenceContext = (context: {
      * Re-capture every still-connected child's next sibling. Called whenever
      * the child set changes so each child's `lastNextSibling` reflects the
      * DOM order just before the next detach — the exit placeholder's anchor.
+     *
+     * @returns Nothing; updates each connected child's `lastNextSibling`.
+     * @example
+     * ```ts
+     * children.delete(key)
+     * refreshSiblingAnchors()
+     * ```
      */
     const refreshSiblingAnchors = () => {
         // Only registered sibling elements and THIS context's live exit
@@ -581,6 +599,15 @@ export const createAnimatePresenceContext = (context: {
      * hopping over siblings that detached in the same update. The chain is
      * acyclic by construction — every pointer comes from one forward
      * DOM-order pass in `refreshSiblingAnchors` — so the walk terminates.
+     *
+     * @param child The exiting child whose slot anchor is being resolved.
+     * @returns The connected element to `insertBefore`, or `null` to append
+     *   at the end of the insertion parent.
+     * @example
+     * ```ts
+     * const anchor = resolvePlaceholderAnchor(child)
+     * parent.insertBefore(placeholder, anchor)
+     * ```
      */
     const resolvePlaceholderAnchor = (child: PresenceChild): Element | null => {
         if (child.element.isConnected) return child.element
@@ -817,7 +844,7 @@ export const createAnimatePresenceContext = (context: {
         const isOutOfFlow = exitPosition === 'absolute' || exitPosition === 'fixed'
         let placeholder: HTMLElement | null = null
         const insertionParent =
-            child.element.parentElement ??
+            (child.element.parentElement?.isConnected ? child.element.parentElement : null) ??
             (child.insertionParent?.isConnected ? child.insertionParent : null)
         if (shouldPreserveLayout && !isOutOfFlow && insertionParent) {
             placeholder = document.createElement(child.element.tagName.toLowerCase())

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -526,6 +526,14 @@
                         AnimatePresence custom
                     </a>
                 </li>
+                <li>
+                    <a
+                        class="text-blue-300 hover:underline"
+                        href={resolve('/tests/animate-presence/grid-exit') + searchParams}
+                    >
+                        Grid exit (siblings hold slots)
+                    </a>
+                </li>
             </ul>
         </div>
         <div>

--- a/src/routes/tests/animate-presence/grid-exit/+page.svelte
+++ b/src/routes/tests/animate-presence/grid-exit/+page.svelte
@@ -9,22 +9,20 @@
      * exiting card's slot held until its exit finishes, then FLIP the
      * remaining cards into their new slots — never snap-then-jump-back.
      */
-    let cards = $state([
+    const initialCards = () => [
         { id: 'a', label: 'Card A' },
         { id: 'b', label: 'Card B' },
         { id: 'c', label: 'Card C' }
-    ])
+    ]
+
+    let cards = $state(initialCards())
 
     const removeAt = (index: number) => {
         cards = cards.filter((_, i) => i !== index)
     }
 
     const reset = () => {
-        cards = [
-            { id: 'a', label: 'Card A' },
-            { id: 'b', label: 'Card B' },
-            { id: 'c', label: 'Card C' }
-        ]
+        cards = initialCards()
     }
 </script>
 

--- a/src/routes/tests/animate-presence/grid-exit/+page.svelte
+++ b/src/routes/tests/animate-presence/grid-exit/+page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+    import { AnimatePresence, MotionDiv } from '$lib/index.js'
+
+    /**
+     * Repro for a sibling "double jump" when a card exits from a CSS grid.
+     *
+     * Mirrors the consumer setup: a fixed 3-column grid where each card has
+     * `layout` + enter/exit animations. Removing a card should leave the
+     * exiting card's slot held until its exit finishes, then FLIP the
+     * remaining cards into their new slots — never snap-then-jump-back.
+     */
+    let cards = $state([
+        { id: 'a', label: 'Card A' },
+        { id: 'b', label: 'Card B' },
+        { id: 'c', label: 'Card C' }
+    ])
+
+    const removeAt = (index: number) => {
+        cards = cards.filter((_, i) => i !== index)
+    }
+
+    const reset = () => {
+        cards = [
+            { id: 'a', label: 'Card A' },
+            { id: 'b', label: 'Card B' },
+            { id: 'c', label: 'Card C' }
+        ]
+    }
+</script>
+
+<main style="padding: 2rem; max-width: 1200px;">
+    <h1>AnimatePresence grid exit</h1>
+    <div style="display: flex; gap: 0.5rem; margin-bottom: 1rem;">
+        <button data-testid="remove-first" onclick={() => removeAt(0)}>Remove first</button>
+        <button data-testid="remove-middle" onclick={() => removeAt(1)}>Remove middle</button>
+        <button data-testid="remove-last" onclick={() => removeAt(cards.length - 1)}>
+            Remove last
+        </button>
+        <button data-testid="reset" onclick={reset}>Reset</button>
+    </div>
+
+    <div style="position: relative; height: 7rem;">
+        <div
+            data-testid="grid"
+            style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.75rem; height: 100%;"
+        >
+            <AnimatePresence>
+                {#each cards as card (card.id)}
+                    <MotionDiv
+                        key={card.id}
+                        layout
+                        initial={{ opacity: 0, y: 12, scale: 0.97 }}
+                        animate={{ opacity: 1, y: 0, scale: 1 }}
+                        exit={{ opacity: 0, y: -12, scale: 0.97 }}
+                        transition={{ duration: 0.3, ease: 'easeOut' }}
+                        data-testid={`card-${card.id}`}
+                        style="display: flex; height: 100%; flex-direction: column; justify-content: space-between; border: 1px solid #444; border-radius: 0.75rem; padding: 1rem; background: #1a1a1e; color: #eee;"
+                    >
+                        <strong>{card.label}</strong>
+                        <span>content</span>
+                    </MotionDiv>
+                {/each}
+            </AnimatePresence>
+        </div>
+    </div>
+</main>

--- a/src/routes/tests/animate-presence/grid-exit/+page.svelte
+++ b/src/routes/tests/animate-presence/grid-exit/+page.svelte
@@ -1,14 +1,15 @@
+<!--
+@component
+Repro for a sibling "double jump" when a card exits from a CSS grid.
+
+Mirrors the consumer setup: a fixed 3-column grid where each card has
+`layout` + enter/exit animations. Removing a card should leave the
+exiting card's slot held until its exit finishes, then FLIP the
+remaining cards into their new slots — never snap-then-jump-back.
+-->
 <script lang="ts">
     import { AnimatePresence, MotionDiv } from '$lib/index.js'
 
-    /**
-     * Repro for a sibling "double jump" when a card exits from a CSS grid.
-     *
-     * Mirrors the consumer setup: a fixed 3-column grid where each card has
-     * `layout` + enter/exit animations. Removing a card should leave the
-     * exiting card's slot held until its exit finishes, then FLIP the
-     * remaining cards into their new slots — never snap-then-jump-back.
-     */
     const initialCards = () => [
         { id: 'a', label: 'Card A' },
         { id: 'b', label: 'Card B' },


### PR DESCRIPTION
## Summary

Fixes three `AnimatePresence` exit bugs uncovered by a real consumer grid (a 3-column processing strip where finishing jobs animate out and survivors slide over): the exit placeholder always landed in the first slot and shoved every surviving card sideways during the exit; a card that had already FLIPed to a new column exited from its stale registration-time position (covering the sibling underneath); and a valid `key={0}` threw the missing-key error. Every fix landed red-test-first, and the new behavior matches framer-motion's sync-mode semantics: **the exiting card fades in the slot it currently occupies, then survivors FLIP once into the freed column — no snapping, no double jumps.**

Also ships a new `grid-exit` docs example showcasing the fixed behavior, and restyles the `animate-presence` / `animate-presence-custom` demos to the same Brutalist v2 language.

## Changes

🐛 **Bug fixes**

- **Exit placeholder slot** — `findLayoutInsertionParent` walked up past `display: contents` parents and anchored the slot-holding placeholder *before AnimatePresence's own container*, i.e. always at column 1. The placeholder now lands in the exiting child's real slot via per-child sibling anchors (`lastNextSibling`), captured while children are connected and resolved by walking past siblings detached in the same update — Svelte detaches keyed nodes (and their injected `<script>` neighbors) before `unregisterChild` runs, so neither the element nor its raw `nextElementSibling` can anchor.
- **Stale exit-clone position** — `lastRect` only refreshes on *size* changes (ResizeObserver), so a position-only FLIP after a sibling's exit left it stale and the clone faded at the card's registration-time position. When the element is already detached, the clone is now positioned from the freshly inserted placeholder — which occupies exactly the card's current slot.
- **`key={0}` rejected** — the direct-child key validation used a falsiness check; now null-checked, the `key` prop type widened to `string | number`, and registry keys normalized to strings. Matches framer-motion, which accepts falsy keys.

🔧 **Refactoring** (post-review consolidation)

- Retired the now-dead `layoutInsertion.before` mechanism; `resolvePlaceholderAnchor` is the single "where does the placeholder go" concept
- Set-based anchor candidate checks + shared `childByElement` lookup instead of linear registry scans
- Anchor candidates restricted to *this* context's placeholders, so a nested `AnimatePresence`'s placeholder can't become a dangling anchor; no-exit unregisters re-anchor siblings to keep multi-detach chains intact
- `insertionParent` connectivity guarded consistently (CodeRabbit)

🧪 **Testing** (each red before its fix)

- 7 unit tests: placeholder slot preservation (first/middle/last/simultaneous exits), clone positioned from the slot placeholder, `key={0}` + string keys + missing-key error
- 4 e2e specs with per-frame rect sampling: survivors hold their slots while the clone fades, then slide (≥3 intermediate frames, never snap) into place — including sequential removals where the clone must fade in the card's *current* slot
- New shared e2e helper `sampleRectLeftSeries` alongside `sampleTransformSeries`
- Repro/test page at `/tests/animate-presence/grid-exit`, linked from the test index

📚 **Documentation**

- New **grid-exit** example page (`/examples/grid-exit`): a Brutalist v2 "processing strip" — job cards with pulsing status dots (`repeat: Infinity` keyframes), live row/elapsed counters, `whileHover`/`whileTap` controls; complete a job and survivors FLIP into the freed column
- **animate-presence** and **animate-presence-custom** demos restyled to the same theme-variable-driven Brutalist v2 look (light + dark, replacing hardcoded dark styling), with all interactions library-driven; animation semantics, springs, and test ids unchanged

**Validation:** 743 unit tests, 60 animate-presence e2e + 15 layout/layout-id e2e green; verified visually in both themes.

## Commits

- [`196bd62`](https://github.com/humanspeak/svelte-motion/commit/196bd623e21e691974264661628692d29b779b06) test(animate-presence): capture grid exit placeholder slot regressions
- [`4e89c5a`](https://github.com/humanspeak/svelte-motion/commit/4e89c5a919c3fc9552df8af5d7b394b4fa005884) fix(animate-presence): anchor exit placeholder in the exiting child's slot
- [`fec24e7`](https://github.com/humanspeak/svelte-motion/commit/fec24e77a61c96adeb75dc110b3a4b295b690efb) test(animate-presence): capture stale exit-clone position on sequential removals
- [`35e5612`](https://github.com/humanspeak/svelte-motion/commit/35e5612b047ddca2efaa8fd3bc583b3943b85d3d) fix(animate-presence): position exit clone from the slot placeholder
- [`2b04d60`](https://github.com/humanspeak/svelte-motion/commit/2b04d603feb549a632c0c70beb85df9f42500b83) refactor(animate-presence): consolidate exit-slot anchoring after review
- [`900ea97`](https://github.com/humanspeak/svelte-motion/commit/900ea9781232a3f579513c3421ff438ddcf4a44e) fix(animate-presence): address CodeRabbit review findings
- [`cccf35c`](https://github.com/humanspeak/svelte-motion/commit/cccf35c2f1565cfc758d6d4bbf14687b961563ec) test(animate-presence): capture key={0} rejection on direct children
- [`8e91cb2`](https://github.com/humanspeak/svelte-motion/commit/8e91cb2450a6abbd5817aa72e8c5ff02e5389606) fix(animate-presence): accept falsy-but-valid keys like 0
- [`3bac430`](https://github.com/humanspeak/svelte-motion/commit/3bac430b13873e733f4ed7649ae2589a49ac520e) docs(examples): add grid-exit example page
- [`7ac2810`](https://github.com/humanspeak/svelte-motion/commit/7ac28105aea03e530ed79223ff1b72d797a01de4) docs(examples): restyle presence demos to the brutalist v2 language

🤖 Generated with [Claude Code](https://claude.com/claude-code)
