### PR TITLE
ci: trigger post-merge publish and deploy on push to main

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -34,14 +34,14 @@ jobs:
         name: Deploy
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
 
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js - 24
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
                   cache: pnpm
@@ -90,7 +90,7 @@ jobs:
 
             - name: Upload Wrangler logs
               if: always()
-              uses: actions/upload-artifact@v4 # zizmor: ignore[unpinned-uses]
+              uses: actions/upload-artifact@v7 # zizmor: ignore[unpinned-uses]
               with:
                   name: wrangler-logs
                   path: ~/.config/.wrangler/logs/*.log

--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -3,9 +3,15 @@ name: Cloudflare Workers - Deploy
 permissions:
     contents: read
 
+# Runs on push to main rather than pull_request[closed]: GitHub withholds
+# secrets (CLOUDFLARE_API_TOKEN etc.) from pull_request events triggered by
+# fork PRs — even the merged close event — so deploys silently failed for
+# external contributions (first hit: PR #466). Push events always run in
+# the base repo with secrets.
 on:
-    pull_request:
-        types: [closed]
+    push:
+        branches:
+            - main
         paths:
             - docs/**
             - src/**
@@ -16,15 +22,13 @@ on:
             - svelte.config.js
             - vite.config.ts
             - .github/workflows/cloudflare-deploy.yml
-        branches:
-            - main
     workflow_dispatch:
         # trunk-ignore(checkov/CKV_GHA_7)
         inputs: {}
 
 jobs:
     deploy:
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
         runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
         environment: docs
         name: Deploy

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,15 +20,15 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name != github.repository
 
         steps:
-            - uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+            - uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   fetch-depth: 0
 
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v3 # zizmor: ignore[unpinned-uses]
+              uses: github/codeql-action/init@v4 # zizmor: ignore[unpinned-uses]
               with:
                   languages: javascript
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v3 # zizmor: ignore[unpinned-uses]
+              uses: github/codeql-action/analyze@v4 # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -19,7 +19,7 @@ jobs:
                 node-version: [22, 24]
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.ACTIONS_KEY }}
@@ -27,7 +27,7 @@ jobs:
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: ${{ matrix.node-version }}
 
@@ -46,7 +46,7 @@ jobs:
               if: matrix.node-version == '22'
 
             - name: Cache dependencies
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: ~/.npm
                   key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -294,6 +294,9 @@ jobs:
 
             - name: Upload Vitest Results
               if: always()
+              # Telemetry only — a flaky upload must never block the release
+              # (a "fetch failed" here blocked the v0.9.0 publish on 2026-08-12).
+              continue-on-error: true
               uses: trunk-io/analytics-uploader@main # zizmor: ignore[unpinned-uses]
               with:
                   junit-paths: junit-vitest.xml
@@ -340,6 +343,9 @@ jobs:
 
             - name: Upload Playwright Results
               if: always()
+              # Telemetry only — a flaky upload must never block the release
+              # (a "fetch failed" here blocked the v0.9.0 publish on 2026-08-12).
+              continue-on-error: true
               uses: trunk-io/analytics-uploader@main # zizmor: ignore[unpinned-uses]
               with:
                   junit-paths: test-results/junit-playwright.xml

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -62,7 +62,7 @@ jobs:
             # skip-publish/major/minor labels and release notes) from the commit.
             - id: pr
               if: github.event_name == 'push'
-              uses: actions/github-script@v7 # zizmor: ignore[unpinned-uses]
+              uses: actions/github-script@v9 # zizmor: ignore[unpinned-uses]
               with:
                   script: |
                       const { owner, repo } = context.repo
@@ -124,7 +124,7 @@ jobs:
         environment: ci
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.ACTIONS_KEY }}
@@ -214,7 +214,7 @@ jobs:
 
             - name: Upload Results
               if: failure() && github.event_name == 'push' && needs.check-if-merged.outputs.pr_number != ''
-              uses: actions/github-script@v7 # zizmor: ignore[unpinned-uses]
+              uses: actions/github-script@v9 # zizmor: ignore[unpinned-uses]
               env:
                   PR_NUMBER: ${{ needs.check-if-merged.outputs.pr_number }}
               with:
@@ -271,7 +271,7 @@ jobs:
             packages: write
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.ACTIONS_KEY }}
@@ -279,7 +279,7 @@ jobs:
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: ${{ matrix.node-version }}
 
@@ -321,14 +321,14 @@ jobs:
         runs-on: blacksmith-4vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
         environment: ci
         steps:
-            - uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+            - uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.ACTIONS_KEY }}
 
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
-            - uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+            - uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
 
@@ -352,7 +352,7 @@ jobs:
                   org-slug: ${{ secrets.TRUNK_ORG_SLUG }}
                   token: ${{ secrets.TRUNK_TOKEN }}
 
-            - uses: actions/upload-artifact@v4 # zizmor: ignore[unpinned-uses]
+            - uses: actions/upload-artifact@v7 # zizmor: ignore[unpinned-uses]
               if: always()
               with:
                   name: playwright-results
@@ -396,7 +396,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.GITHUB_TOKEN }}
@@ -405,7 +405,7 @@ jobs:
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js - 24
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses,cache-poisoning]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses,cache-poisoning]
               with:
                   node-version: 24
 
@@ -443,7 +443,7 @@ jobs:
 
             - name: Create Comment on Skip
               if: github.event_name == 'push' && steps.publish-check.outputs.should_publish == 'false' && needs.check-if-merged.outputs.pr_number != ''
-              uses: actions/github-script@v7 # zizmor: ignore[unpinned-uses]
+              uses: actions/github-script@v9 # zizmor: ignore[unpinned-uses]
               env:
                   PR_NUMBER: ${{ needs.check-if-merged.outputs.pr_number }}
               with:
@@ -459,7 +459,7 @@ jobs:
             - name: Import GPG key
               if: steps.publish-check.outputs.should_publish == 'true'
               id: import_gpg
-              uses: crazy-max/ghaction-import-gpg@v6 # zizmor: ignore[unpinned-uses]
+              uses: crazy-max/ghaction-import-gpg@v7 # zizmor: ignore[unpinned-uses]
               with:
                   gpg_private_key: ${{ secrets.ACTIONS_GPG_PRIVATE_KEY }}
                   passphrase: ${{ secrets.ACTIONS_GPG_PASSPHRASE }}
@@ -630,7 +630,7 @@ jobs:
 
             - name: Notify on failure
               if: failure() && needs.check-if-merged.outputs.pr_number != ''
-              uses: actions/github-script@v7 # zizmor: ignore[unpinned-uses]
+              uses: actions/github-script@v9 # zizmor: ignore[unpinned-uses]
               env:
                   PR_NUMBER: ${{ needs.check-if-merged.outputs.pr_number }}
               with:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,12 +7,18 @@ permissions:
     pull-requests: read
 
 # 2. Trigger conditions
+#
+# Runs on push to main rather than pull_request[closed]: GitHub withholds
+# secrets from pull_request events triggered by fork PRs — even the merged
+# close event — so publishes silently failed for external contributions
+# (first hit: PR #466). Push events always run in the base repo with
+# secrets. PR context (labels, title, URL) is recovered by API lookup in
+# check-if-merged. The version-bump commit is "[skip ci]" so it can't
+# retrigger this workflow.
 on:
-    pull_request:
-        types: [closed]
+    push:
         branches:
             - main
-            - '!dependabot/**'
         paths:
             - src/**
             - '!docs/**'
@@ -46,20 +52,70 @@ jobs:
         outputs:
             should_run: ${{ steps.check.outputs.should_run }}
             has_skip_label: ${{ steps.check.outputs.has_skip_label }}
+            has_major: ${{ steps.check.outputs.has_major }}
+            has_minor: ${{ steps.check.outputs.has_minor }}
+            pr_number: ${{ steps.check.outputs.pr_number }}
+            pr_title: ${{ steps.check.outputs.pr_title }}
+            pr_url: ${{ steps.check.outputs.pr_url }}
         steps:
+            # Push payloads carry no PR context, so recover the merged PR (for
+            # skip-publish/major/minor labels and release notes) from the commit.
+            - id: pr
+              if: github.event_name == 'push'
+              uses: actions/github-script@v7 # zizmor: ignore[unpinned-uses]
+              with:
+                  script: |
+                      const { owner, repo } = context.repo
+                      const { data: prs } =
+                          await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                              owner,
+                              repo,
+                              commit_sha: context.sha
+                          })
+                      const pr = prs.find((candidate) => candidate.merged_at)
+                      if (!pr) {
+                          core.info(`No merged PR associated with ${context.sha}`)
+                          return
+                      }
+                      const labels = pr.labels.map((label) => label.name)
+                      core.setOutput('found', 'true')
+                      core.setOutput('number', String(pr.number))
+                      core.setOutput('title', pr.title)
+                      core.setOutput('url', pr.html_url)
+                      core.setOutput('has_skip_label', String(labels.includes('skip-publish')))
+                      core.setOutput('has_major', String(labels.includes('major')))
+                      core.setOutput('has_minor', String(labels.includes('minor')))
+
             - id: check
               env:
                   EVENT_NAME: ${{ github.event_name }}
-                  PR_MERGED: ${{ github.event.pull_request.merged }}
-                  HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-publish') }}
+                  PR_FOUND: ${{ steps.pr.outputs.found }}
+                  PR_NUMBER: ${{ steps.pr.outputs.number }}
+                  PR_TITLE: ${{ steps.pr.outputs.title }}
+                  PR_URL: ${{ steps.pr.outputs.url }}
+                  HAS_SKIP_LABEL: ${{ steps.pr.outputs.has_skip_label }}
+                  HAS_MAJOR: ${{ steps.pr.outputs.has_major }}
+                  HAS_MINOR: ${{ steps.pr.outputs.has_minor }}
               run: |
-                  if [[ "$EVENT_NAME" == "pull_request" && "$PR_MERGED" != "true" ]]; then
+                  # Pushes publish only when the commit landed via a merged PR;
+                  # direct pushes to main stay unpublished (same behavior as the
+                  # old pull_request[closed] trigger). Dispatch always runs.
+                  if [[ "$EVENT_NAME" == "push" && "$PR_FOUND" != "true" ]]; then
                       echo "should_run=false" >> $GITHUB_OUTPUT
                   else
                       echo "should_run=true" >> $GITHUB_OUTPUT
                   fi
 
-                  echo "has_skip_label=$HAS_SKIP_LABEL" >> $GITHUB_OUTPUT
+                  echo "has_skip_label=${HAS_SKIP_LABEL:-false}" >> $GITHUB_OUTPUT
+                  echo "has_major=${HAS_MAJOR:-false}" >> $GITHUB_OUTPUT
+                  echo "has_minor=${HAS_MINOR:-false}" >> $GITHUB_OUTPUT
+                  echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+                  {
+                      echo "pr_title<<PR_TITLE_EOF"
+                      echo "$PR_TITLE"
+                      echo "PR_TITLE_EOF"
+                  } >> $GITHUB_OUTPUT
+                  echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
 
     debug-check:
         needs: check-if-merged
@@ -157,8 +213,10 @@ jobs:
                   [[ $OUTPUT == *"::error"* ]] && exit 1 || exit 0
 
             - name: Upload Results
-              if: failure() && github.event_name == 'pull_request'
+              if: failure() && github.event_name == 'push' && needs.check-if-merged.outputs.pr_number != ''
               uses: actions/github-script@v7 # zizmor: ignore[unpinned-uses]
+              env:
+                  PR_NUMBER: ${{ needs.check-if-merged.outputs.pr_number }}
               with:
                   github-token: ${{ secrets.ACTIONS_KEY }}
                   script: |
@@ -184,7 +242,7 @@ jobs:
                       commentBody += '\nPlease remove these debugging statements before merging.';
 
                       github.rest.issues.createComment({
-                          issue_number: context.issue.number,
+                          issue_number: Number(process.env.PR_NUMBER),
                           owner: owner,
                           repo: repo,
                           body: commentBody
@@ -352,22 +410,19 @@ jobs:
               id: publish-check
               env:
                   EVENT_NAME: ${{ github.event_name }}
-                  IS_MERGED: ${{ github.event.pull_request.merged }}
-                  HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-publish') }}
+                  HAS_SKIP_LABEL: ${{ needs.check-if-merged.outputs.has_skip_label }}
                   INPUT_VERSION: ${{ github.event.inputs.version_bump }}
               run: |
                   # Validate event name first
-                  if [[ "$EVENT_NAME" != "pull_request" && "$EVENT_NAME" != "workflow_dispatch" ]]; then
+                  if [[ "$EVENT_NAME" != "push" && "$EVENT_NAME" != "workflow_dispatch" ]]; then
                     echo "Invalid event type"
                     exit 1
                   fi
 
-                  # Check publishing conditions
-                  if [[ "$EVENT_NAME" == "pull_request" ]]; then
-                    if [[ "$IS_MERGED" != "true" ]]; then
-                      echo "PR not merged, skipping publish"
-                      echo "should_publish=false" >> $GITHUB_OUTPUT
-                    elif [[ "$HAS_SKIP_LABEL" == "true" ]]; then
+                  # Check publishing conditions (check-if-merged already gated
+                  # push events on an associated merged PR)
+                  if [[ "$EVENT_NAME" == "push" ]]; then
+                    if [[ "$HAS_SKIP_LABEL" == "true" ]]; then
                       echo "Publishing skipped due to skip-publish label"
                       echo "should_publish=false" >> $GITHUB_OUTPUT
                     else
@@ -381,13 +436,15 @@ jobs:
                   fi
 
             - name: Create Comment on Skip
-              if: github.event_name == 'pull_request' && steps.publish-check.outputs.should_publish == 'false'
+              if: github.event_name == 'push' && steps.publish-check.outputs.should_publish == 'false' && needs.check-if-merged.outputs.pr_number != ''
               uses: actions/github-script@v7 # zizmor: ignore[unpinned-uses]
+              env:
+                  PR_NUMBER: ${{ needs.check-if-merged.outputs.pr_number }}
               with:
                   github-token: ${{ secrets.ACTIONS_KEY }}
                   script: |
                       github.rest.issues.createComment({
-                          issue_number: context.issue.number,
+                          issue_number: Number(process.env.PR_NUMBER),
                           owner: context.repo.owner,
                           repo: context.repo.repo,
                           body: '⏭️ NPM publishing was skipped due to the `skip-publish` label.'
@@ -409,8 +466,8 @@ jobs:
               if: steps.publish-check.outputs.should_publish == 'true'
               id: version-type
               env:
-                  HAS_MAJOR: ${{ contains(github.event.pull_request.labels.*.name, 'major') }}
-                  HAS_MINOR: ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}
+                  HAS_MAJOR: ${{ needs.check-if-merged.outputs.has_major }}
+                  HAS_MINOR: ${{ needs.check-if-merged.outputs.has_minor }}
                   INPUT_VERSION: ${{ github.event.inputs.version_bump }}
               run: |
                   # Function to validate version bump type
@@ -444,8 +501,8 @@ jobs:
               if: steps.publish-check.outputs.should_publish == 'true'
               id: version
               env:
-                  PR_TITLE: ${{ github.event.pull_request.title }}
-                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  PR_TITLE: ${{ needs.check-if-merged.outputs.pr_title }}
+                  PR_URL: ${{ needs.check-if-merged.outputs.pr_url }}
                   BUMP_TYPE: ${{ steps.version-type.outputs.bump }}
                   GITHUB_TOKEN: ${{ secrets.ACTIONS_KEY }}
                   GPG_KEY_ID: ${{ steps.import_gpg.outputs.keyid }}
@@ -523,12 +580,12 @@ jobs:
                   NEW_VERSION: ${{ steps.version.outputs.new_version }}
                   EVENT_NAME: ${{ github.event_name }}
                   CUSTOM_MESSAGE: ${{ github.event.inputs.custom_message }}
-                  PR_TITLE: ${{ github.event.pull_request.title }}
-                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  PR_TITLE: ${{ needs.check-if-merged.outputs.pr_title }}
+                  PR_URL: ${{ needs.check-if-merged.outputs.pr_url }}
               run: |
                   BODY="Changes in this Release
                   ${CUSTOM_MESSAGE:-$PR_TITLE}"
-                  if [[ "$EVENT_NAME" == "pull_request" ]]; then
+                  if [[ "$EVENT_NAME" == "push" && -n "$PR_URL" ]]; then
                       BODY="$BODY
 
                   For more details, see the [Pull Request]($PR_URL)"
@@ -566,13 +623,15 @@ jobs:
                   git push --delete origin "$RELEASE_VERSION" || true
 
             - name: Notify on failure
-              if: failure()
+              if: failure() && needs.check-if-merged.outputs.pr_number != ''
               uses: actions/github-script@v7 # zizmor: ignore[unpinned-uses]
+              env:
+                  PR_NUMBER: ${{ needs.check-if-merged.outputs.pr_number }}
               with:
                   github-token: ${{ secrets.ACTIONS_KEY }}
                   script: |
                       github.rest.issues.createComment({
-                          issue_number: context.issue.number,
+                          issue_number: Number(process.env.PR_NUMBER),
                           owner: context.repo.owner,
                           repo: context.repo.repo,
                           body: '❌ Release workflow failed. Please check the [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -35,7 +35,7 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   fetch-depth: 1
@@ -43,7 +43,7 @@ jobs:
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js - 24
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
 
@@ -59,7 +59,7 @@ jobs:
         timeout-minutes: 15
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   fetch-depth: 1
@@ -67,7 +67,7 @@ jobs:
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js - 24
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   fetch-depth: 1
@@ -40,12 +40,12 @@ jobs:
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js - 24
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
 
             - name: Cache build artifacts
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: |
                       .svelte-kit
@@ -55,7 +55,7 @@ jobs:
                       ${{ runner.os }}-build-
 
             - name: Cache vitest artifacts
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: |
                       node_modules/.vitest
@@ -80,7 +80,7 @@ jobs:
 
             - name: Upload unit test results
               if: always()
-              uses: actions/upload-artifact@v4 # zizmor: ignore[unpinned-uses]
+              uses: actions/upload-artifact@v7 # zizmor: ignore[unpinned-uses]
               with:
                   name: unit-test-results
                   path: |
@@ -103,7 +103,7 @@ jobs:
                       shard_name: 2-2
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   fetch-depth: 1
@@ -111,7 +111,7 @@ jobs:
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js - 24
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
 
@@ -119,7 +119,7 @@ jobs:
               run: pnpm install --filter . --frozen-lockfile --config.engine-strict=false
 
             - name: Cache Playwright browsers
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: ~/.cache/ms-playwright
                   key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -139,7 +139,7 @@ jobs:
 
             - name: Upload Playwright artifacts
               if: always()
-              uses: actions/upload-artifact@v4 # zizmor: ignore[unpinned-uses]
+              uses: actions/upload-artifact@v7 # zizmor: ignore[unpinned-uses]
               with:
                   name: playwright-artifacts-${{ matrix.shard_name }}
                   path: |

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
 
         steps:
-            - uses: actions/stale@v10 # zizmor: ignore[unpinned-uses]
+            - uses: actions/stale@v11 # zizmor: ignore[unpinned-uses]
               with:
                   # PR specific settings
                   stale-pr-message: This PR is being marked as stale due to 30 days of inactivity. It will be closed in 5 days if no further activity occurs.

--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -16,14 +16,14 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
 
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js - 24
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
 

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -15,13 +15,13 @@ jobs:
         runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   fetch-depth: 0 # Fetch full history for git comparisons
 
             - name: Set up Python
-              uses: actions/setup-python@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-python@v7 # zizmor: ignore[unpinned-uses]
               with:
                   python-version: '3.12'
 
@@ -40,7 +40,7 @@ jobs:
                   fi
 
             - name: Cache uv installation
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: ~/.local/bin/uv
                   key: ${{ runner.os }}-uv-${{ steps.uv-version.outputs.version }}
@@ -64,7 +64,7 @@ jobs:
                   # echo "version=test-version-$(date +%s)" >> $GITHUB_OUTPUT
 
             - name: Cache zizmor tool
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: |
                       ~/.local/bin/zizmor

--- a/.trunk/setup-ci/action.yaml
+++ b/.trunk/setup-ci/action.yaml
@@ -4,7 +4,7 @@ runs:
     using: composite
     steps:
         - name: Setup Node.js
-          uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+          uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
           with:
               node-version: 24
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,9 @@ export default defineConfig({
     fullyParallel: false,
     // Retry flaky tests once
     retries: process.env.CI ? 1 : 0,
-    reporter: [['junit', { outputFile: 'junit-playwright.xml' }]],
+    // Written into test-results/ so CI's trunk analytics uploader and the
+    // playwright-results artifact both find it (junit-paths in npm-publish.yml)
+    reporter: [['junit', { outputFile: 'test-results/junit-playwright.xml' }]],
     webServer: {
         // Project-specific port: vite's default preview port (4173) is
         // shared by every repo on the machine, so concurrent e2e sessions

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -66,6 +66,9 @@ export default defineConfig({
         maxWorkers: '50%',
         testTimeout: 10000,
         hookTimeout: 10000,
-        reporters: process.env.CI ? ['verbose'] : ['default']
+        // junit feeds the trunk analytics uploader in CI (junit-vitest.xml
+        // matches the workflow's junit-paths)
+        reporters: process.env.CI ? ['verbose', 'junit'] : ['default'],
+        outputFile: { junit: 'junit-vitest.xml' }
     }
 })


### PR DESCRIPTION
## Summary

Fixes three independent ways the post-merge CI pipeline has been failing or lying, all surfaced by the first external contribution (#466), plus a full GitHub Actions version refresh.

1. **Fork merges ran secretless.** `pull_request: types: [closed]` events from fork PRs are denied repository/environment secrets — even after merge — so npm publish and the Cloudflare docs deploy silently failed (empty `ACTIONS_KEY`, empty `CLOUDFLARE_API_TOKEN`). Both had to be dispatched manually for #466, and the Aug 11 publish failure has the same signature.
2. **Telemetry could block releases.** A transient `fetch failed` in the trunk analytics uploader failed the `playwright-tests` job and blocked the v0.9.0 publish until a rerun.
3. **That telemetry was empty anyway.** Vitest never had a junit reporter, and Playwright wrote its junit to the repo root while the workflow globs `test-results/` — every analytics upload has reported 0 tests.

## Changes

- 🔄 **`npm-publish.yml`** — trigger swapped to `push: branches: [main]`. Push payloads carry no PR context, so `check-if-merged` resolves the merged PR for the pushed commit via `listPullRequestsAssociatedWithCommit`, preserving the `skip-publish`/`major`/`minor` labels, release-note title/URL, and PR comment targets. Direct pushes with no associated merged PR skip publishing (matching the old trigger); the `[skip ci]` bump commit can't loop.
- 🔄 **`cloudflare-deploy.yml`** — same trigger swap; job gate now checks the event name.
- 🔧 **Telemetry hardening** — both trunk analytics-uploader steps are `continue-on-error: true`; a flaky upload can never block a release again.
- 🧪 **Real junit payloads** — vitest emits `junit-vitest.xml` in CI (`vitest.config.ts`); Playwright junit moves to `test-results/junit-playwright.xml` (`playwright.config.ts`), where the uploader and the results artifact both look.
- 📦 **Action major bumps across all workflows** — checkout v6→v7, setup-node v6→v7, cache v5→v6, upload-artifact v4→v7, github-script v7→v9, codeql-action v3→v4, ghaction-import-gpg v6→v7, stale v10→v11, setup-python v6→v7. Already current: pnpm/action-setup v6, coveralls v2, trunk-action v1.

## Commits

- [`b173363`](https://github.com/humanspeak/svelte-motion/commit/b173363) ci: trigger post-merge publish and deploy on push to main
- [`de64ae2`](https://github.com/humanspeak/svelte-motion/commit/de64ae2) ci(npm-publish): never let trunk analytics uploads block the release
- [`e348b72`](https://github.com/humanspeak/svelte-motion/commit/e348b72) ci: wire junit outputs to the analytics uploader and bump action majors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
