### PR TITLE
fix(ci): prevent pipefail SIGPIPE in workflow validation

### DIFF
--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -123,7 +123,7 @@ jobs:
 
                       # Debug: Show available refs
                       echo "Available branches:"
-                      git branch -a | head -5
+                      git branch -a | sed -n '1,5p'
 
                       # Try different git diff approaches for PR context
                       if git rev-parse "origin/${BASE_REF}" >/dev/null 2>&1; then


### PR DESCRIPTION
Prevents workflow validation from failing with exit code 141 when a repository has more than five branches. The diagnostic branch listing now uses `sed`, which consumes the complete input stream and remains compatible with `set -o pipefail`.

Replaces `git branch -a | head -5` with `git branch -a | sed -n '1,5p'` in `.github/workflows/validate-workflows.yml`. Unlike `head`, `sed` reads the entire input stream, so the upstream `git branch` never receives SIGPIPE and genuine validation failures are still detected under `set -euo pipefail`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
