### PR TITLE
chore: point t3.json at branded project icon

### DIFF
--- a/t3.json
+++ b/t3.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://t3.codes/schema/t3.json",
-    "iconPath": "static/favicon.png"
+    "iconPath": "docs/static/favicon.svg"
 }


### PR DESCRIPTION
Follow-up to the t3.json PR: the root `static/favicon.png` is the stock SvelteKit favicon (identical across repos), so T3 Code showed the generic Svelte logo. Point `iconPath` at the branded docs icon `docs/static/favicon.svg` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)