### PR TITLE
feat(docs): add comparison GEO mirrors

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -54,6 +54,7 @@ static/examples/
 # Generated llms.txt + llms-full.txt (docs-kit's llmsPlugin / llmsFullPlugin —
 # discovery index + concatenated dump for LLM agents)
 static/llms*.txt
+static/compare/
 
 .dev.vars*
 !.dev.vars.example

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,12 +20,13 @@
         "registry:generate": "node ./scripts/generate-registry.mjs",
         "registry:watch": "chokidar 'src/lib/shadcn/ui/**/*.svelte' 'src/lib/shadcn/ui/**/*.ts' -c 'node ./scripts/generate-registry.mjs' --initial --silent",
         "test": "npm run test:unit -- --run",
+        "test:geo-seo": "vite build && tsx --test ./scripts/geo-seo-output.test.ts",
         "test:unit": "vitest"
     },
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.7.6",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.8.1",
         "@humanspeak/svelte-markdown": "^1.6.1",
         "@humanspeak/svelte-motion": "workspace:*",
         "@humanspeak/svelte-scoped-props": "^0.1.3",

--- a/docs/scripts/geo-seo-output.test.ts
+++ b/docs/scripts/geo-seo-output.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { describe, test } from 'node:test'
+
+import { createSitemapResponse } from '@humanspeak/docs-kit/server'
+
+import { competitors, ours } from '../src/lib/compare-data'
+
+const root = process.cwd()
+
+async function read(relativePath: string): Promise<string> {
+    return readFile(join(root, relativePath), 'utf8')
+}
+
+describe('generated GEO and SEO artifacts', () => {
+    test('publishes a Markdown mirror for every comparison page', async () => {
+        const index = await read('static/compare/index.md')
+
+        for (const competitor of competitors) {
+            const canonical = `${ours.url}/compare/${competitor.slug}`
+            const mirror = await read(`static/compare/${competitor.slug}.md`)
+
+            assert.match(index, new RegExp(`${competitor.slug}\\.md`))
+            assert.ok(mirror.includes(`<!-- Canonical: ${canonical} -->`))
+            assert.ok(mirror.includes(`# ${ours.name} vs ${competitor.name}`))
+            assert.ok(mirror.includes('## Feature comparison'))
+            assert.ok(mirror.includes('## Verdict'))
+        }
+    })
+
+    test('advertises every comparison in both LLM discovery files', async () => {
+        const [index, full] = await Promise.all([
+            read('static/llms.txt'),
+            read('static/llms-full.txt')
+        ])
+
+        assert.ok(index.includes('## Comparisons'))
+        for (const competitor of competitors) {
+            const canonical = `${ours.url}/compare/${competitor.slug}`
+            assert.ok(index.includes(`(${canonical}.md): ${canonical}`))
+            assert.ok(full.includes(`# ${ours.name} vs ${competitor.name}`))
+        }
+    })
+
+    test('emits concrete comparison sitemap URLs without dynamic placeholders', async () => {
+        const manifest = JSON.parse(await read('src/lib/sitemap-manifest.json')) as Record<
+            string,
+            string
+        >
+        const response = createSitemapResponse({ manifest, siteUrl: ours.url })
+        const xml = await response.text()
+
+        assert.doesNotMatch(xml, /\[[^\]]+\]/)
+        for (const competitor of competitors) {
+            assert.ok(xml.includes(`<loc>${ours.url}/compare/${competitor.slug}</loc>`))
+        }
+    })
+})

--- a/docs/src/routes/sitemap.xml/+server.ts
+++ b/docs/src/routes/sitemap.xml/+server.ts
@@ -1,39 +1,11 @@
 import { env } from '$env/dynamic/public'
+import { docsConfig } from '$lib/docs-config'
 import manifest from '$lib/sitemap-manifest.json'
+import { createSitemapResponse } from '@humanspeak/docs-kit/server'
 import type { RequestHandler } from '@sveltejs/kit'
 
-// Eager=false keeps build light; we only need the keys for paths
-const pageFiles = Object.keys(
-    import.meta.glob('/src/routes/**/+page.{svelte,svx,md}', { eager: false })
-)
-
-function toPath(file: string): string {
-    // Strip /src/routes and "+page.*" suffix; default root to '/'
-    const p = file.replace('/src/routes', '').replace(/\/\+page\.(svelte|svx|md)$/i, '')
-    return p === '' ? '/' : p
-}
-
-export const GET: RequestHandler = async ({ url }) => {
-    const base = (env.PUBLIC_SITE_URL || `${url.origin}`).replace(/\/$/, '')
-
-    // Unique, sorted, and exclude private/underscore folders
-    const routes = [...new Set(pageFiles.map(toPath))]
-        .filter((p) => !/\/_(?:.*)|\/(?:\+|__)/.test(p) && p.startsWith('/social-cards') === false)
-        .sort()
-
-    const today = new Date().toISOString().slice(0, 10)
-    const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${routes
-        .map(
-            (p) =>
-                `  <url>\n    <loc>${base}${p}</loc>\n    <lastmod>${manifest[p] || today}</lastmod>\n  </url>`
-        )
-        .join('\n')}\n</urlset>`
-
-    return new Response(xml, {
-        headers: {
-            'Content-Type': 'application/xml',
-            // CDN caches for 1 hour; browsers get latest on next request
-            'Cache-Control': 'max-age=0, s-maxage=3600'
-        }
+export const GET: RequestHandler = () =>
+    createSitemapResponse({
+        manifest,
+        siteUrl: env.PUBLIC_SITE_URL || docsConfig.url
     })
-}

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -16,7 +16,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { playwright } from '@vitest/browser-playwright'
 import devtoolsJson from 'vite-plugin-devtools-json'
 import { defineConfig } from 'vitest/config'
-import { competitors } from './src/lib/compare-data'
+import { competitors, ours } from './src/lib/compare-data'
 import { docsConfig } from './src/lib/docs-config'
 
 // const __filename = fileURLToPath(import.meta.url)
@@ -43,7 +43,13 @@ export default defineConfig({
         // (`sync-examples-catalog.mjs`) now owns only the
         // `examples/+page.ts` metadata sync. `blogDir: false` disables
         // docs-kit's default blog-folder scan — we don't have a blog.
-        sitemapManifestPlugin({ blogDir: false }),
+        sitemapManifestPlugin({
+            blogDir: false,
+            extraPages: competitors.map((competitor) => ({
+                route: `/compare/${competitor.slug}`,
+                source: 'src/lib/compare-data.ts'
+            }))
+        }),
         // Scans `src/lib/examples/<slug>/demos/*.svelte`, pre-highlights each
         // demo's source with Shiki (light + dark), and emits a lightweight
         // `src/lib/demo-manifest.json` index. The heavy code + Shiki HTML stay
@@ -91,7 +97,8 @@ export default defineConfig({
             siteUrl: docsConfig.url,
             pkgName: docsConfig.name,
             description: docsConfig.description,
-            prepend: 'llms-positioning.md'
+            prepend: 'llms-positioning.md',
+            comparisons: { ours, competitors }
         }),
         llmsFullPlugin({
             siteUrl: docsConfig.url,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.7.6
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc(@humanspeak/svelte-markdown@1.6.1(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@humanspeak/svelte-motion@)(@internationalized/date@3.12.2)(@lucide/svelte@1.22.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@sveltejs/kit@2.68.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.1.2(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.2(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(shiki@4.3.0)(svelte@5.56.4(@typescript-eslint/types@8.62.1))
+        specifier: github:humanspeak/docs-kit#2026.8.1
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8(@humanspeak/svelte-markdown@1.6.1(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@humanspeak/svelte-motion@)(@internationalized/date@3.12.2)(@lucide/svelte@1.22.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@sveltejs/kit@2.68.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.1.2(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.2(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(shiki@4.3.0)(svelte@5.56.4(@typescript-eslint/types@8.62.1))
       '@humanspeak/svelte-markdown':
         specifier: ^1.6.1
         version: 1.6.1(svelte@5.56.4(@typescript-eslint/types@8.62.1))
@@ -943,8 +943,8 @@ packages:
     resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc':
-    resolution: {gitHosted: true, integrity: sha512-Xxt3dmuuwbejKVBjEzE09d2Zgnzc5c4FqgVkPN+Yix0mbgEVe+YWYpxwX6yIACQS/w5oCper3W7sD/UQFv3c+w==, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8':
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4937,7 +4937,7 @@ snapshots:
 
   '@humanfs/types@0.15.0': {}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc(@humanspeak/svelte-markdown@1.6.1(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@humanspeak/svelte-motion@)(@internationalized/date@3.12.2)(@lucide/svelte@1.22.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@sveltejs/kit@2.68.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.1.2(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.2(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(shiki@4.3.0)(svelte@5.56.4(@typescript-eslint/types@8.62.1))':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8(@humanspeak/svelte-markdown@1.6.1(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@humanspeak/svelte-motion@)(@internationalized/date@3.12.2)(@lucide/svelte@1.22.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(@sveltejs/kit@2.68.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.1.2(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.2(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)))(shiki@4.3.0)(svelte@5.56.4(@typescript-eslint/types@8.62.1))':
     dependencies:
       '@humanspeak/svelte-motion': 'link:'
       '@humanspeak/svelte-satori-fix': 0.0.6(svelte@5.56.4(@typescript-eslint/types@8.62.1))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,8 +7,7 @@ allowBuilds:
     # plain package-name key does NOT match. This key embeds the resolved
     # commit of docs-kit#<tag>, so it must be refreshed whenever the docs-kit
     # tag in docs/package.json bumps (pnpm approve-builds will prompt).
-    '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc': true
-    '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/bc850a017d844972bf12ab6174655575d5915c54': set this to true or false
+    '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/cb293900ffe271d0df0e2d50f44ccd0bd9ec56e8': true
     core-js: true
     esbuild: true
     sharp: true


### PR DESCRIPTION
## Summary

Expose the existing comparison content as machine-readable GEO surfaces and make the sitemap use concrete, canonical comparison routes. This gives LLM agents complete comparison citations while preventing dynamic route placeholders from leaking into sitemap output.

## Changes

- ✨ Generate a Markdown index and per-competitor mirrors from the existing comparison data
- ✨ Include comparison links and content in `llms.txt` and `llms-full.txt`
- 🐛 Replace the custom sitemap response with docs-kit's shared helper and add concrete comparison routes
- 📦 Upgrade `@humanspeak/docs-kit` to `2026.8.1` and refresh its approved build hash
- 🧪 Add build-backed regression coverage for comparison mirrors, LLM discovery files, and sitemap URLs
- 🧹 Ignore generated comparison Markdown artifacts

## Validation

- `pnpm --dir docs run test:geo-seo` — 3 tests passed
- Targeted Prettier and ESLint checks passed
- Production docs build passed
- `pnpm run package` / publint passed
- Repository pre-commit formatting, lint, and Svelte checks passed

## Commits

- [`405294d`](https://github.com/humanspeak/svelte-motion/commit/405294d) feat(docs): add comparison GEO mirrors
