### PR TITLE
fix(layout): match upstream layoutDependency gate semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,8 @@ Single-element FLIP layout animation:
 
 - `layout`: translate + scale.
 - `layout="position"`: translate only.
-- Shared layout (`layoutId`) is not implemented yet.
+- `layoutDependency`: only re-measure when a value changes. In a keyed list, gate on the row's index so every row that moves animates — a per-row data field only changes for the row that triggered the re-sort, and the rows it displaces jump (upstream parity).
+- Shared layout: `layoutId` animates matching elements between positions, `LayoutGroup` scopes ids, and `layoutScroll` marks scroll containers. Full docs: <https://motion.svelte.page/docs/layout-animations>.
 
 ## Utilities
 

--- a/docs/src/lib/examples/layout-dependency/demos/KeyedList.svelte
+++ b/docs/src/lib/examples/layout-dependency/demos/KeyedList.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+    import { ArrowUpToLine, ListOrdered, RotateCcw } from '@lucide/svelte'
+    import { motion } from '@humanspeak/svelte-motion'
+
+    // A keyed list sorted by "last activity". Bumping a row moves it to the
+    // top and displaces every row above it.
+    type Row = { id: string; label: string; ts: number }
+    let rows = $state<Row[]>([
+        { id: 'a', label: 'Design review', ts: 5 },
+        { id: 'b', label: 'Sprint planning', ts: 4 },
+        { id: 'c', label: 'Bug triage', ts: 3 },
+        { id: 'd', label: 'Release notes', ts: 2 },
+        { id: 'e', label: 'On-call handoff', ts: 1 }
+    ])
+    let nextTs = 10
+
+    // 'field': layoutDependency={row.ts} — only the bumped row's dependency
+    // changes, so upstream (and we) animate only that row; the displaced rows
+    // jump. 'index': layoutDependency={i} — every row whose slot changed has a
+    // new dependency and animates.
+    let gate = $state<'field' | 'index'>('field')
+
+    const sorted = $derived([...rows].sort((x, y) => y.ts - x.ts))
+
+    function bump(id: string) {
+        rows = rows.map((row) => (row.id === id ? { ...row, ts: nextTs++ } : row))
+    }
+
+    function reset() {
+        rows = rows.map((row, i) => ({ ...row, ts: rows.length - i }))
+        nextTs = 10
+    }
+</script>
+
+<!-- dk-strip: docs-kit positioning shell - stripped from the published code. -->
+<div class="dk-demo-shell">
+    <div class="toolbar" aria-label="keyed list controls">
+        <button
+            type="button"
+            class="primary"
+            class:active={gate === 'index'}
+            onclick={() => (gate = gate === 'field' ? 'index' : 'field')}
+        >
+            <ListOrdered size={15} />
+            gate: {gate === 'field' ? 'row.ts (field)' : 'i (index)'}
+        </button>
+        <button type="button" onclick={reset}>
+            <RotateCcw size={15} />
+            Reset order
+        </button>
+    </div>
+
+    <ul class="rows">
+        {#each sorted as row, i (row.id)}
+            <motion.li
+                class="row"
+                layout="position"
+                layoutDependency={gate === 'field' ? row.ts : i}
+                transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
+            >
+                <span class="label">{row.label}</span>
+                <span class="meta">ts {row.ts}</span>
+                <button
+                    type="button"
+                    class="bump"
+                    aria-label={`Bump ${row.label} to the top`}
+                    onclick={() => bump(row.id)}
+                >
+                    <ArrowUpToLine size={14} />
+                </button>
+            </motion.li>
+        {/each}
+    </ul>
+
+    <p class="hint">
+        {#if gate === 'field'}
+            <code>layoutDependency={'{row.ts}'}</code> — bump a row: it slides up, the rows it
+            displaces
+            <strong>jump</strong> (their dependency didn't change).
+        {:else}
+            <code>layoutDependency={'{i}'}</code> — bump a row: every row whose slot changed slides.
+        {/if}
+    </p>
+</div>
+
+<style>
+    .dk-demo-shell {
+        width: 100%;
+        height: clamp(520px, calc(100vh - 160px), 600px);
+        display: grid;
+        grid-template-rows: auto minmax(0, 1fr) auto;
+        gap: 16px;
+        padding: 20px 26px;
+        background: var(--brut-bg, #f8fcfb);
+        color: var(--brut-ink, #0a0a0a);
+    }
+
+    .toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 8px;
+    }
+
+    button {
+        height: 36px;
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        padding: 0 12px;
+        border: 1px solid var(--brut-rule-2, #bbc4c0);
+        background: var(--brut-bg-2, #eef4f1);
+        color: var(--brut-ink, #0a0a0a);
+        font-family: var(--brut-mono, monospace);
+        font-size: 12px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        cursor: pointer;
+    }
+
+    button.primary {
+        border-color: var(--brut-accent, #247768);
+        background: var(--brut-accent-soft, rgba(36, 119, 104, 0.1));
+        color: var(--brut-accent, #247768);
+    }
+
+    button.active {
+        border-color: var(--brut-ink, #0a0a0a);
+        background: var(--brut-ink, #0a0a0a);
+        color: var(--brut-accent-ink, #f8fcfb);
+    }
+
+    .rows {
+        list-style: none;
+        margin: 0 auto;
+        padding: 0;
+        width: min(460px, 100%);
+        display: grid;
+        align-content: start;
+        gap: 8px;
+        min-height: 0;
+    }
+
+    :global(.row) {
+        display: grid;
+        grid-template-columns: 1fr auto auto;
+        align-items: center;
+        gap: 12px;
+        height: 52px;
+        padding: 0 8px 0 16px;
+        border: 1px solid var(--brut-rule-2, #bbc4c0);
+        background: var(--brut-bg-2, #eef4f1);
+    }
+
+    .label {
+        font-weight: 700;
+        font-size: 14px;
+    }
+
+    .meta {
+        font-family: var(--brut-mono, monospace);
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--brut-accent, #247768);
+    }
+
+    button.bump {
+        height: 32px;
+        width: 32px;
+        padding: 0;
+        justify-content: center;
+    }
+
+    .hint {
+        margin: 0;
+        text-align: center;
+        font-size: 13px;
+        color: var(--brut-ink-2, #3a3a3a);
+    }
+
+    .hint code {
+        font-family: var(--brut-mono, monospace);
+        color: var(--brut-accent, #247768);
+    }
+</style>

--- a/docs/src/routes/docs/layout-dependency/+page.svx
+++ b/docs/src/routes/docs/layout-dependency/+page.svx
@@ -59,19 +59,65 @@ Reach for `layoutDependency` when a `layout` element:
 - only changes layout box on a specific, known signal.
 
 Pass a value that changes **exactly when the layout should be re-measured** —
-commonly a counter, a sorted key, or the array length / order of a list.
-
-```svelte
-<motion.ul layout layoutDependency={items.length}>
-  {#each items as item (item.id)}
-    <motion.li layout layoutDependency={items.length}>{item.label}</motion.li>
-  {/each}
-</motion.ul>
-```
+commonly a counter, a sort key, or the element's position in a list.
 
 Any defined value gates — including falsy ones like `0`, `''`, or `null`. Leave
 it `undefined` (the default) to keep framer-motion's "measure on every render"
 behavior.
+
+## What the gate blocks
+
+While `layoutDependency` is set, **only a change to that value** re-measures the
+element. This matches upstream `MeasureLayout`, which snapshots when `drag` is
+set, the dependency changed, or the element's **own** presence flipped — and
+never otherwise. Layout changes that arrive any other way do **not** animate a
+gated element, and don't fire its `onProjectionUpdate` / `onLayoutMeasure`; it
+jumps to its new slot:
+
+- a sibling reorder that re-slots it,
+- a resize or a parent style change that moves it,
+- a sibling's `AnimatePresence` enter/exit,
+- an `AnimatePresence mode="wait"` child swap *inside* a gated `layout` parent
+  (that's the child's presence, not the parent's).
+
+Two escape hatches, both from upstream: `drag` opts the element out of gating
+entirely, and the element's own `isPresent` flip (an owned
+`<AnimatePresence present={…}>{#snippet child()}…` exit or re-entry) still
+snapshots it.
+
+### What the gate costs
+
+The parity is *behavioral*. Upstream can skip a gated node entirely because
+React lets it snapshot before the DOM commits; Svelte reconciles a keyed
+`{#each}` before a child can look. So a gated element still refreshes its
+cached slot with **one silent DOM read** when an observed change re-slots it
+(no snapshot, no FLIP, no callbacks) — that cached slot is the origin its next
+dependency-driven FLIP animates from. Unrelated renders cost a gated element
+nothing. Observers are shared per parent/ancestor, so a 1,000-row list runs one
+observer per target, not one per row.
+
+## Keyed lists
+
+In a keyed `{#each}` the dependency must change for **every row that moves**.
+Bind it to the row's index (or sort position), not to a field of the row's data:
+
+```svelte
+{#each rows as row, i (row.id)}
+  <!-- ✅ index changes for exactly the rows whose slot changed -->
+  <motion.li layout="position" layoutDependency={i}>{row.label}</motion.li>
+{/each}
+```
+
+```svelte
+{#each rows as row (row.id)}
+  <!-- ❌ only the row whose timestamp changed animates; the rows it
+       displaces have an unchanged dependency and jump -->
+  <motion.li layout="position" layoutDependency={row.updatedAt}>{row.label}</motion.li>
+{/each}
+```
+
+If you don't need the gate, simply omit `layoutDependency` and every row
+animates on every reorder.
 
 ## API Reference
 

--- a/docs/src/routes/examples/layout-dependency/+page.svelte
+++ b/docs/src/routes/examples/layout-dependency/+page.svelte
@@ -5,11 +5,12 @@
         type ExampleSection,
         formatSheetLabel
     } from '@humanspeak/docs-kit'
-    import { Gauge, Layers, Zap } from '@lucide/svelte'
+    import { ArrowUpToLine, Gauge, Layers, ListOrdered, Zap } from '@lucide/svelte'
     import { demoCodeSample } from '$lib/demo-loaders'
     import { getBreadcrumbContext } from '$lib/components/contexts/Breadcrumb/Breadcrumb.context'
     import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
     import LayoutDependencyDefault from '$lib/examples/layout-dependency/demos/Default.svelte'
+    import LayoutDependencyKeyedList from '$lib/examples/layout-dependency/demos/KeyedList.svelte'
 
     const breadcrumbs = getBreadcrumbContext()
     const seo = getSeoContext()
@@ -49,6 +50,22 @@
                 { k: 'mode', v: 'live' }
             ],
             sourceUrl: `${SOURCE_URL}layout-dependency/demos/Default.svelte`
+        },
+        {
+            figId: 'FIG-002',
+            tag: 'LAYOUT',
+            title: { prefix: 'keyed list, ', accent: 'what to gate on', end: '.' },
+            description:
+                'Rows are `layout="position"` in a keyed `{#each}` sorted by activity. Gated on a per-row field, only the bumped row animates and the rows it displaces jump — upstream parity. Gate on the row index and every moved row slides.',
+            snippet: keyedListSection,
+            codeSnippet: keyedListCode,
+            notes: keyedListNotes,
+            barCells: [
+                { k: 'api', v: 'layoutDependency' },
+                { k: 'input', v: 'keyed each' },
+                { k: 'mode', v: 'live' }
+            ],
+            sourceUrl: `${SOURCE_URL}layout-dependency/demos/KeyedList.svelte`
         }
     ]
 </script>
@@ -88,6 +105,48 @@
                 'layout-dependency/demos/Default.svelte',
                 'layout-dependency-default',
                 'Default.svelte'
+            )
+        ]}
+        columns={1}
+    />
+{/snippet}
+
+{#snippet keyedListSection()}
+    <LayoutDependencyKeyedList />
+{/snippet}
+{#snippet keyedListNotes()}
+    <ul>
+        <li>
+            <ArrowUpToLine />
+            <span>
+                Bumping a row re-sorts the list. With <code>layoutDependency={'{row.ts}'}</code>
+                only that row's dependency changed, so only it FLIPs — the displaced rows jump, exactly
+                as upstream <code>MeasureLayout</code> behaves.
+            </span>
+        </li>
+        <li>
+            <ListOrdered />
+            <span>
+                Switch to <code>layoutDependency={'{i}'}</code>: the index changes for every row
+                whose slot changed, so every moved row animates and untouched rows stay gated.
+            </span>
+        </li>
+        <li>
+            <Layers />
+            <span>
+                Don't need the gate in a list? Omit <code>layoutDependency</code> and every reorder animates
+                every row.
+            </span>
+        </li>
+    </ul>
+{/snippet}
+{#snippet keyedListCode()}
+    <CodeReferenceV2
+        samples={[
+            demoCodeSample(
+                'layout-dependency/demos/KeyedList.svelte',
+                'layout-dependency-keyed-list',
+                'KeyedList.svelte'
             )
         ]}
         columns={1}

--- a/e2e/layout/layout-dependency.spec.ts
+++ b/e2e/layout/layout-dependency.spec.ts
@@ -16,6 +16,28 @@ const render = async (page: Page, times: number) => {
     for (let i = 0; i < times; i++) await page.getByTestId('tick').click()
 }
 
+// Identity transforms: 'none', translate3d(0px, 0px, 0px), translate(0px, 0px),
+// translateY(0px). Anything else is a live FLIP frame.
+const isFlipTransform = (t: string) =>
+    !!t && t !== 'none' && !/^translate(?:3d|X|Y)?\((?:0px(?:, )?)+\)$/.test(t)
+
+/**
+ * Run `act`, then sample the element's inline transform for ~600ms and report
+ * whether a non-identity FLIP transform was ever applied.
+ */
+const sawFlipTransform = async (page: Page, testId: string, act: () => Promise<void>) => {
+    await act()
+    let seen = false
+    for (let i = 0; i < 36; i++) {
+        await page.waitForTimeout(16)
+        const t = await page
+            .getByTestId(testId)
+            .evaluate((el) => (el as HTMLElement).style.transform)
+        if (isFlipTransform(t)) seen = true
+    }
+    return seen
+}
+
 test.describe('layoutDependency (#314)', () => {
     test('gated box does not re-measure on unrelated renders; ungated box does', async ({
         page
@@ -58,10 +80,11 @@ test.describe('layoutDependency (#314)', () => {
     })
 })
 
-// Upstream MeasureLayout also forces a snapshot while dragging and on presence
-// changes, regardless of layoutDependency. The drag case is handled by an
-// explicit escape hatch in the gate; the presence case flows through the
-// observer path. Both panels hold the dependency constant (never bumped).
+// Upstream MeasureLayout forces a snapshot while `drag` is set, and on the
+// element's OWN presence flip, regardless of layoutDependency — and on
+// NOTHING else. A sibling's presence toggle re-slots a gated box without
+// touching its dependency, so upstream never re-measures it: it jumps.
+// Both panels hold the dependency constant (never bumped).
 test.describe('layoutDependency escape hatches', () => {
     test('drag forces measurement on renders; non-drag box stays gated', async ({ page }) => {
         await page.goto(URL)
@@ -80,13 +103,9 @@ test.describe('layoutDependency escape hatches', () => {
         await expect.poll(readCount(page, 'nodrag-measures')).toBe(0)
     })
 
-    test('gated box ignores renders but measures on AnimatePresence sibling toggle', async ({
+    test('gated box stays gated when an AnimatePresence sibling toggles (upstream parity)', async ({
         page
     }) => {
-        // Use a tall viewport so the whole page fits without scrolling: the
-        // projection deliberately suppresses the layout commit that follows a
-        // viewport scroll (so scrolling never triggers FLIP), and it skips
-        // commits for fully-offscreen elements — both would mask the reflow.
         await page.setViewportSize({ width: 1280, height: 1400 })
         await page.goto(URL)
         await waitForMotionReady(page, 'presence-gated-box')
@@ -101,18 +120,203 @@ test.describe('layoutDependency escape hatches', () => {
         const boxTop = () =>
             page
                 .getByTestId('presence-gated-box')
-                .evaluate((el) => Math.round(el.getBoundingClientRect().top))
+                .evaluate((el) => Math.round(el.getBoundingClientRect().top + window.scrollY))
         const startTop = await boxTop()
 
-        // Sibling exits → real layout shift → gated box reflows up and measures.
-        await page.getByTestId('toggle-sibling').click()
-        await expect.poll(readCount(page, 'presence-measures')).toBeGreaterThanOrEqual(1)
+        // Sibling exits → the box reflows up, but its dependency is unchanged
+        // → no snapshot, no measure, no FLIP transform (it jumps).
+        expect(
+            await sawFlipTransform(page, 'presence-gated-box', () =>
+                page.getByTestId('toggle-sibling').click()
+            )
+        ).toBe(false)
         await expect(page.getByTestId('presence-sibling')).toHaveCount(0)
         await expect.poll(boxTop).toBeLessThan(startTop)
+        expect(await readCount(page, 'presence-measures')()).toBe(0)
 
-        // Sibling re-enters → box reflows back down.
+        // Sibling re-enters → box reflows back down, still without measuring.
         await page.getByTestId('toggle-sibling').click()
         await expect(page.getByTestId('presence-sibling')).toHaveCount(1)
         await expect.poll(boxTop).toBe(startTop)
+        await page.waitForTimeout(500)
+        expect(await readCount(page, 'presence-measures')()).toBe(0)
+    })
+})
+
+// #470 — keyed `{#each}` reorder. Upstream only measures the row whose
+// dependency changed; displaced rows with an unchanged dependency jump. Gate on
+// the row's index and every moved row animates.
+test.describe('layoutDependency in a keyed list (#470)', () => {
+    const rowIds = ['a', 'b', 'c', 'd', 'e'] as const
+
+    /** Sample each row's inline transform for ~200ms after `act()`. */
+    const sampleTransforms = async (page: Page, act: () => Promise<void>) => {
+        const seen: Record<string, boolean> = {}
+        for (const id of rowIds) seen[id] = false
+        await act()
+        for (let i = 0; i < 24; i++) {
+            await page.waitForTimeout(16)
+            const transforms = await page.evaluate(() =>
+                Object.fromEntries(
+                    Array.from(document.querySelectorAll('[data-testid^="row-"]')).map((el) => [
+                        (el as HTMLElement).dataset.testid!.replace('row-', ''),
+                        (el as HTMLElement).style.transform
+                    ])
+                )
+            )
+            for (const id of rowIds) {
+                if (isFlipTransform(transforms[id] ?? '')) seen[id] = true
+            }
+        }
+        return seen
+    }
+
+    // Page-space (scroll-invariant): clicking a control may scroll the page.
+    const rowTop = (page: Page, id: string) =>
+        page
+            .getByTestId(`row-${id}`)
+            .evaluate((el) => Math.round(el.getBoundingClientRect().top + window.scrollY))
+
+    test('per-row field gate: only the bumped row animates; displaced rows jump', async ({
+        page
+    }) => {
+        await page.setViewportSize({ width: 1280, height: 1800 })
+        await page.goto(URL)
+        for (const id of rowIds) await waitForMotionReady(page, `row-${id}`)
+        await page.getByTestId('reset').click()
+
+        const eStart = await rowTop(page, 'e')
+        const aStart = await rowTop(page, 'a')
+
+        const seen = await sampleTransforms(page, () => page.getByTestId('bump-row-e').click())
+
+        // The row whose dependency changed FLIPs into its new slot.
+        expect(seen.e).toBe(true)
+        // The rows it displaced have an unchanged dependency: no transform.
+        expect(seen.a).toBe(false)
+        expect(seen.b).toBe(false)
+        expect(seen.c).toBe(false)
+        expect(seen.d).toBe(false)
+
+        // ...and no public measurement either: upstream never runs
+        // `updateLayout()` for a node it didn't snapshot, so `onLayoutMeasure`
+        // stays silent for the displaced rows while the bumped row reports.
+        const layoutMeasures = (id: string) =>
+            page.evaluate(
+                (rowId) =>
+                    (window as unknown as { __rowLayoutMeasures: Record<string, number> })
+                        .__rowLayoutMeasures[rowId] ?? 0,
+                id
+            )
+        await expect.poll(() => layoutMeasures('e')).toBeGreaterThanOrEqual(1)
+        for (const id of ['a', 'b', 'c', 'd']) expect(await layoutMeasures(id)).toBe(0)
+
+        // Everyone still lands in the right slot — they jumped, not stuck.
+        await expect.poll(() => rowTop(page, 'e')).toBe(aStart)
+        await expect.poll(() => rowTop(page, 'a')).toBeGreaterThan(aStart)
+        expect(eStart).toBeGreaterThan(aStart)
+    })
+
+    test('measurement cadence: renders cost gated rows no DOM reads; a reorder costs one silent read per displaced row', async ({
+        page
+    }) => {
+        await page.setViewportSize({ width: 1280, height: 2200 })
+        await page.goto(URL)
+        for (const id of rowIds) await waitForMotionReady(page, `row-${id}`)
+        await page.getByTestId('reset').click()
+
+        const stats = () =>
+            page.evaluate(() => {
+                const s = (
+                    window as unknown as {
+                        __layoutMeasureStats: { reads: number; silentReads: number }
+                    }
+                ).__layoutMeasureStats
+                return { reads: s.reads, silentReads: s.silentReads }
+            })
+
+        // Unrelated renders: gated elements do no silent cache reads at all
+        // (only the ungated default box measures on render).
+        await render(page, 5)
+        await page.waitForTimeout(200)
+        expect((await stats()).silentReads).toBe(0)
+
+        // Keyed reorder: each gated row refreshes its cache with exactly ONE
+        // silent read per observer delivery — not the two (measure + seed) the
+        // pre-mitigation path did. Accounting: `observeLayoutChanges` delivers
+        // leading + one trailing frame → 4 displaced rows × 2 = 8, plus the
+        // bumped row's own trailing pass (its leading pass was the loud FLIP
+        // commit) and one delivery for the rows' measure-count text update ≈ 10.
+        // Two reads per delivery would put this at ~20; guard well below that.
+        await page.getByTestId('reset').click()
+        await page.getByTestId('bump-row-e').click()
+        await page.waitForTimeout(600)
+        const after = await stats()
+        expect(after.silentReads).toBeGreaterThanOrEqual(4)
+        expect(after.silentReads).toBeLessThanOrEqual(12)
+    })
+
+    test('index gate: every row whose slot changed animates', async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 1800 })
+        await page.goto(URL)
+        for (const id of rowIds) await waitForMotionReady(page, `row-${id}`)
+        await page.getByTestId('toggle-list-gate').click()
+        await expect(page.getByTestId('toggle-list-gate')).toHaveText(/index/)
+        await page.getByTestId('reset').click()
+
+        const seen = await sampleTransforms(page, () => page.getByTestId('bump-row-e').click())
+
+        // e moves to index 0; a-d each shift down one index → all indices changed.
+        for (const id of rowIds) expect(seen[id]).toBe(true)
+    })
+})
+
+// Upstream MeasureLayout's remaining escape hatch: the element's OWN presence
+// flip (`prevProps.isPresent !== isPresent`) snapshots regardless of the
+// dependency. A CHILD's presence change inside the element is not that.
+test.describe('layoutDependency own-presence and wait-mode parent (upstream parity)', () => {
+    test('own presence flip measures a gated element; renders do not', async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 2200 })
+        await page.goto(URL)
+        await waitForMotionReady(page, 'self-presence-box')
+        await page.getByTestId('reset').click()
+        await expect.poll(readCount(page, 'self-presence-measures')).toBe(0)
+
+        await render(page, 4)
+        await expect.poll(readCount(page, 'self-presence-measures')).toBe(0)
+
+        // Exit: this element's isPresent flips false → snapshot + measure.
+        await page.getByTestId('toggle-self').click()
+        await expect.poll(readCount(page, 'self-presence-measures')).toBeGreaterThanOrEqual(1)
+    })
+
+    test('gated wait-mode parent jumps on child swap; ungated parent animates size', async ({
+        page
+    }) => {
+        await page.setViewportSize({ width: 1280, height: 2200 })
+        await page.goto(URL)
+        await waitForMotionReady(page, 'wait-parent')
+        await waitForMotionReady(page, 'gated-wait-parent')
+
+        const width = (id: string) =>
+            page.getByTestId(id).evaluate((el) => Math.round(el.getBoundingClientRect().width))
+        const smallWidth = await width('gated-wait-parent')
+
+        // Gated parent: the swap is a child's presence change, not this
+        // element's dependency or own presence → no FLIP transform, ever.
+        expect(
+            await sawFlipTransform(page, 'gated-wait-parent', () =>
+                page.getByTestId('swap-gated-wait-child').click()
+            )
+        ).toBe(false)
+        await expect.poll(() => width('gated-wait-parent')).toBeGreaterThan(smallWidth)
+
+        // Ungated parent keeps the hold/release size animation.
+        expect(
+            await sawFlipTransform(page, 'wait-parent', () =>
+                page.getByTestId('swap-wait-child').click()
+            )
+        ).toBe(true)
+        await expect.poll(() => width('wait-parent')).toBeGreaterThan(smallWidth)
     })
 })

--- a/src/lib/html/_MotionContainer.svelte
+++ b/src/lib/html/_MotionContainer.svelte
@@ -66,6 +66,7 @@
         runLayoutSizeAnimation,
         finishFlipAnimations,
         setCompositorHints,
+        isLayoutMeasurementGated,
         observeLayoutChanges,
         selectLayoutDependencies,
         sizeCorrectionSeedEvent,
@@ -633,10 +634,13 @@
     // `layoutScroll` offsets folded in. A viewport scroll between the
     // 'snapshot' (pre-patch) and 'measure' (post-patch) phases cancels
     // exactly, so it can never masquerade as a layout delta.
-    const measureLayoutRect = (phase: 'snapshot' | 'measure' = 'measure'): RectLike | null =>
+    const measureLayoutRect = (
+        phase: 'snapshot' | 'measure' = 'measure',
+        options?: { silent?: boolean }
+    ): RectLike | null =>
         // Null without a window (SSR) — every caller lives inside a
         // client-only effect, so the null branch is never animated against.
-        motionDomProjection?.measurePageRect(phase) ?? null
+        motionDomProjection?.measurePageRect(phase, options) ?? null
 
     // Get current presence depth (0 = direct child of AnimatePresence, undefined = not in AnimatePresence)
     const presenceDepth = getPresenceDepth()
@@ -2165,23 +2169,40 @@
     // committed — so it skips the duplicate re-commit that would otherwise
     // restart the FLIP from origin and double-fire `onProjectionUpdate`.
     let observerCommitSerial = 0
+    // Upstream `MeasureLayout.getSnapshotBeforeUpdate` snapshots only when
+    // `drag || layoutDependency changed || layoutDependency === undefined ||
+    // own presence flipped`; otherwise the node is never marked layout-dirty
+    // and `updateLayout()` skips it (create-projection-node.ts). So while the
+    // gate is closed, NOTHING re-measures this element — not a render, and not
+    // a DOM change the observer path would otherwise catch (a sibling reorder
+    // that re-slots it, a resize, a sibling's presence toggle). #470.
+    const layoutMeasurementGated = $derived(
+        isLayoutMeasurementGated(layoutDependencyProp, dragProp)
+    )
     // Reactive deps the measure effects read to decide when to re-snapshot and
-    // FLIP. When `layoutDependency` is set, gate measurement on *only* that
-    // value so frequent renders that touch class/style/etc. no longer force a
-    // re-measure. The fallback list stays a thunk so those props are tracked
-    // only when gating is off. See `selectLayoutDependencies` for the contract.
+    // FLIP. When gated, track *only* `layoutDependency` so frequent renders that
+    // touch class/style/etc. no longer force a re-measure. The fallback list
+    // stays a thunk so those props are tracked only when gating is off. See
+    // `selectLayoutDependencies` for the contract.
     //
-    // Drag escape hatch: upstream `MeasureLayout` also forces a snapshot while a
-    // drag is active, regardless of `layoutDependency` (MeasureLayout.tsx:92).
-    // We mirror that by ignoring the gate while `drag` is set, so a draggable
-    // `layout` element keeps measuring as the user moves it.
-    const trackLayoutProjectionDependencies = () =>
-        selectLayoutDependencies(dragProp ? undefined : layoutDependencyProp, () => [
-            classProp,
-            styleProp,
-            scopedLayoutId,
-            mergedTransition
-        ])
+    // Drag escape hatch: upstream `MeasureLayout` forces a snapshot whenever the
+    // `drag` prop is set, regardless of `layoutDependency` (MeasureLayout.tsx:92).
+    // `isLayoutMeasurementGated` folds that in, so a draggable `layout` element
+    // keeps measuring like an ungated one.
+    //
+    // Own-presence escape hatch: upstream also snapshots when THIS element's
+    // `isPresent` flips (MeasureLayout.tsx `prevProps.isPresent !== isPresent`)
+    // — exit start and re-entry — regardless of the dependency. Read the
+    // PresenceChild flag here so that flip re-runs the measure effects (and,
+    // via the pending reactive commit, opens the observer gate for exactly
+    // that update). A sibling's presence change is NOT this element's flip.
+    const trackLayoutProjectionDependencies = () => {
+        void presenceChildContext?.isPresent
+        return selectLayoutDependencies(
+            layoutMeasurementGated ? layoutDependencyProp : undefined,
+            () => [classProp, styleProp, scopedLayoutId, mergedTransition]
+        )
+    }
 
     $effect.pre(() => {
         const shouldProject = element && layoutProp && isLoaded === 'ready' && hasLayoutFeatures
@@ -2274,12 +2295,24 @@
             if (!commitDraggedLayoutChange(prev)) {
                 motionDomProjection?.commitObservedLayoutChange(prev)
             }
+            return
         }
         // No delta from THIS path's snapshot: leave `lastRect` alone. The
         // snapshot may have raced the DOM patch (measured post-patch, so
         // prev === next), and overwriting the cache here would poison the
         // observer path's diff — it would compare new-vs-new and skip the
         // FLIP entirely (an intermittent snap, ordering-dependent).
+        //
+        // Still close the update: upstream pairs EVERY getSnapshotBeforeUpdate
+        // `willUpdate()` with a componentDidUpdate `root.didUpdate()`, and the
+        // root update is what clears the projection snapshot (`updateSnapshot`
+        // keeps an existing one). Without this, the snapshot the `$effect.pre`
+        // took lingers, and the NEXT root update — triggered by any sibling's
+        // commit, possibly long after this element was re-slotted without
+        // measuring (a `layoutDependency`-gated row displaced by a keyed
+        // reorder, #470) — diffs that stale snapshot against the fresh layout
+        // and animates a move that never happened in this update.
+        motionDomProjection?.didUpdate()
     }
 
     $effect(() => {
@@ -2399,13 +2432,27 @@
             observerRestartElement === observedElement ? observerRestartRect : null
         observerRestartRect = null
         observerRestartElement = null
-        motionDomProjection?.seedLayout()
-        lastRect = measureLayoutRect()
+        // One read seeds the projection AND primes the observer cache
+        // (`seedLayout()` + `measureLayoutRect()` would read the box twice —
+        // and a keyed reorder restarts this effect for every moved row).
+        // Loud on purpose: this is the mount / restart slot `onLayoutMeasure`
+        // consumers (Reorder.Item) register from.
+        lastRect = motionDomProjection?.refreshLayout() ?? measureLayoutRect()
+        // Upstream gate (#470): a `layoutDependency`-gated node only snapshots
+        // when the dependency changed in THIS update (MeasureLayout.tsx:93-100
+        // `prevProps.layoutDependency !== layoutDependency`). A pending reactive
+        // commit is exactly that signal here — the `$effect.pre` that tracks the
+        // dependency queued it. Read untracked: flipping the gate must not tear
+        // down and re-wire the observers (that restart would itself look like a
+        // keyed move via `observerRestartRect`).
+        const isObservedCommitGated = () =>
+            untrack(() => layoutMeasurementGated) && reactiveCommitPrevious === null
         if (
             previousBeforeObserverRestart &&
             lastRect &&
             hasRectChanged(previousBeforeObserverRestart, lastRect) &&
-            !suppressObservedLayoutCommit()
+            !suppressObservedLayoutCommit() &&
+            !isObservedCommitGated()
         ) {
             observerCommitSerial += 1
             emitProjectionUpdate(previousBeforeObserverRestart, lastRect)
@@ -2415,8 +2462,30 @@
         }
         setCompositorHints(observedElement, true)
 
+        // Gated on `layoutDependency` with no dependency (or own-presence)
+        // change in this update: upstream takes no snapshot, so the node is
+        // never layout-dirty and skips measure, FLIP, and every layout
+        // listener — it jumps to its new slot (a sibling reorder, a resize, a
+        // sibling's presence toggle). Mirror that: no FLIP, no
+        // `onProjectionUpdate`, no `onLayoutMeasure`. The cache still tracks
+        // the live slot (Svelte patches the DOM before the dependency's
+        // `$effect.pre` can snapshot a keyed move, so `lastRect` is the only
+        // pre-move origin a later dependency change can FLIP from), and the
+        // projection's own layout is re-seeded so later animation targets the
+        // box the element actually has.
+        const refreshGatedLayoutCache = () => {
+            // ONE DOM read: seeds the projection layout and returns the rect
+            // (`measurePageRect` + `seedLayout` would read the box twice).
+            const next = motionDomProjection?.refreshLayout({ silent: true }) ?? null
+            if (next) lastRect = next
+        }
+
         const commitObservedLayout = () => {
             if (suppressObservedLayoutCommit()) return
+            if (isObservedCommitGated()) {
+                refreshGatedLayoutCache()
+                return
+            }
 
             const next = measureLayoutRect()
             if (!next) return
@@ -2471,6 +2540,16 @@
                     viewportScrolledDuringHold?: boolean
                 }>
             ).detail
+            // A wait-mode child swap is a CHILD's presence change, not this
+            // parent's dependency or own presence — upstream never
+            // `willUpdate()`s the parent for it, so a gated parent must not
+            // FLIP from the held box to its natural size (#470 review).
+            // Decided before any DOM read: the gated branch needs neither the
+            // viewport rect nor the held `previousRect`.
+            if (isObservedCommitGated()) {
+                refreshGatedLayoutCache()
+                return
+            }
             const previous = detail?.previousRect
             const viewportRect = element!.getBoundingClientRect()
             const next = measureLayoutRect()

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -705,19 +705,41 @@ export type MotionProps = {
      * When `undefined` (the default), measurement runs on every layout-affecting
      * render, matching framer-motion. Mirrors framer-motion's `layoutDependency`.
      *
+     * While gated, **only** a change to this value (or, matching upstream, the
+     * element's *own* presence flip inside an owned `AnimatePresence present
+     * child`) snapshots and animates the element — upstream `MeasureLayout`
+     * snapshots when `drag` is set, the dependency changed, or its own
+     * `isPresent` flipped, and otherwise never marks the node layout-dirty.
+     * Layout changes that arrive any other way (a sibling reorder that
+     * re-slots the element, a resize, a sibling's `AnimatePresence`
+     * enter/exit, an `AnimatePresence mode="wait"` child swap inside a gated
+     * parent) do **not** animate a gated element and do not fire
+     * `onProjectionUpdate` or `onLayoutMeasure` for it: it jumps to its new
+     * slot. (Internally the element still refreshes its cached slot with one
+     * silent DOM read on such a change — Svelte reconciles keyed lists before
+     * a child can snapshot, so that cache is the origin its next
+     * dependency-driven FLIP starts from. Unrelated renders cost nothing.)
+     *
+     * In a keyed `{#each}` list, that means the dependency must change for
+     * every row that moves. Bind it to the row's index (or sort position) — not
+     * to a field of the row's data, which only changes for the row that
+     * triggered the re-sort and lets the rows it displaces jump.
+     *
      * Enabling `drag` opts the element out of `layoutDependency` gating
      * entirely — a `layout` element with `drag` set re-measures like an ungated
      * one whether or not a drag is in progress, matching upstream
      * `MeasureLayout` (which keys off the `drag` prop, not active-gesture
-     * state). The gate only suppresses render-driven re-measurement; real
-     * layout changes detected by the observer system — element resize,
-     * structural/child mutations, and `AnimatePresence` enter/exit — are still
-     * measured so the element keeps animating genuine moves.
+     * state).
      *
      * @example
      * ```svelte
      * <!-- Re-measures only when `order` changes, not on every tick -->
      * <motion.div layout layoutDependency={order} />
+     *
+     * <!-- Keyed list: gate on the index so every moved row animates -->
+     * {#each rows as row, i (row.id)}
+     *   <motion.li layout="position" layoutDependency={i}>{row.label}</motion.li>
+     * {/each}
      * ```
      */
     layoutDependency?: unknown

--- a/src/lib/utils/layout.spec.ts
+++ b/src/lib/utils/layout.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
     computeFlipTransforms,
+    isLayoutMeasurementGated,
     measureRect,
     observeLayoutChanges,
     runLayoutSizeAnimation,
@@ -319,7 +320,9 @@ describe('utils/layout', () => {
             }
             observe(target: Element, options?: unknown) {
                 resizeObserveCalls.push({ target, options })
-                this._cb([], this as unknown as ResizeObserver)
+                // Real ResizeObserver delivers one entry per target; the shared
+                // registry routes by `entry.target`.
+                this._cb([{ target } as ResizeObserverEntry], this as unknown as ResizeObserver)
             }
             disconnect() {}
         }
@@ -374,6 +377,65 @@ describe('utils/layout', () => {
         vi.unstubAllGlobals()
     })
 
+    it('observeLayoutChanges: siblings share ONE observer per (target, options) and the last release disconnects', () => {
+        const parent = document.createElement('div')
+        const a = document.createElement('div')
+        const b = document.createElement('div')
+        parent.append(a, b)
+        document.body.appendChild(parent)
+
+        const instances: Array<{
+            target: Node
+            options: MutationObserverInit
+            disconnected: boolean
+        }> = []
+        class CountingMutationObserver {
+            private record?: { target: Node; options: MutationObserverInit; disconnected: boolean }
+            constructor(private readonly _cb: MutationCallback) {}
+            observe(target: Node, options: MutationObserverInit) {
+                this.record = { target, options, disconnected: false }
+                instances.push(this.record)
+            }
+            disconnect() {
+                if (this.record) this.record.disconnected = true
+            }
+        }
+        class NoopResizeObserver {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        }
+        vi.stubGlobal('MutationObserver', CountingMutationObserver)
+        vi.stubGlobal('ResizeObserver', NoopResizeObserver)
+
+        const cleanupA = observeLayoutChanges(a, vi.fn())
+        const parentChildListBefore = instances.filter(
+            (i) => i.target === parent && i.options.childList
+        ).length
+        const cleanupB = observeLayoutChanges(b, vi.fn())
+        const parentChildListAfter = instances.filter(
+            (i) => i.target === parent && i.options.childList
+        ).length
+
+        // The immediate parent's childList observer is created once and shared:
+        // b's subscription must not add a second observer on `parent`.
+        expect(parentChildListBefore).toBe(1)
+        expect(parentChildListAfter).toBe(1)
+        // Likewise the parent's attribute observer (style/class re-slot signal).
+        expect(instances.filter((i) => i.target === parent && i.options.attributes).length).toBe(1)
+
+        // Ref-counted: releasing a keeps the shared observer alive for b ...
+        cleanupA()
+        const parentEntry = instances.find((i) => i.target === parent && i.options.childList)!
+        expect(parentEntry.disconnected).toBe(false)
+        // ... and the last release disconnects it.
+        cleanupB()
+        expect(parentEntry.disconnected).toBe(true)
+
+        vi.unstubAllGlobals()
+        parent.remove()
+    })
+
     it('observeLayoutChanges: throttles via requestAnimationFrame and cancels on cleanup (no parent)', () => {
         const el = document.createElement('div')
         const cb = vi.fn()
@@ -406,8 +468,10 @@ describe('utils/layout', () => {
             constructor(cb2: ResizeObserverCallback) {
                 this._cb = cb2
             }
-            observe() {
-                this._cb([], this as unknown as ResizeObserver)
+            observe(target: Element) {
+                // Real ResizeObserver delivers one entry per target; the shared
+                // registry routes by `entry.target`.
+                this._cb([{ target } as ResizeObserverEntry], this as unknown as ResizeObserver)
             }
             disconnect() {}
         }
@@ -470,8 +534,10 @@ describe('utils/layout', () => {
             constructor(cb2: ResizeObserverCallback) {
                 this._cb = cb2
             }
-            observe() {
-                this._cb([], this as unknown as ResizeObserver)
+            observe(target: Element) {
+                // Real ResizeObserver delivers one entry per target; the shared
+                // registry routes by `entry.target`.
+                this._cb([{ target } as ResizeObserverEntry], this as unknown as ResizeObserver)
             }
             disconnect() {}
         }
@@ -529,8 +595,10 @@ describe('utils/layout', () => {
             constructor(cb2: ResizeObserverCallback) {
                 this._cb = cb2
             }
-            observe() {
-                this._cb([], this as unknown as ResizeObserver)
+            observe(target: Element) {
+                // Real ResizeObserver delivers one entry per target; the shared
+                // registry routes by `entry.target`.
+                this._cb([{ target } as ResizeObserverEntry], this as unknown as ResizeObserver)
             }
             disconnect() {}
         }
@@ -791,6 +859,31 @@ describe('utils/layout', () => {
             expect(selectLayoutDependencies(obj, fallback)).toEqual([obj])
             expect(selectLayoutDependencies(arr, fallback)).toEqual([arr])
             expect(fallback).not.toHaveBeenCalled()
+        })
+    })
+
+    // Upstream MeasureLayout.getSnapshotBeforeUpdate: willUpdate() runs when
+    // `drag || layoutDependency changed || layoutDependency === undefined ||
+    // presence flipped`; otherwise NOTHING re-measures — including DOM changes
+    // our observers would otherwise catch (sibling reorder, resize). #470.
+    describe('isLayoutMeasurementGated (#470 upstream parity)', () => {
+        it('is open (not gated) when layoutDependency is undefined', () => {
+            expect(isLayoutMeasurementGated(undefined, undefined)).toBe(false)
+            expect(isLayoutMeasurementGated(undefined, false)).toBe(false)
+        })
+
+        it('is closed for any defined dependency, including falsy ones', () => {
+            expect(isLayoutMeasurementGated('key', undefined)).toBe(true)
+            expect(isLayoutMeasurementGated(0, undefined)).toBe(true)
+            expect(isLayoutMeasurementGated('', false)).toBe(true)
+            expect(isLayoutMeasurementGated(null, false)).toBe(true)
+            expect(isLayoutMeasurementGated(false, false)).toBe(true)
+        })
+
+        it('is forced open by the drag prop (any truthy drag value)', () => {
+            expect(isLayoutMeasurementGated('key', true)).toBe(false)
+            expect(isLayoutMeasurementGated(0, 'x')).toBe(false)
+            expect(isLayoutMeasurementGated(0, 'y')).toBe(false)
         })
     })
 })

--- a/src/lib/utils/layout.ts
+++ b/src/lib/utils/layout.ts
@@ -519,6 +519,173 @@ export const selectLayoutDependencies = (
 ): unknown[] => (layoutDependency !== undefined ? [layoutDependency] : fallback())
 
 /**
+ * Whether `layout` measurement is currently closed by `layoutDependency`.
+ *
+ * Mirrors upstream `MeasureLayout.getSnapshotBeforeUpdate`, which calls
+ * `projection.willUpdate()` only when `drag` is set, `layoutDependency`
+ * changed, `layoutDependency` is `undefined`, or the element's own presence
+ * flipped — and otherwise takes no snapshot at all. While the gate is closed
+ * NOTHING animates the element: not a render, and not a DOM change the
+ * observer system would otherwise catch (a sibling reorder that re-slots it, a
+ * resize, a sibling's presence toggle). Those changes only refresh the cached
+ * slot; no snapshot, FLIP, or `onProjectionUpdate` happens until the dependency
+ * value itself changes.
+ *
+ * `drag` keys off the PROP, not active-gesture state, exactly like upstream
+ * (MeasureLayout.tsx `if (drag || ...)`), so a draggable `layout` element is
+ * never gated.
+ *
+ * @param layoutDependency The user-supplied `layoutDependency` prop value.
+ * @param drag The user-supplied `drag` prop value.
+ * @returns `true` when measurement is gated on `layoutDependency` changes only.
+ * @example
+ * ```ts
+ * isLayoutMeasurementGated(undefined, undefined) // => false (default)
+ * isLayoutMeasurementGated(order, undefined) // => true
+ * isLayoutMeasurementGated(order, true) // => false (drag opens the gate)
+ * ```
+ */
+export const isLayoutMeasurementGated = (layoutDependency: unknown, drag: unknown): boolean =>
+    layoutDependency !== undefined && !drag
+
+/**
+ * Shared observer registries.
+ *
+ * Every `layout` element used to own its own `ResizeObserver` plus one
+ * `MutationObserver` per observed target (self attributes, self subtree, the
+ * parent's child list, and each observed ancestor's attributes). A 1,000-row
+ * list therefore ran ~1,000 resize observers and ~6,000 mutation observers,
+ * and one parent `childList` mutation fanned out through 1,000 separate
+ * observer callbacks. Native observers accept many targets, so these
+ * registries hold ONE observer per (target, options) and dispatch to every
+ * subscriber. Ref-counted: the last release disconnects.
+ *
+ * Instances are keyed on the current global constructor so a test that swaps
+ * `ResizeObserver` / `MutationObserver` for a shim gets fresh observers.
+ */
+type ObserverHandler = () => void
+
+interface SharedResizeRegistry {
+    ctor: typeof ResizeObserver
+    observer: ResizeObserver
+    handlers: Map<Element, Set<ObserverHandler>>
+}
+let sharedResize: SharedResizeRegistry | null = null
+
+const acquireResizeObserver = (target: Element, handler: ObserverHandler): (() => void) => {
+    const Ctor = globalThis.ResizeObserver
+    if (!sharedResize || sharedResize.ctor !== Ctor) {
+        const handlers = new Map<Element, Set<ObserverHandler>>()
+        const observer = new Ctor((entries) => {
+            for (const entry of entries) {
+                const set = handlers.get(entry.target)
+                if (set) for (const h of [...set]) h()
+            }
+        })
+        sharedResize = { ctor: Ctor, observer, handlers }
+    }
+    const registry = sharedResize
+    let set = registry.handlers.get(target)
+    const isFirst = !set
+    if (!set) {
+        set = new Set()
+        registry.handlers.set(target, set)
+    }
+    // Subscribe BEFORE observe(): a synchronously-firing observer double
+    // (tests) must reach this handler on its first delivery.
+    set.add(handler)
+    if (isFirst) registry.observer.observe(target)
+    return () => {
+        const current = registry.handlers.get(target)
+        if (!current) return
+        current.delete(handler)
+        if (current.size === 0) {
+            registry.handlers.delete(target)
+            // Test shims may lack `unobserve`.
+            registry.observer.unobserve?.(target)
+        }
+    }
+}
+
+type MutationHandler = (records: MutationRecord[]) => void
+interface SharedMutationEntry {
+    ctor: typeof MutationObserver
+    observer: MutationObserver
+    handlers: Set<MutationHandler>
+}
+/** Keyed by a stable serialization of the observe() options, then by target. */
+const sharedMutation = new Map<string, WeakMap<Node, SharedMutationEntry>>()
+
+const acquireMutationObserver = (
+    target: Node,
+    init: MutationObserverInit,
+    handler: MutationHandler
+): (() => void) => {
+    const Ctor = globalThis.MutationObserver
+    const key = JSON.stringify(init)
+    let byTarget = sharedMutation.get(key)
+    if (!byTarget) {
+        byTarget = new WeakMap()
+        sharedMutation.set(key, byTarget)
+    }
+    const targets = byTarget
+    let entry = targets.get(target)
+    let isFirst = false
+    if (!entry || entry.ctor !== Ctor) {
+        const handlers = new Set<MutationHandler>()
+        const observer = new Ctor((records) => {
+            for (const h of [...handlers]) h(records)
+        })
+        entry = { ctor: Ctor, observer, handlers }
+        targets.set(target, entry)
+        isFirst = true
+    }
+    const owned = entry
+    // Subscribe BEFORE observe(): a synchronously-firing observer double
+    // (tests) must reach this handler on its first delivery.
+    owned.handlers.add(handler)
+    if (isFirst) owned.observer.observe(target, init)
+    return () => {
+        owned.handlers.delete(handler)
+        if (owned.handlers.size === 0) {
+            owned.observer.disconnect()
+            if (targets.get(target) === owned) targets.delete(target)
+        }
+    }
+}
+
+const SELF_ATTRIBUTE_INIT: MutationObserverInit = {
+    attributes: true,
+    attributeFilter: ['class', 'data-presence-layout-hold']
+}
+const CHILD_LIST_INIT: MutationObserverInit = { childList: true, subtree: true }
+const ANCESTOR_ATTRIBUTE_INIT: MutationObserverInit = {
+    attributes: true,
+    attributeFilter: ['style', 'class'],
+    attributeOldValue: true
+}
+
+/**
+ * Whether an ancestor attribute mutation batch can re-slot children. Style
+ * mutations that only touch animation channels (transforms / opacity /
+ * will-change — written every frame by gesture and FLIP animations) never
+ * re-slot children, so they are filtered out to avoid commit storms.
+ */
+const ancestorMutationsAffectLayout = (mutations: MutationRecord[]): boolean => {
+    for (const mutation of mutations) {
+        if (mutation.attributeName === 'style') {
+            const before = stripNonChildLayoutStyle(mutation.oldValue ?? '')
+            const after = stripNonChildLayoutStyle(
+                (mutation.target as HTMLElement).getAttribute('style') ?? ''
+            )
+            if (before === after) continue
+        }
+        return true
+    }
+    return false
+}
+
+/**
  * Observe size/attribute changes that commonly trigger layout changes.
  *
  * Returns a cleanup function that disconnects observers. The callback is called
@@ -578,39 +745,11 @@ export const observeLayoutChanges = (el: HTMLElement, onChange: () => void): (()
             }, 50)
         }
     }
-    const ro = new ResizeObserver(() => schedule())
-    const attributeObserver = new MutationObserver(() => schedule())
-    const childListObserver = new MutationObserver(() => schedule())
-    // The element's OWN childList (subtree) observation. Kept separate from the
-    // ancestor wiring below so a re-parent can disconnect/re-attach the ancestor
-    // observers without dropping this self-observation.
-    const observeSelfChildList = () =>
-        childListObserver.observe(el, {
-            childList: true,
-            subtree: true
-        })
-    // An ANCESTOR's style/class change can re-slot this element (e.g. the
-    // classic toggle-switch: align-items flip on the track, or the same flip
-    // two levels up) with no childList or resize signal, and the Svelte-owned
-    // reactive path can't snapshot it — the ancestor patches before this
-    // element's effects run. Watch each observed ancestor's attributes and let
-    // the commit path diff against the cached rect. Style mutations that only
-    // touch animation channels (transforms / opacity / will-change — written
-    // every frame by gesture and FLIP animations) never re-slot children, so
-    // they're filtered out at EVERY observed level to avoid commit storms.
-    const parentAttributeObserver = new MutationObserver((mutations) => {
-        for (const mutation of mutations) {
-            if (mutation.attributeName === 'style') {
-                const before = stripNonChildLayoutStyle(mutation.oldValue ?? '')
-                const after = stripNonChildLayoutStyle(
-                    (mutation.target as HTMLElement).getAttribute('style') ?? ''
-                )
-                if (before === after) continue
-            }
-            schedule()
-            return
-        }
-    })
+    // The element's OWN observers: resize, class / presence-hold attributes,
+    // and childList (subtree). Shared instances — see the registries above.
+    const releaseSelf: Array<() => void> = []
+    // Ancestor subscriptions are re-acquired on re-parenting.
+    let releaseAncestors: Array<() => void> = []
 
     /**
      * Collect the bounded ancestor chain (closest first) up to
@@ -632,8 +771,12 @@ export const observeLayoutChanges = (el: HTMLElement, onChange: () => void): (()
     // empty placeholder — real MutationObserver/ResizeObserver never fire on
     // `observe()`, so in production this is simply the initial chain.
     let observedAncestors: HTMLElement[] = collectAncestors()
+    const onAncestorAttributes: MutationHandler = (mutations) => {
+        if (ancestorMutationsAffectLayout(mutations)) schedule()
+    }
     const wireAncestors = () => {
-        observedAncestors.forEach((ancestor, index) => {
+        releaseAncestors = observedAncestors.flatMap((ancestor, index) => {
+            const releases: Array<() => void> = []
             // Only the IMMEDIATE parent gets childList: `subtree: true` already
             // covers sibling reorders/insertions that re-slot this element.
             // Higher levels intentionally SKIP childList — a higher-level DOM
@@ -641,19 +784,25 @@ export const observeLayoutChanges = (el: HTMLElement, onChange: () => void): (()
             // rect, which surfaces on the attribute path; adding childList at
             // every level only widens noise without catching a distinct case.
             if (index === 0) {
-                childListObserver.observe(ancestor, { childList: true, subtree: true })
+                releases.push(acquireMutationObserver(ancestor, CHILD_LIST_INIT, schedule))
             }
-            parentAttributeObserver.observe(ancestor, {
-                attributes: true,
-                attributeFilter: ['style', 'class'],
-                attributeOldValue: true
-            })
+            // An ANCESTOR's style/class change can re-slot this element (e.g.
+            // the classic toggle-switch: align-items flip on the track, or the
+            // same flip two levels up) with no childList or resize signal, and
+            // the Svelte-owned reactive path can't snapshot it — the ancestor
+            // patches before this element's effects run. Watch each observed
+            // ancestor's attributes and let the commit path diff against the
+            // cached rect.
+            releases.push(
+                acquireMutationObserver(ancestor, ANCESTOR_ATTRIBUTE_INIT, onAncestorAttributes)
+            )
+            return releases
         })
     }
 
     /**
      * If the element's ancestor chain has changed since it was last wired
-     * (portal, imperative move), disconnect the stale ancestor observers and
+     * (portal, imperative move), release the stale ancestor subscriptions and
      * re-attach to the new chain. Cheap array-of-references equality.
      */
     const rewireIfReparented = () => {
@@ -662,13 +811,8 @@ export const observeLayoutChanges = (el: HTMLElement, onChange: () => void): (()
             next.length === observedAncestors.length &&
             next.every((ancestor, index) => ancestor === observedAncestors[index])
         if (unchanged) return
-        // Drop every stale-chain observer and re-attach to the new chain.
-        // childListObserver also carries el's own self-observation, so
-        // disconnect() wipes that too — re-establish it before re-wiring.
-        childListObserver.disconnect()
-        parentAttributeObserver.disconnect()
+        for (const release of releaseAncestors) release()
         observedAncestors = next
-        observeSelfChildList()
         wireAncestors()
     }
 
@@ -676,19 +820,15 @@ export const observeLayoutChanges = (el: HTMLElement, onChange: () => void): (()
     // observer double that fires synchronously on `observe()` (used in tests)
     // would otherwise re-enter `schedule` → `rewireIfReparented` before those
     // closures exist. Real observers never fire on `observe()`.
-    ro.observe(el)
-    attributeObserver.observe(el, {
-        attributes: true,
-        attributeFilter: ['class', 'data-presence-layout-hold']
-    })
-    observeSelfChildList()
+    releaseSelf.push(acquireResizeObserver(el, schedule))
+    releaseSelf.push(acquireMutationObserver(el, SELF_ATTRIBUTE_INIT, schedule))
+    releaseSelf.push(acquireMutationObserver(el, CHILD_LIST_INIT, schedule))
     wireAncestors()
 
     return () => {
-        ro.disconnect()
-        attributeObserver.disconnect()
-        childListObserver.disconnect()
-        parentAttributeObserver.disconnect()
+        for (const release of releaseSelf) release()
+        for (const release of releaseAncestors) release()
+        releaseAncestors = []
         if (pendingRaf !== null && typeof cancelAnimationFrame === 'function') {
             cancelAnimationFrame(pendingRaf)
             pendingRaf = null

--- a/src/lib/utils/motionDomProjection.spec.ts
+++ b/src/lib/utils/motionDomProjection.spec.ts
@@ -1,6 +1,6 @@
 import { visualElementStore } from 'motion-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { MotionDomProjectionAdapter } from './motionDomProjection.js'
+import { MotionDomProjectionAdapter, layoutMeasureStats } from './motionDomProjection.js'
 import { createMotionVisualElement } from './visualElementCore.js'
 
 /**
@@ -86,6 +86,63 @@ describe('MotionDomProjectionAdapter.measurePageRect', () => {
         setScrollAndRect(element, 700, 100)
         const second = adapter.measurePageRect('measure')
         expect(second!.top).toBe(100)
+        adapter.unmount()
+    })
+
+    it('notifies onMeasure listeners by default and skips them for a silent read (#470 gate)', () => {
+        setScrollAndRect(element, 0, 100)
+        adapter.mount(element)
+        const listener = vi.fn()
+        const off = adapter.onMeasure(listener)
+
+        const loud = adapter.measurePageRect('measure')
+        expect(loud).not.toBeNull()
+        expect(listener).toHaveBeenCalledTimes(1)
+        expect(listener).toHaveBeenLastCalledWith(loud)
+
+        // A `layoutDependency`-gated node re-slotted by a sibling refreshes its
+        // cache without surfacing a measurement — upstream never runs
+        // `updateLayout()` for it, so `onLayoutMeasure` must stay silent.
+        const quiet = adapter.measurePageRect('measure', { silent: true })
+        expect(quiet).toEqual(loud)
+        expect(listener).toHaveBeenCalledTimes(1)
+
+        off()
+        adapter.unmount()
+    })
+
+    it('refreshLayout seeds the projection and returns the rect in ONE DOM read (silent skips listeners)', () => {
+        setScrollAndRect(element, 0, 100)
+        adapter.mount(element)
+        const listener = vi.fn()
+        const off = adapter.onMeasure(listener)
+        const readSpy = vi.spyOn(element, 'getBoundingClientRect')
+        readSpy.mockClear()
+        const silentBefore = layoutMeasureStats.silentReads
+        const loudBefore = layoutMeasureStats.reads
+
+        // The observer bridge used to do measurePageRect() + seedLayout(),
+        // reading the box twice; the gated cache refresh must read it once.
+        const rect = adapter.refreshLayout({ silent: true })
+        expect(rect).toEqual({ left: 10, top: 100, width: 100, height: 50 })
+        expect(readSpy).toHaveBeenCalledTimes(1)
+        // Seeded: the projection's cached slot equals the returned rect.
+        expect(adapter.lastMeasuredRect).toEqual(rect)
+        // Silent: no `onLayoutMeasure` fan-out, only the silent counter moves.
+        expect(listener).not.toHaveBeenCalled()
+        expect(layoutMeasureStats.silentReads).toBe(silentBefore + 1)
+        expect(layoutMeasureStats.reads).toBe(loudBefore)
+
+        // Loud variant notifies once and counts as a public read.
+        readSpy.mockClear()
+        const loud = adapter.refreshLayout()
+        expect(readSpy).toHaveBeenCalledTimes(1)
+        expect(listener).toHaveBeenCalledTimes(1)
+        expect(listener).toHaveBeenLastCalledWith(loud)
+        expect(layoutMeasureStats.reads).toBe(loudBefore + 1)
+
+        readSpy.mockRestore()
+        off()
         adapter.unmount()
     })
 

--- a/src/lib/utils/motionDomProjection.ts
+++ b/src/lib/utils/motionDomProjection.ts
@@ -23,6 +23,30 @@ type LayoutOption = boolean | string | undefined
 type AnimationType = 'position' | 'x' | 'y' | 'size' | 'both' | 'preserve-aspect'
 type RectLike = { left: number; top: number; width: number; height: number }
 
+/**
+ * Development-only measurement counters.
+ *
+ * `onProjectionUpdate` / `onLayoutMeasure` counts prove *callback* parity, not
+ * *measurement-cost* parity: a `layoutDependency`-gated element that is
+ * re-slotted by a sibling still refreshes its cached slot with a silent DOM
+ * read. These counters make that hidden cost observable so a demo or test can
+ * assert the cadence (one read per observed change, none per unrelated
+ * render). Reset them yourself between samples.
+ *
+ * @example
+ * ```ts
+ * layoutMeasureStats.reads = 0
+ * // ...trigger a keyed reorder...
+ * console.log(layoutMeasureStats.reads)
+ * ```
+ */
+export const layoutMeasureStats = {
+    /** Page-rect reads that notified `onMeasure` listeners (`measurePageRect`). */
+    reads: 0,
+    /** Silent cache refreshes for gated elements (`refreshLayout({ silent: true })`). */
+    silentReads: 0
+}
+
 export interface MotionDomProjectionOptions {
     /** Parent adapter used to connect this node into the upstream projection tree. */
     parent?: MotionDomProjectionAdapter | null
@@ -334,6 +358,54 @@ export class MotionDomProjectionAdapter {
     }
 
     /**
+     * Seed the current layout AND return its page-space rect in a single DOM
+     * read.
+     *
+     * `measurePageRect()` followed by `seedLayout()` reads the box twice (the
+     * second via upstream `updateLayout()`). Callers that need both — the
+     * observer bridge's cache refresh — use this instead: it strips motion
+     * transforms like `measurePageRect`, runs upstream `updateLayout()` once
+     * (which is what installs `projection.layout`), and derives the rect from
+     * that measurement.
+     *
+     * @param options.silent Skip the `onMeasure` listener fan-out. A
+     * `layoutDependency`-gated element re-slotted by a sibling refreshes its
+     * cache silently: upstream never runs `updateLayout()` for a node it
+     * didn't snapshot, so `onLayoutMeasure` must not fire.
+     * @returns The freshly seeded page-space rect, or `null` before mount.
+     *
+     * @example
+     * ```ts
+     * // One read: projection layout seeded, cache rect returned.
+     * const rect = adapter.refreshLayout({ silent: true })
+     * ```
+     */
+    refreshLayout(options?: { silent?: boolean }): RectLike | null {
+        if (!this.element) return null
+        this.updatePathScroll('measure')
+        // Physically strip in-flight FLIP/motion transforms for the read —
+        // `updateLayout()` measures with `measure(false)`, which trusts the DOM.
+        const restore = this.stripToBaseTransforms()
+        try {
+            this.projection.isLayoutDirty = true
+            this.projection.updateLayout()
+        } finally {
+            restore()
+        }
+        this.lastLayout = cloneMeasurements(this.projection.layout)
+        const box = this.projection.layout?.layoutBox
+        if (!box) return null
+        const rect = rectFromBox(box)
+        if (options?.silent) {
+            layoutMeasureStats.silentReads += 1
+        } else {
+            layoutMeasureStats.reads += 1
+            for (const listener of this.measureListeners) listener(rect)
+        }
+        return rect
+    }
+
+    /**
      * Measure this element's layout rect in scroll-invariant PAGE space via
      * the upstream projection node.
      *
@@ -354,6 +426,10 @@ export class MotionDomProjectionAdapter {
      * this read belongs to: `'snapshot'` before the DOM patch, `'measure'`
      * after. Mirrors upstream `updateScroll(phase)`; the observer bridge's
      * callbacks mark the phase boundaries.
+     * @param options.silent Skip the `onMeasure` listener fan-out. Used for
+     * cache-only refreshes that upstream would never surface as a measurement
+     * — a `layoutDependency`-gated node re-slotted by a sibling never runs
+     * `updateLayout()`, so its `onLayoutMeasure` must not fire either.
      * @returns The page-space rect, or `null` before mount / without a window.
      *
      * @example
@@ -361,9 +437,11 @@ export class MotionDomProjectionAdapter {
      * const before = adapter.measurePageRect('snapshot')
      * // ...DOM patch...
      * const after = adapter.measurePageRect('measure')
+     * // Cache refresh only, no listener notification:
+     * const quiet = adapter.measurePageRect('measure', { silent: true })
      * ```
      */
-    measurePageRect(phase: Phase = 'measure'): RectLike | null {
+    measurePageRect(phase: Phase = 'measure', options?: { silent?: boolean }): RectLike | null {
         if (!this.element) return null
         this.updatePathScroll(phase)
 
@@ -383,7 +461,12 @@ export class MotionDomProjectionAdapter {
         // Notify after the inline transforms are restored so listeners
         // (e.g. Reorder.Item slot registration via `onLayoutMeasure`) see a
         // consistent DOM.
-        for (const listener of this.measureListeners) listener(rect)
+        if (options?.silent) {
+            layoutMeasureStats.silentReads += 1
+        } else {
+            layoutMeasureStats.reads += 1
+            for (const listener of this.measureListeners) listener(rect)
+        }
         return rect
     }
 

--- a/src/routes/tests/layout-dependency/+page.svelte
+++ b/src/routes/tests/layout-dependency/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { AnimatePresence, motion } from '$lib'
+    import { layoutMeasureStats } from '$lib/utils/motionDomProjection'
 
     // A high-frequency render driver. Each tick changes both boxes' inline
     // `style` (the background hue), forcing a re-render that — without
@@ -23,10 +24,71 @@
     // Drag: a gated box with `drag` should ignore the gate and keep measuring.
     let dragMeasures = $state(0)
     let noDragMeasures = $state(0)
-    // Presence: a gated box whose sibling toggles via AnimatePresence should
-    // still measure when the real layout shift happens (observer path).
+    // Presence: a gated box whose SIBLING toggles via AnimatePresence must NOT
+    // measure — upstream only re-snapshots on the element's OWN presence flip
+    // (MeasureLayout.tsx `prevProps.isPresent !== isPresent`), so a sibling
+    // reflow with an unchanged dependency jumps.
     let presenceMeasures = $state(0)
     let siblingPresent = $state(true)
+
+    // Keyed list (#470): rows gated on a PER-ROW field. Bumping one row's
+    // timestamp re-sorts the list. Upstream only measures the row whose
+    // dependency changed; the rows it displaces have an unchanged dependency
+    // and jump. Gate on the row's index instead to animate every row that
+    // moves — that value changes for exactly the rows whose slot changed.
+    type Row = { id: string; ts: number }
+    let rows = $state<Row[]>([
+        { id: 'a', ts: 5 },
+        { id: 'b', ts: 4 },
+        { id: 'c', ts: 3 },
+        { id: 'd', ts: 2 },
+        { id: 'e', ts: 1 }
+    ])
+    let nextTs = 10
+    let listGate = $state<'field' | 'index'>('field')
+    const sortedRows = $derived([...rows].sort((x, y) => y.ts - x.ts))
+    let rowMeasures = $state<Record<string, number>>({})
+    // `onLayoutMeasure` counter per row: a gated row that merely gets
+    // re-slotted must not surface a measurement (upstream never runs
+    // `updateLayout()` for it), so this stays flat for displaced rows.
+    // Deliberately NON-reactive (a plain object on `window`, read by the e2e
+    // via `page.evaluate`): `onLayoutMeasure` fires from inside layout effects,
+    // and writing `$state` there re-enters the measure cycle.
+    const rowLayoutMeasures: Record<string, number> = {}
+    if (typeof window !== 'undefined') {
+        const w = window as unknown as {
+            __rowLayoutMeasures: Record<string, number>
+            __layoutMeasureStats: typeof layoutMeasureStats
+        }
+        w.__rowLayoutMeasures = rowLayoutMeasures
+        // Library-internal DOM-read counters (public callbacks can't see the
+        // silent cache refresh a gated element does when a sibling re-slots it).
+        w.__layoutMeasureStats = layoutMeasureStats
+    }
+
+    // Own-presence escape hatch: upstream also snapshots when THIS element's
+    // isPresent flips (exit / re-entry), regardless of the dependency.
+    let selfPresent = $state(true)
+    let selfPresenceMeasures = $state(0)
+
+    // Wait-mode parent: a `layout` parent wrapping AnimatePresence
+    // mode="wait". A child swap is a CHILD's presence change, so a gated
+    // parent must not FLIP from the held box to its new size; the ungated
+    // parent keeps our hold/release size animation.
+    let waitChild = $state<'a' | 'b'>('a')
+    let gatedWaitChild = $state<'a' | 'b'>('a')
+
+    function bumpRow(id: string) {
+        rows = rows.map((row) => (row.id === id ? { ...row, ts: nextTs++ } : row))
+    }
+
+    function countRowMeasure(id: string) {
+        rowMeasures = { ...rowMeasures, [id]: (rowMeasures[id] ?? 0) + 1 }
+    }
+
+    function countRowLayoutMeasure(id: string) {
+        rowLayoutMeasures[id] = (rowLayoutMeasures[id] ?? 0) + 1
+    }
 
     let autoTicking = $state(false)
 
@@ -52,6 +114,11 @@
         dragMeasures = 0
         noDragMeasures = 0
         presenceMeasures = 0
+        selfPresenceMeasures = 0
+        rowMeasures = {}
+        for (const id of Object.keys(rowLayoutMeasures)) rowLayoutMeasures[id] = 0
+        layoutMeasureStats.reads = 0
+        layoutMeasureStats.silentReads = 0
     }
 
     function toggleSibling() {
@@ -95,9 +162,6 @@
             {autoTicking ? 'Stop' : 'Start'} auto-render
         </button>
         <button type="button" data-testid="reflow" onclick={reflow}>Reflow + bump dep</button>
-        <button type="button" data-testid="toggle-sibling" onclick={toggleSibling}>
-            Toggle sibling
-        </button>
         <button type="button" data-testid="reset" onclick={resetCounters}>Reset counters</button>
         <span class="readout" data-testid="tick-count">renders: {tick}</span>
     </section>
@@ -149,9 +213,11 @@
     <section class="escape">
         <h2 class="section-title">Escape hatches (upstream parity)</h2>
         <p class="section-note">
-            Upstream <code>MeasureLayout</code> ignores the gate while a drag is active, and re-snapshots
-            on presence changes. These two panels show both, with the dependency held constant (never
-            bumped).
+            Upstream <code>MeasureLayout</code> ignores the gate while <code>drag</code> is set, and
+            re-snapshots on the element's <em>own</em> presence flip — nothing else. These panels
+            hold the dependency constant (never bumped) and show that a sibling's presence toggle
+            does
+            <strong>not</strong> re-measure a gated box.
         </p>
 
         <div class="grid">
@@ -196,13 +262,20 @@
             </article>
 
             <article>
-                <h2>presence-driven reflow</h2>
+                <h2>sibling presence reflow (stays gated)</h2>
                 <p class="expectation">
-                    The gated box (constant <code>layoutDependency={0}</code>) ignores renders, but
-                    when its AnimatePresence sibling enters/exits the real layout shift still
-                    measures via the observer path.
+                    The gated box (constant <code>layoutDependency={0}</code>) ignores renders —
+                    and, matching upstream, also ignores the reflow when its AnimatePresence sibling
+                    enters/exits. Its dependency didn't change, so it jumps to the new slot.
                 </p>
-                <p class="measure" data-testid="presence-measures">measures: {presenceMeasures}</p>
+                <div class="panel-controls">
+                    <button type="button" data-testid="toggle-sibling" onclick={toggleSibling}>
+                        Toggle sibling
+                    </button>
+                    <p class="measure" data-testid="presence-measures">
+                        measures: {presenceMeasures}
+                    </p>
+                </div>
                 <div class="track column">
                     <AnimatePresence>
                         {#if siblingPresent}
@@ -233,6 +306,192 @@
                 </div>
             </article>
         </div>
+    </section>
+
+    <section class="escape" data-testid="own-presence-section">
+        <h2 class="section-title">Own presence & wait-mode parent (upstream parity)</h2>
+        <p class="section-note">
+            Upstream re-snapshots a gated element when <em>its own</em> presence flips (exit /
+            re-entry) — but a <code>layout</code> parent whose
+            <code>AnimatePresence mode="wait"</code>
+            child swaps is only seeing a <em>child's</em> presence change, so a gated parent must not
+            FLIP to its new size. The ungated parent keeps the hold/release size animation.
+        </p>
+        <div class="grid">
+            <article>
+                <h2>own presence flip measures</h2>
+                <p class="expectation">
+                    Gated (<code>layoutDependency={0}</code>) owned child of
+                    <code>AnimatePresence present child</code> — the real node stays mounted for its
+                    exit, so its own <code>isPresent</code> flips in place. Renders never measure
+                    it; toggling <em>its own</em> presence does.
+                </p>
+                <div class="panel-controls">
+                    <button
+                        type="button"
+                        data-testid="toggle-self"
+                        onclick={() => (selfPresent = !selfPresent)}
+                    >
+                        Toggle self
+                    </button>
+                    <p class="measure" data-testid="self-presence-measures">
+                        measures: {selfPresenceMeasures}
+                    </p>
+                </div>
+                <div class="track">
+                    <AnimatePresence present={selfPresent}>
+                        {#snippet child()}
+                            <motion.div
+                                class="orb"
+                                data-testid="self-presence-box"
+                                layout
+                                layoutDependency={0}
+                                style={boxStyle}
+                                initial={{ opacity: 0 }}
+                                animate={{ opacity: 1 }}
+                                exit={{ opacity: 0 }}
+                                transition={{ duration: 0.25 }}
+                                onProjectionUpdate={() => (selfPresenceMeasures += 1)}
+                            >
+                                S
+                            </motion.div>
+                        {/snippet}
+                    </AnimatePresence>
+                </div>
+            </article>
+
+            <article>
+                <h2>wait-mode parent: gated vs ungated</h2>
+                <p class="expectation">
+                    Both parents have <code>layout</code> and wrap an
+                    <code>AnimatePresence mode="wait"</code>
+                    swapping a small child for a large one. The ungated parent animates its size; the
+                    gated parent (<code>layoutDependency={0}</code>) jumps.
+                </p>
+                <div class="panel-controls">
+                    <button
+                        type="button"
+                        data-testid="swap-wait-child"
+                        onclick={() => (waitChild = waitChild === 'a' ? 'b' : 'a')}
+                    >
+                        Swap ungated ({waitChild})
+                    </button>
+                    <button
+                        type="button"
+                        data-testid="swap-gated-wait-child"
+                        onclick={() => (gatedWaitChild = gatedWaitChild === 'a' ? 'b' : 'a')}
+                    >
+                        Swap gated ({gatedWaitChild})
+                    </button>
+                </div>
+                <div class="track two wait-track">
+                    <motion.div
+                        class="wait-parent"
+                        data-testid="wait-parent"
+                        layout
+                        transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+                    >
+                        <AnimatePresence mode="wait" initial={false}>
+                            {#if waitChild === 'a'}
+                                <motion.div
+                                    key="a"
+                                    class="wait-child small"
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    transition={{ duration: 0.2 }}
+                                >
+                                    a
+                                </motion.div>
+                            {:else}
+                                <motion.div
+                                    key="b"
+                                    class="wait-child large"
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    transition={{ duration: 0.2 }}
+                                >
+                                    b
+                                </motion.div>
+                            {/if}
+                        </AnimatePresence>
+                    </motion.div>
+                    <motion.div
+                        class="wait-parent gated"
+                        data-testid="gated-wait-parent"
+                        layout
+                        layoutDependency={0}
+                        transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+                    >
+                        <AnimatePresence mode="wait" initial={false}>
+                            {#if gatedWaitChild === 'a'}
+                                <motion.div
+                                    key="a"
+                                    class="wait-child small"
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    transition={{ duration: 0.2 }}
+                                >
+                                    a
+                                </motion.div>
+                            {:else}
+                                <motion.div
+                                    key="b"
+                                    class="wait-child large"
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    transition={{ duration: 0.2 }}
+                                >
+                                    b
+                                </motion.div>
+                            {/if}
+                        </AnimatePresence>
+                    </motion.div>
+                </div>
+            </article>
+        </div>
+    </section>
+
+    <section class="escape" data-testid="keyed-list-section">
+        <h2 class="section-title">Keyed list (#470)</h2>
+        <p class="section-note">
+            Every row is <code>layout="position"</code>. With <code>List gate: field</code> each row
+            passes <code>layoutDependency={'{row.ts}'}</code>; bumping E re-sorts it to the top, but
+            only E's dependency changed — the four rows it displaces jump (upstream parity). Switch
+            to
+            <code>List gate: index</code> and every row whose slot changed animates.
+        </p>
+        <div class="panel-controls">
+            <button type="button" data-testid="bump-row-e" onclick={() => bumpRow('e')}>
+                Bump row E
+            </button>
+            <button
+                type="button"
+                data-testid="toggle-list-gate"
+                onclick={() => (listGate = listGate === 'field' ? 'index' : 'field')}
+            >
+                List gate: {listGate}
+            </button>
+        </div>
+        <ul class="rows" data-testid="keyed-list">
+            {#each sortedRows as row, i (row.id)}
+                <motion.li
+                    class="row"
+                    data-testid={`row-${row.id}`}
+                    layout="position"
+                    layoutDependency={listGate === 'field' ? row.ts : i}
+                    transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+                    onProjectionUpdate={() => countRowMeasure(row.id)}
+                    onLayoutMeasure={() => countRowLayoutMeasure(row.id)}
+                >
+                    <span>{row.id}</span>
+                    <span class="row-meta">ts {row.ts} · measures {rowMeasures[row.id] ?? 0}</span>
+                </motion.li>
+            {/each}
+        </ul>
     </section>
 </main>
 
@@ -399,7 +658,7 @@
         color: #64748b;
     }
 
-    .sibling {
+    :global(.sibling) {
         width: 100%;
         padding: 14px 16px;
         border: 1px solid rgba(125, 211, 252, 0.35);
@@ -410,6 +669,83 @@
         text-transform: uppercase;
         font-size: 12px;
         box-sizing: border-box;
+    }
+
+    .rows {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        width: min(420px, 100%);
+        display: grid;
+        gap: 8px;
+    }
+
+    :global(.row) {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        height: 48px;
+        padding: 0 14px;
+        border: 1px solid rgba(125, 211, 252, 0.35);
+        background: #102332;
+        color: #ecfeff;
+        font-weight: 850;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+    }
+
+    .row-meta {
+        color: #67e8f9;
+        font-family: 'SFMono-Regular', Consolas, monospace;
+        font-size: 12px;
+        font-weight: 700;
+        text-transform: none;
+        letter-spacing: 0;
+    }
+
+    .panel-controls {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .panel-controls .measure {
+        margin-left: 6px;
+    }
+
+    .wait-track {
+        align-items: flex-start;
+        gap: 16px;
+    }
+
+    :global(.wait-parent) {
+        display: inline-block;
+        padding: 12px;
+        border: 1px solid rgba(125, 211, 252, 0.45);
+        background: #102332;
+    }
+
+    :global(.wait-parent.gated) {
+        border-color: #f0abfc;
+    }
+
+    :global(.wait-child) {
+        display: grid;
+        place-items: center;
+        background: #67e8f9;
+        color: #031316;
+        font-weight: 900;
+    }
+
+    :global(.wait-child.small) {
+        width: 72px;
+        height: 40px;
+    }
+
+    :global(.wait-child.large) {
+        width: 160px;
+        height: 96px;
     }
 
     :global(.orb) {


### PR DESCRIPTION
## Summary

Brings `layoutDependency` to strict parity with upstream framer-motion's `MeasureLayout` (verified against motion v13.1.0 source and empirically in React): while gated, **only** a dependency change, `drag`, or the element's *own* presence flip snapshots the element. Any other layout change — a sibling reorder that re-slots it, a resize, a sibling's `AnimatePresence` toggle, an `AnimatePresence mode="wait"` child swap inside a gated parent — makes it **jump**, with no FLIP and no `onProjectionUpdate` / `onLayoutMeasure`. Previously our observer path animated all of those (and the docstring advertised it).

Known boundary, documented in the PR: parity is *behavioral*. Svelte reconciles a keyed `{#each}` before a child can snapshot, so a gated element still refreshes its cached slot with **one silent DOM read** on an observed re-slot — that cache is the only pre-move origin a later dependency-driven FLIP can start from. Unrelated renders cost a gated element nothing.

## Changes

🐛 **Parity fixes** (`_MotionContainer.svelte`, `layout.ts`)
- `isLayoutMeasurementGated(layoutDependency, drag)` helper; observer commits and the wait-mode presence release are gated unless a dependency / own-presence change is pending in the same update
- Own-presence escape hatch: track `PresenceChild.isPresent` so an owned `<AnimatePresence present>{#snippet child()}` exit/re-entry still snapshots
- Pair every reactive `willUpdate()` with `didUpdate()` — a no-delta commit left a stale projection snapshot that a later sibling commit would animate from (root cause of displaced gated rows sliding)

🔧 **Measurement cost** (`motionDomProjection.ts`, `layout.ts`)
- `refreshLayout({ silent })`: seeds the projection and returns the rect in one DOM read (replaces `measurePageRect()` + `seedLayout()` double reads on gated refresh and observer-effect restart); `measurePageRect(phase, { silent })` skips `onMeasure` fan-out
- Wait-mode release decides the gate before any DOM read
- Shared, ref-counted observer registries: one `ResizeObserver` total and one `MutationObserver` per (target, options) — N siblings share their parent's observers; ancestor style filter runs once per batch
- `layoutMeasureStats { reads, silentReads }` counters for tests/demos

🧪 **Tests**
- Unit: gate predicate, single-read `refreshLayout`, silent `measurePageRect`, shared-observer ref-counting
- e2e (`e2e/layout/layout-dependency.spec.ts`, 9 tests): keyed-list field gate (bumped row slides, displaced rows jump, no `onLayoutMeasure`), index gate (all moved rows slide), sibling-presence stays gated (inverted from prior non-parity assertion), own-presence flip measures, gated vs ungated wait-mode parent, measurement cadence
- Test page `/tests/layout-dependency`: keyed-list, own-presence, and wait-mode panels with per-panel controls

📚 **Docs**
- `/docs/layout-dependency`: "What the gate blocks", "Keyed lists" (gate on index, not a row field), "What the gate costs"
- New `KeyedList` example on `/examples/layout-dependency`; `layoutDependency` docstring rewritten; README stale "layoutId not implemented" line fixed

## Verification

- Unit 818/818; `trunk check` / `pnpm check` clean
- Full Playwright suite via build+preview: 413 passed, 2 skipped, 1 load-related flake (`owned-child` opacity timing, 21/21 on isolated rerun)

Closes #470

## Commits

- [`d8e5fc8`](https://github.com/humanspeak/svelte-motion/commit/d8e5fc8ce3b2405e0825ef34505e1ec8f624a1c3) fix(layout): match upstream layoutDependency gate semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
