### PR TITLE
fix(optimized-appear): emit WAAPI entries for non-transform CSS properties

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
     sources:
         - id: trunk
-          ref: v1.10.2
+          ref: v1.11.0
           uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -52,21 +52,21 @@ lint:
               - svelte
               - javascript
     enabled:
-        - grype@0.114.0
+        - grype@0.117.0
         - sort-package-json@4.0.0
         - actionlint@1.7.12
-        - checkov@3.3.2
-        - eslint@10.5.0
+        - checkov@3.3.10
+        - eslint@10.8.1
         - git-diff-check
-        - markdownlint@0.49.0
-        - osv-scanner@2.4.0
-        - oxipng@10.1.1
-        - prettier@3.8.4
+        - markdownlint@0.49.1
+        - osv-scanner@2.5.0
+        - oxipng@10.2.0
+        - prettier@3.9.6
         - shellcheck@0.11.0
-        - shfmt@3.6.0
-        - svgo@4.0.1
+        - shfmt@3.13.1
+        - svgo@4.0.2
         - taplo@0.10.0
-        - trufflehog@3.95.6
+        - trufflehog@3.96.0
         - yamllint@1.38.0
 actions:
     disabled:
@@ -74,3 +74,6 @@ actions:
         - trunk-check-pre-push
         - trunk-fmt-pre-commit
         - trunk-upgrade-available
+tools:
+    enabled:
+        - oxfmt@0.63.0

--- a/docs/src/lib/examples/optimized-appear/demos/BlurFade.svelte
+++ b/docs/src/lib/examples/optimized-appear/demos/BlurFade.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+    import { motion, styleString } from '@humanspeak/svelte-motion'
+
+    const lines = [
+        'Filter, clip-path, and color now ride the appear path.',
+        'Each line starts blurred inside the SSR payload.',
+        'Hydration adopts the animation mid-flight — no snap, no pop.'
+    ]
+</script>
+
+<!-- dk-strip: docs-kit positioning shell — stripped from the published code. -->
+<div class="dk-demo-shell">
+    <div class="strip">
+        <div class="strip-head">
+            <span class="micro">// blur fade</span>
+            <span class="micro readout">filter: WAAPI</span>
+        </div>
+
+        <div class="stage">
+            <motion.h3
+                initial={{ opacity: 0, y: 12, filter: 'blur(8px)' }}
+                animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
+                transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
+            >
+                Blur fade
+            </motion.h3>
+            {#each lines as line, i (line)}
+                <motion.p
+                    initial={{ opacity: 0, y: 12, filter: 'blur(8px)' }}
+                    animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
+                    transition={{
+                        duration: 0.5,
+                        delay: 0.15 * (i + 1),
+                        ease: [0.16, 1, 0.3, 1]
+                    }}
+                    style={styleString(() => ({
+                        borderLeft: '3px solid var(--brut-accent, #247768)',
+                        paddingLeft: '0.75rem'
+                    }))}
+                >
+                    {line}
+                </motion.p>
+            {/each}
+        </div>
+
+        <div class="strip-foot">
+            <span class="micro">blur(8px) → blur(0px)</span>
+            <span class="micro">stagger: 150ms</span>
+        </div>
+    </div>
+</div>
+
+<style>
+    .dk-demo-shell {
+        min-height: 300px;
+        display: grid;
+        place-items: center;
+        padding: 2rem;
+    }
+
+    .strip {
+        width: 100%;
+        max-width: 420px;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .micro {
+        font-family: var(--brut-mono, monospace);
+        font-size: 0.6875rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--brut-ink-3, #9a9a9a);
+    }
+
+    .readout {
+        color: var(--brut-accent, #247768);
+    }
+
+    .strip-head,
+    .strip-foot {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        border-bottom: 1px dashed var(--brut-rule-2, #bbc4c0);
+        padding-bottom: 0.5rem;
+    }
+
+    .strip-foot {
+        border-bottom: none;
+        border-top: 1px dashed var(--brut-rule-2, #bbc4c0);
+        padding-top: 0.75rem;
+        padding-bottom: 0;
+    }
+
+    .stage {
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+        padding: 0.5rem 0;
+    }
+
+    .stage :global(h3) {
+        margin: 0;
+        font-family: var(--brut-mono, monospace);
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: var(--brut-ink, #0a0a0a);
+    }
+
+    .stage :global(p) {
+        margin: 0;
+        color: var(--brut-ink-2, #525252);
+        line-height: 1.55;
+    }
+</style>

--- a/docs/src/routes/examples/optimized-appear/+page.svelte
+++ b/docs/src/routes/examples/optimized-appear/+page.svelte
@@ -5,10 +5,11 @@
         type ExampleSection,
         formatSheetLabel
     } from '@humanspeak/docs-kit'
-    import { Gauge, Sparkles } from '@lucide/svelte'
+    import { Focus, Gauge, Sparkles, Timer } from '@lucide/svelte'
     import { demoCodeSample } from '$lib/demo-loaders'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+    import OptimizedAppearBlurFade from '$lib/examples/optimized-appear/demos/BlurFade.svelte'
     import OptimizedAppearDefault from '$lib/examples/optimized-appear/demos/Default.svelte'
 
     const breadcrumbs = getBreadcrumbContext()
@@ -26,7 +27,7 @@
         seo.ogTitle = 'Optimized appear'
         seo.h1 = { title: 'Optimized appear', mode: 'sr-only' }
         seo.ogTagline = 'SSR entrance animations without the flash'
-        seo.ogFeatures = ['SSR', 'Hydration', 'WAAPI', 'Appear handoff']
+        seo.ogFeatures = ['SSR', 'Hydration', 'WAAPI', 'Blur fade']
         seo.ogSlug = 'examples-optimized-appear'
     }
 
@@ -45,6 +46,18 @@
             notes: defaultNotes,
             barCells: [{ k: 'handoff', v: 'data-framer-appear-id' }],
             sourceUrl: `${SOURCE_URL}optimized-appear/demos/Default.svelte`
+        },
+        {
+            figId: 'FIG-002',
+            tag: 'FILTER',
+            title: { prefix: 'blur fade ', accent: 'beyond transforms', end: '.' },
+            description:
+                'Any animatable CSS property declared in initial/animate — filter, clip-path, color — now rides the same SSR appear path, so blur-fade entrances start before hydration.',
+            snippet: blurFadeSection,
+            codeSnippet: blurFadeCode,
+            notes: blurFadeNotes,
+            barCells: [{ k: 'filter', v: 'blur(8px) → blur(0px)' }],
+            sourceUrl: `${SOURCE_URL}optimized-appear/demos/BlurFade.svelte`
         }
     ]
 </script>
@@ -77,6 +90,39 @@
                 'optimized-appear/demos/Default.svelte',
                 'optimized-appear-default',
                 'Default.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+{#snippet blurFadeSection()}
+    <OptimizedAppearBlurFade />
+{/snippet}
+{#snippet blurFadeNotes()}
+    <ul>
+        <li>
+            <Focus />
+            <span>
+                The SSR bootstrap emits a WAAPI entry for <code>filter</code> alongside opacity and transform,
+                so the first frame is already mid blur-fade.
+            </span>
+        </li>
+        <li>
+            <Timer />
+            <span>
+                Staggered <code>delay</code> values ride along too — each line holds its blurred
+                initial state with <code>fill: both</code> until its turn.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet blurFadeCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'optimized-appear/demos/BlurFade.svelte',
+                'optimized-appear-blur-fade',
+                'BlurFade.svelte'
             )
         ]}
         columns={1}

--- a/docs/src/routes/examples/optimized-appear/+page.svelte
+++ b/docs/src/routes/examples/optimized-appear/+page.svelte
@@ -52,7 +52,7 @@
             tag: 'FILTER',
             title: { prefix: 'blur fade ', accent: 'beyond transforms', end: '.' },
             description:
-                'Any animatable CSS property declared in initial/animate — filter, clip-path, color — now rides the same SSR appear path, so blur-fade entrances start before hydration.',
+                'WAAPI-safe properties beyond opacity and transform — filter and clip-path — now ride the same SSR appear path, so blur-fade entrances start before hydration.',
             snippet: blurFadeSection,
             codeSnippet: blurFadeCode,
             notes: blurFadeNotes,

--- a/e2e/motion/optimized-appear.spec.ts
+++ b/e2e/motion/optimized-appear.spec.ts
@@ -67,4 +67,36 @@ test.describe('optimized appear animations', () => {
         })
         expect(new Set(ids).size).toBe(1)
     })
+
+    test('starts a WAAPI appear for non-transform CSS properties like filter', async ({ page }) => {
+        await page.goto('/tests/optimized-appear?@isPlaywright=true')
+
+        const blur = page.getByTestId('optimized-appear-blur')
+        await expect(blur).toBeVisible()
+        await expect(blur).toHaveAttribute('data-framer-appear-id', /svelte-motion-/)
+
+        const started = await page.evaluate(() => {
+            return (
+                (
+                    window as unknown as {
+                        __SvelteMotionAppear?: { started: Array<{ name: string }> }
+                    }
+                ).__SvelteMotionAppear?.started.map((entry) => entry.name) ?? []
+            )
+        })
+        expect(started).toContain('opacity')
+        expect(started).toContain('transform')
+        expect(started).toContain('filter')
+
+        await expect
+            .poll(
+                async () => {
+                    const value = await blur.evaluate((el) => getComputedStyle(el).filter)
+                    const match = value.match(/blur\(([\d.]+)px\)/)
+                    return match ? Number(match[1]) : Number.POSITIVE_INFINITY
+                },
+                { timeout: 3000, message: 'filter never animated through a blur value' }
+            )
+            .toBeLessThan(0.5)
+    })
 })

--- a/e2e/motion/optimized-appear.spec.ts
+++ b/e2e/motion/optimized-appear.spec.ts
@@ -99,4 +99,91 @@ test.describe('optimized appear animations', () => {
             )
             .toBeLessThan(0.5)
     })
+
+    test('filter appear animates through intermediate blurs and settles clean', async ({
+        page
+    }) => {
+        await page.addInitScript(() => {
+            const blurSamples: number[] = []
+            const filterKeyframes: string[][] = []
+            Object.defineProperty(window, '__optimizedAppearBlurSamples', {
+                value: blurSamples
+            })
+            Object.defineProperty(window, '__optimizedAppearFilterKeyframes', {
+                value: filterKeyframes
+            })
+            const sample = () => {
+                const element = document.querySelector('[data-testid="optimized-appear-blur"]')
+                if (element) {
+                    const match = getComputedStyle(element).filter.match(/blur\(([\d.]+)px\)/)
+                    blurSamples.push(match ? Number(match[1]) : 0)
+                    for (const animation of element.getAnimations()) {
+                        const keyframes =
+                            (animation.effect as KeyframeEffect | null)?.getKeyframes() ?? []
+                        const frames = keyframes
+                            .map((keyframe) => (keyframe as { filter?: string }).filter)
+                            .filter((value): value is string => Boolean(value))
+                        if (
+                            frames.length > 0 &&
+                            !filterKeyframes.some((seen) => seen.join('|') === frames.join('|'))
+                        ) {
+                            filterKeyframes.push(frames)
+                        }
+                    }
+                }
+                requestAnimationFrame(sample)
+            }
+            requestAnimationFrame(sample)
+        })
+
+        await page.goto('/tests/optimized-appear?@isPlaywright=true')
+
+        const blur = page.getByTestId('optimized-appear-blur')
+        await expect(blur).toBeVisible()
+
+        const started = await page.evaluate(() => {
+            return (
+                (
+                    window as unknown as {
+                        __SvelteMotionAppear?: { started: Array<{ name: string }> }
+                    }
+                ).__SvelteMotionAppear?.started.map((entry) => entry.name) ?? []
+            )
+        })
+        expect(started).toContain('filter')
+
+        await expect
+            .poll(async () => blur.evaluate((el) => getComputedStyle(el).filter), {
+                timeout: 3000,
+                message: 'filter never settled to a sharp value'
+            })
+            .toMatch(/^(none|blur\(0px\))$/)
+        await expect
+            .poll(async () => blur.evaluate((el) => getComputedStyle(el).opacity), {
+                timeout: 3000,
+                message: 'blur card never settled to full opacity'
+            })
+            .toBe('1')
+
+        const keyframeSets = await page.evaluate(() => {
+            return (window as unknown as { __optimizedAppearFilterKeyframes: string[][] })
+                .__optimizedAppearFilterKeyframes
+        })
+        expect(keyframeSets).toContainEqual(['blur(8px)', 'blur(0px)'])
+
+        const samples = await page.evaluate(() => {
+            return (window as unknown as { __optimizedAppearBlurSamples: number[] })
+                .__optimizedAppearBlurSamples
+        })
+        expect(
+            samples.some((value) => value > 0.5 && value < 7.5),
+            'expected at least one intermediate blur frame — filter snapped instead of animating'
+        ).toBe(true)
+        const firstSharpIndex = samples.findIndex((value) => value < 0.5)
+        expect(firstSharpIndex).toBeGreaterThanOrEqual(0)
+        expect(
+            Math.max(...samples.slice(firstSharpIndex)),
+            'blur re-appeared after settling — appear/handoff popped'
+        ).toBeLessThan(1)
+    })
 })

--- a/src/lib/utils/optimizedAppear.spec.ts
+++ b/src/lib/utils/optimizedAppear.spec.ts
@@ -52,6 +52,71 @@ describe('optimizedAppear', () => {
         ])
     })
 
+    it('emits a WAAPI entry per non-transform CSS property in initial/animate', () => {
+        const entries = createOptimizedAppearData(
+            { opacity: 0, y: 8, filter: 'blur(8px)', clipPath: 'inset(0 0 100% 0)' },
+            { opacity: 1, y: -8, filter: 'blur(0px)', clipPath: 'inset(0)' },
+            { duration: 0.4, ease: 'easeOut' }
+        )
+
+        expect(entries).toHaveLength(4)
+        expect(entries.map((e) => e.name)).toEqual(['opacity', 'transform', 'filter', 'clipPath'])
+        expect(entries.find((e) => e.name === 'filter')?.keyframes).toEqual(['blur(8px)', 'blur(0px)'])
+        expect(entries.find((e) => e.name === 'clipPath')?.keyframes).toEqual([
+            'inset(0 0 100% 0)',
+            'inset(0)'
+        ])
+    })
+
+    it('emits a backgroundColor entry with the first concrete scalar from initial and the resting scalar from animate', () => {
+        const entries = createOptimizedAppearData(
+            { backgroundColor: ['#ff0000', '#00ff00'] },
+            { backgroundColor: ['#0000ff', '#ffff00'] }
+        )
+
+        expect(entries).toEqual([
+            {
+                name: 'backgroundColor',
+                keyframes: ['#ff0000', '#ffff00'],
+                options: expect.objectContaining({ fill: 'both' })
+            }
+        ])
+    })
+
+    it('omits properties that are equal between initial and animate', () => {
+        const entries = createOptimizedAppearData(
+            { opacity: 0, filter: 'blur(4px)' },
+            { opacity: 1, filter: 'blur(4px)' }
+        )
+
+        expect(entries.find((e) => e.name === 'filter')).toBeUndefined()
+        expect(entries.map((e) => e.name)).toEqual(['opacity'])
+    })
+
+    it('skips SVG path-only keys and transform channels', () => {
+        const entries = createOptimizedAppearData(
+            { opacity: 0, pathLength: 0, strokeDasharray: '0 1', x: -10 },
+            { opacity: 1, pathLength: 1, strokeDasharray: '1 0', x: 0 }
+        )
+
+        const names = entries.map((e) => e.name)
+        expect(names).toContain('opacity')
+        expect(names).toContain('transform')
+        expect(names).not.toContain('pathLength')
+        expect(names).not.toContain('strokeDasharray')
+        expect(names).not.toContain('x')
+    })
+
+    it('omits non-string/non-number values and MotionValue-like objects', () => {
+        const motionValue = { get: () => 'blur(4px)' }
+        const entries = createOptimizedAppearData(
+            { opacity: 0, filter: motionValue },
+            { opacity: 1, filter: 'blur(0px)' }
+        )
+
+        expect(entries.find((e) => e.name === 'filter')).toBeUndefined()
+    })
+
     it('creates an SSR bootstrap script with the upstream data attribute', () => {
         const script = createOptimizedAppearScript('appear-1', [
             {

--- a/src/lib/utils/optimizedAppear.spec.ts
+++ b/src/lib/utils/optimizedAppear.spec.ts
@@ -71,19 +71,52 @@ describe('optimizedAppear', () => {
         ])
     })
 
-    it('emits a backgroundColor entry with the first concrete scalar from initial and the resting scalar from animate', () => {
+    it('keeps backgroundColor on the main thread, mirroring upstream acceleratedValues', () => {
         const entries = createOptimizedAppearData(
             { backgroundColor: ['#ff0000', '#00ff00'] },
             { backgroundColor: ['#0000ff', '#ffff00'] }
         )
 
-        expect(entries).toEqual([
+        expect(entries).toEqual([])
+    })
+
+    it('omits Motion pseudo-properties and unnormalized dimensional values', () => {
+        const entries = createOptimizedAppearData(
+            { opacity: 0, originX: 0, originY: 1, width: 100, borderRadius: 0 },
+            { opacity: 1, originX: 1, originY: 0, width: 200, borderRadius: 12 }
+        )
+
+        expect(entries.map((e) => e.name)).toEqual(['opacity'])
+    })
+
+    it('resolves per-key transitions like upstream getValueTransition', () => {
+        const entries = createOptimizedAppearData(
+            { opacity: 0, y: 8, filter: 'blur(8px)' },
+            { opacity: 1, y: 0, filter: 'blur(0px)' },
             {
-                name: 'backgroundColor',
-                keyframes: ['#ff0000', '#ffff00'],
-                options: expect.objectContaining({ fill: 'both' })
-            }
-        ])
+                duration: 0.4,
+                opacity: { duration: 0.2 },
+                filter: { duration: 2 }
+            } as never
+        )
+
+        const byName = Object.fromEntries(entries.map((e) => [e.name, e.options]))
+        expect(byName.opacity.duration).toBe(200)
+        expect(byName.filter.duration).toBe(2000)
+        expect(byName.transform.duration).toBe(400)
+    })
+
+    it('falls back to transition.default before the top-level transition', () => {
+        const entries = createOptimizedAppearData(
+            { filter: 'blur(8px)' },
+            { filter: 'blur(0px)' },
+            {
+                duration: 0.4,
+                default: { duration: 1 }
+            } as never
+        )
+
+        expect(entries[0]?.options.duration).toBe(1000)
     })
 
     it('omits properties that are equal between initial and animate', () => {

--- a/src/lib/utils/optimizedAppear.spec.ts
+++ b/src/lib/utils/optimizedAppear.spec.ts
@@ -61,7 +61,10 @@ describe('optimizedAppear', () => {
 
         expect(entries).toHaveLength(4)
         expect(entries.map((e) => e.name)).toEqual(['opacity', 'transform', 'filter', 'clipPath'])
-        expect(entries.find((e) => e.name === 'filter')?.keyframes).toEqual(['blur(8px)', 'blur(0px)'])
+        expect(entries.find((e) => e.name === 'filter')?.keyframes).toEqual([
+            'blur(8px)',
+            'blur(0px)'
+        ])
         expect(entries.find((e) => e.name === 'clipPath')?.keyframes).toEqual([
             'inset(0 0 100% 0)',
             'inset(0)'

--- a/src/lib/utils/optimizedAppear.ts
+++ b/src/lib/utils/optimizedAppear.ts
@@ -193,8 +193,7 @@ const getValueTransition = (
 ): AnimationOptions | undefined => {
     const record = transition as Record<string, unknown> | undefined
     const valueTransition = (record?.[key] ?? record?.default ?? transition) as
-        | (AnimationOptions & { inherit?: boolean })
-        | undefined
+        (AnimationOptions & { inherit?: boolean }) | undefined
     if (valueTransition !== transition && valueTransition?.inherit && transition) {
         const merged: AnimationOptions & { inherit?: boolean } = {
             ...transition,

--- a/src/lib/utils/optimizedAppear.ts
+++ b/src/lib/utils/optimizedAppear.ts
@@ -8,10 +8,10 @@ import {
     transformProps
 } from 'motion-dom'
 
-type AppearValueName = 'opacity' | 'transform'
+type OptimizedValueName = 'opacity' | 'transform' | (string & {})
 
 type OptimizedAppearEntry = {
-    name: AppearValueName
+    name: OptimizedValueName
     keyframes: [string | number, string | number]
     options: KeyframeAnimationOptions
 }
@@ -171,14 +171,42 @@ const toNativeOptions = (transition: AnimationOptions | undefined): KeyframeAnim
     return options
 }
 
+const NON_APPEAR_KEYS = new Set([
+    'pathLength',
+    'pathOffset',
+    'pathSpacing',
+    'strokeDasharray',
+    'stroke-dasharray',
+    'strokeDashoffset',
+    'stroke-dashoffset'
+])
+
+const extractKeyframeScalar = (value: unknown): string | number | undefined => {
+    if (Array.isArray(value)) {
+        for (const element of value) {
+            if (typeof element === 'string' || typeof element === 'number') return element
+        }
+        return undefined
+    }
+    return typeof value === 'string' || typeof value === 'number' ? value : undefined
+}
+
 /**
  * Build serialisable optimized-appear animation entries from an initial and
  * animate pair.
  *
+ * Emits one entry per animatable CSS property that has a defined value in
+ * both the initial and animate keyframe maps. The `transform` composite is
+ * built from the resolved inline-style string (so decomposed channels like
+ * `x`/`y`/`scale` merge into a single WAAPI entry); every other property
+ * — `opacity`, `filter`, `clipPath`, `backgroundColor`, etc. — is emitted
+ * by name so the SSR bootstrap can hand it off to the runtime WAAPI
+ * animation owner.
+ *
  * @param initial Initial keyframes reflected into SSR markup.
  * @param animate Target keyframes for the enter animation.
  * @param transition Motion transition options.
- * @returns Appear entries for WAAPI-supported opacity and transform values.
+ * @returns Appear entries for the WAAPI-supported properties in `initial`/`animate`.
  *
  * @example
  * ```ts
@@ -220,6 +248,15 @@ export const createOptimizedAppearData = (
             keyframes: [initialTransform, targetTransform],
             options
         })
+    }
+
+    for (const key of Object.keys(initial)) {
+        if (key === 'opacity' || key === 'transform' || transformProps.has(key)) continue
+        if (NON_APPEAR_KEYS.has(key)) continue
+        const from = extractKeyframeScalar(initial[key])
+        const to = extractKeyframeScalar(target[key])
+        if (from === undefined || to === undefined || from === to) continue
+        entries.push({ name: key, keyframes: [from, to], options })
     }
 
     return entries
@@ -272,7 +309,7 @@ export const createOptimizedAppearScript = (
  */
 export const startOptimizedAppearAnimation = (
     element: HTMLElement,
-    name: AppearValueName,
+    name: OptimizedValueName,
     keyframes: string[] | number[],
     options: AnimationOptions,
     onReady?: (animation: Animation) => void

--- a/src/lib/utils/optimizedAppear.ts
+++ b/src/lib/utils/optimizedAppear.ts
@@ -171,15 +171,40 @@ const toNativeOptions = (transition: AnimationOptions | undefined): KeyframeAnim
     return options
 }
 
-const NON_APPEAR_KEYS = new Set([
-    'pathLength',
-    'pathOffset',
-    'pathSpacing',
-    'strokeDasharray',
-    'stroke-dasharray',
-    'strokeDashoffset',
-    'stroke-dashoffset'
-])
+/**
+ * Non-composite values the appear bootstrap may animate by name. Mirrors
+ * upstream motion-dom's `acceleratedValues` allowlist: WAAPI-safe properties
+ * that need no Motion-side normalization. `opacity` and the composite
+ * `transform` are handled by their dedicated paths in
+ * {@link createOptimizedAppearData}; `backgroundColor` stays on the main
+ * thread, matching upstream (disabled pending Chromium issue 41491098).
+ */
+const APPEAR_VALUES = new Set(['filter', 'clipPath'])
+
+/**
+ * Resolve the transition for a single value, mirroring upstream motion-dom's
+ * `getValueTransition`: a per-key transition replaces the top-level options
+ * (merging them only when it opts in via `inherit: true`), falling back to
+ * `default` and then the top-level transition.
+ */
+const getValueTransition = (
+    transition: AnimationOptions | undefined,
+    key: string
+): AnimationOptions | undefined => {
+    const record = transition as Record<string, unknown> | undefined
+    const valueTransition = (record?.[key] ?? record?.default ?? transition) as
+        | (AnimationOptions & { inherit?: boolean })
+        | undefined
+    if (valueTransition !== transition && valueTransition?.inherit && transition) {
+        const merged: AnimationOptions & { inherit?: boolean } = {
+            ...transition,
+            ...valueTransition
+        }
+        delete merged.inherit
+        return merged
+    }
+    return valueTransition
+}
 
 const extractKeyframeScalar = (value: unknown): string | number | undefined => {
     if (Array.isArray(value)) {
@@ -195,13 +220,16 @@ const extractKeyframeScalar = (value: unknown): string | number | undefined => {
  * Build serialisable optimized-appear animation entries from an initial and
  * animate pair.
  *
- * Emits one entry per animatable CSS property that has a defined value in
- * both the initial and animate keyframe maps. The `transform` composite is
- * built from the resolved inline-style string (so decomposed channels like
- * `x`/`y`/`scale` merge into a single WAAPI entry); every other property
- * — `opacity`, `filter`, `clipPath`, `backgroundColor`, etc. — is emitted
- * by name so the SSR bootstrap can hand it off to the runtime WAAPI
- * animation owner.
+ * Emits one entry per WAAPI-safe property that has a defined value in both
+ * the initial and animate keyframe maps. The `transform` composite is built
+ * from the resolved inline-style string (so decomposed channels like
+ * `x`/`y`/`scale` merge into a single WAAPI entry); `opacity` and the
+ * {@link APPEAR_VALUES} allowlist (`filter`, `clipPath`) are emitted by
+ * name. Anything else — colors, dimensions, Motion pseudo-properties like
+ * `originX` — stays on the main-thread runtime, mirroring upstream
+ * motion-dom's `acceleratedValues`. Each entry resolves its own per-key
+ * transition (`transition[name] ?? transition.default ?? transition`) so the
+ * bootstrap's timing matches what the hydrated runtime will adopt.
  *
  * @param initial Initial keyframes reflected into SSR markup.
  * @param animate Target keyframes for the enter animation.
@@ -226,7 +254,6 @@ export const createOptimizedAppearData = (
 
     const target = resolveRestingValues(animate as never) as Record<string, unknown> | undefined
     if (!target) return []
-    const options = toNativeOptions(transition)
     const entries: OptimizedAppearEntry[] = []
 
     if (initial.opacity != null && target.opacity != null) {
@@ -236,7 +263,7 @@ export const createOptimizedAppearData = (
                 Array.isArray(initial.opacity) ? initial.opacity[0] : initial.opacity,
                 Array.isArray(target.opacity) ? target.opacity[0] : target.opacity
             ] as [string | number, string | number],
-            options
+            options: toNativeOptions(getValueTransition(transition, 'opacity'))
         })
     }
 
@@ -246,17 +273,20 @@ export const createOptimizedAppearData = (
         entries.push({
             name: 'transform',
             keyframes: [initialTransform, targetTransform],
-            options
+            options: toNativeOptions(getValueTransition(transition, 'transform'))
         })
     }
 
     for (const key of Object.keys(initial)) {
-        if (key === 'opacity' || key === 'transform' || transformProps.has(key)) continue
-        if (NON_APPEAR_KEYS.has(key)) continue
+        if (!APPEAR_VALUES.has(key)) continue
         const from = extractKeyframeScalar(initial[key])
         const to = extractKeyframeScalar(target[key])
         if (from === undefined || to === undefined || from === to) continue
-        entries.push({ name: key, keyframes: [from, to], options })
+        entries.push({
+            name: key,
+            keyframes: [from, to],
+            options: toNativeOptions(getValueTransition(transition, key))
+        })
     }
 
     return entries

--- a/src/routes/tests/optimized-appear/+page.svelte
+++ b/src/routes/tests/optimized-appear/+page.svelte
@@ -28,5 +28,19 @@
                 The browser starts opacity and transform before Svelte Motion takes ownership.
             </p>
         </motion.div>
+
+        <motion.div
+            data-testid="optimized-appear-blur"
+            class="rounded-lg border border-fuchsia-300/30 bg-fuchsia-300/10 p-8 shadow-2xl shadow-fuchsia-950/50"
+            initial={{ opacity: 0, y: 16, filter: 'blur(8px)' }}
+            animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
+            transition={{ duration: 0.6, ease: 'easeOut' }}
+        >
+            <div class="h-2 w-24 rounded-full bg-fuchsia-300"></div>
+            <h2 class="mt-6 text-xl font-semibold">Non-transform appear</h2>
+            <p class="mt-3 text-sm leading-6 text-slate-200">
+                Filter and opacity both start in the SSR bootstrap and hand off to the runtime.
+            </p>
+        </motion.div>
     </section>
 </main>


### PR DESCRIPTION
## Summary

`createOptimizedAppearData` in `packages/svelte-motion/src/lib/utils/optimizedAppear.ts` (compiled to `dist/utils/optimizedAppear.js`) only emits WAAPI appear entries for `opacity` and the composite `transform`. Every other animatable CSS property declared in `initial`/`animate` is silently dropped from the SSR appear payload, so the browser never WAAPI-animates it. The element's hidden value gets baked into the inline `style=` attribute (via `mergeInlineStyles`), and the visible value never reaches a compositor animation, so the property snaps to its hidden state for the entire appear window before the main-thread JS animation runs.

This blocks any port of framer-motion's `BlurFade` and similar utilities (`backgroundColor` cross-fades, `clipPath` reveals, `borderRadius` morphs, etc.) from using the optimized appear path.

## Reproduction

```svelte
<script>
    import { motion } from '$lib'
</script>

<motion.div
    data-testid="blur-card"
    initial={{ opacity: 0, y: 8, filter: 'blur(8px)' }}
    animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
    transition={{ duration: 0.4, ease: 'easeOut' }}
>
    hello
</motion.div>
```

- Expected: `opacity`, `y`, and `filter` all animate through the appear window.
- Actual: `opacity` and `transform` animate. `filter` snaps to `blur(8px)` and never animates before handoff to the runtime JS animation, which then animates from `blur(8px)` to `blur(0px)` only if the user keeps watching past the handoff. The first paint and the optimized appear show a permanently blurred element.

Inspecting `window.__SvelteMotionAppear?.started` after the page loads confirms only `opacity` and `transform` are present — `filter` is missing.

## Expected

`createOptimizedAppearData` should emit one WAAPI entry per animatable CSS property that is defined in both `initial` and `animate`, mirroring framer-motion's historical `createOptimizedAppearAnimation` behaviour. The composite `transform` entry should still merge all decomposed transform channels (`x`, `y`, `scale`, etc.) into a single WAAPI animation; everything else (`opacity`, `filter`, `clipPath`, `backgroundColor`, ...) should be emitted by name.

The inline SSR bootstrap is already property-agnostic — it iterates `entries[*]` and calls `e.animate({[a.name]: keyframes}, options)` — so the runtime can drive any property; the loss is purely in the producer.

## Environment

- `@humanspeak/svelte-motion` v0.8.2 (latest)
- Svelte 5, SvelteKit 2
- Reproduced in Chromium via the existing e2e setup (`pnpm test:e2e`)

## Notes

- `MotionHandoffAnimation` is already invoked by the motion runtime for every value in the animate target (not just `"transform"`), so the per-value handoff will pick up new entries for `filter`/`clipPath`/etc. without any bridge changes.
- `optimizedAppearSuppressedByTransformTemplate` in `_MotionContainer.svelte` already suppresses the entire appear when a `transformTemplate` is present and any `transform` entry would be emitted; the all-or-nothing per-element gating continues to apply to the new entries, so no additional suppress logic is needed.
